### PR TITLE
fix(cli): correct automation --extra help to snake_case API names

### DIFF
--- a/packages/cli/src/pipefy_cli/commands/automation.py
+++ b/packages/cli/src/pipefy_cli/commands/automation.py
@@ -104,7 +104,10 @@ def automation_create(
     extra: str | None = typer.Option(
         None,
         "--extra",
-        help="Optional JSON object: extra CreateAutomationInput fields (camelCase).",
+        help=(
+            "Optional JSON object of extra CreateAutomationInput fields, "
+            "snake_case API names (e.g. action_params, event_params)."
+        ),
     ),
     json_out: bool = typer.Option(
         False,
@@ -137,7 +140,10 @@ def automation_update(
     extra: str = typer.Option(
         ...,
         "--extra",
-        help="JSON object: fields to patch (UpdateAutomationInput, camelCase).",
+        help=(
+            "JSON object of fields to patch (UpdateAutomationInput), "
+            "snake_case API names."
+        ),
     ),
     json_out: bool = typer.Option(
         False,

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -594,10 +594,13 @@ Usage: pipefy automation create [OPTIONS]
 │    --action-repo                               TEXT  Destination pipe id for │
 │                                                      cross-pipe actions      │
 │                                                      (defaults to --pipe).   │
-│    --extra                                     TEXT  Optional JSON object:   │
+│    --extra                                     TEXT  Optional JSON object of │
 │                                                      extra                   │
 │                                                      CreateAutomationInput   │
-│                                                      fields (camelCase).     │
+│                                                      fields, snake_case API  │
+│                                                      names (e.g.             │
+│                                                      action_params,          │
+│                                                      event_params).          │
 │    --json                   -j                       Print machine-readable  │
 │                                                      JSON to stdout.         │
 │    --help                                            Show this message and   │
@@ -816,8 +819,8 @@ Usage: pipefy automation update [OPTIONS] AUTOMATION_ID
 │ *    automation_id      TEXT  Automation rule id. [required]                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ *  --extra          TEXT  JSON object: fields to patch                       │
-│                           (UpdateAutomationInput, camelCase).                │
+│ *  --extra          TEXT  JSON object of fields to patch                     │
+│                           (UpdateAutomationInput), snake_case API names.     │
 │                           [required]                                         │
 │    --json   -j            Print machine-readable JSON to stdout.             │
 │    --help                 Show this message and exit.                        │


### PR DESCRIPTION
## What

Corrects the `--extra` help on `automation create` and `automation update`. It described `CreateAutomationInput` / `UpdateAutomationInput` fields as camelCase, but the API only accepts snake_case at the top level (`action_params`, `event_params`, ...). The help pointed users at the form that fails.

## Why

Reported in #275: the documented `--extra '{"actionParams":{...}}'` is rejected with `Field is not defined on CreateAutomationInput`, while `action_params` works. This PR is the minimal documentation fix.

## Change

- `automation create` `--extra`: now says snake_case API names, with `action_params` / `event_params` examples.
- `automation update` `--extra`: same correction.
- Refreshed the CLI `--help` golden snapshot.

A follow-up PR makes the CLI accept camelCase as well (normalizing it) and adds a `--to-phase` shortcut.

Closes #275
