### PR TITLE
feat(mcp): default-deny remote tool allowlist (#304)

### DIFF
--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -17,38 +17,45 @@ Implications for tool design:
   server are not appropriate here. They add maintenance cost without buying
   a security boundary.
 
-If a future distribution profile (self-hosted, streaming, etc.) changes this
-trust model, deferred code paths are tagged with `GATED:<PROFILE>` markers.
-See below.
+A hosted/remote distribution profile is in progress (see issue #297). It runs
+the server as a multi-user HTTP service. Tool exposure there is **default-deny**:
+only tools explicitly marked remote-safe are registered; everything else is
+withheld. The marker is described below.
 
-## Greppable deployment-profile markers
+## Remote-profile tool marker
 
-Convention: `GATED:<PROFILE>` is a code comment placed on a tool whose
-inputs or capabilities are restricted in the current deployment profile and
-would be broader under another. Uppercase profile name, no spaces. The
-marker annotates a tool that exists today; it is not a deletion changelog.
+When `PIPEFY_MCP_REMOTE_MODE` is true, the server exposes ONLY tools whose
+registration carries `meta=REMOTE`. Any unmarked tool is implicitly withheld
+(default-deny). When the flag is false (the default, local stdio profile), all
+tools register and the marker is inert.
 
-Greppable as a family: `rg "GATED:" packages/mcp` lists every
-deployment-profile marker in the package.
+The marker is a single co-located source of truth on the `@mcp.tool` decorator:
 
-Today's markers:
+```python
+from pipefy_mcp.tools.remote_profile import REMOTE
 
-- `GATED:SELF_HOSTED` on `upload_attachment_to_card` and
-  `upload_attachment_to_table_record` in `tools/attachment_tools.py`. These
-  tools accept only `file_path` in the local-subprocess profile. Under a
-  self-hosted profile they would also accept a `file_url`, behind a
-  capability flag, with SSRF and size-cap guards initialized from injected
-  settings (not from a fresh `PipefySettings()` env read).
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True), meta=REMOTE)
+async def get_organization(...): ...
+```
 
-### When to add a new marker
+`ToolRegistry.apply_remote_profile()` reads it back via `is_remote_tool` and
+removes every unmarked Pipefy tool at registration time (before the server
+serves anything). The marker is greppable (`rg "meta=REMOTE" packages/mcp`) and
+machine-enforced, unlike the comment-only `GATED:` convention it replaces.
 
-Add a `GATED:<PROFILE>` marker on a tool whose surface differs across
-deployment profiles. The comment lives next to the tool's registration (or
-the relevant restricted parameter) so it reads as an annotation on the tool,
-not a paragraph elsewhere in the file. Document the new profile in this
-file alongside the existing ones: which tools carry the marker, what they
-accept today, what they would accept under the other profile.
+Inclusion criteria for marking a tool remote-safe: it reaches the API with the
+request-scoped bearer and is fully governed by API permissions; it does NOT read
+the local filesystem; it does NOT read process-global settings for a per-user
+decision. Opting a tool in is a deliberate, reviewed change (it shifts the
+`REMOTE_SEED` drift guard in `tests/tools/test_remote_profile.py`).
 
-If you are merely deleting code that another profile might want later,
-that's git history and CHANGELOG territory, not a `GATED:` marker. Re-add
-the marker when the gated tool itself returns.
+### Exposure vs input restriction
+
+The `meta` marker expresses **exposure** only: whether a tool is available in the
+remote profile. The retired `GATED:` convention could also express *input*
+restriction within an exposed tool. Where a remotely-exposed tool needs restricted
+inputs (for example the attachment tools tracked in #305, which would accept a
+`file_url` rather than a local `file_path`), enforce that in the tool body gated on
+`mcp_remote_mode` at call time, not via the marker. A tool whose exclusion deserves
+a reason gets a plain code comment pointing at its follow-up issue (the attachment
+tools point at #305); the exclusion itself needs no annotation.

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -30,6 +30,10 @@ async def lifespan(app: FastMCP) -> AsyncIterator[FastMCP]:
             "PIPEFY_MCP_UNIFIED_ENVELOPE=%s",
             "enabled" if settings.pipefy.mcp_unified_envelope else "disabled",
         )
+        logger.info(
+            "PIPEFY_MCP_REMOTE_MODE=%s",
+            "enabled" if settings.pipefy.mcp_remote_mode else "disabled",
+        )
         install_pipefy_validation_envelope()
         services_container = ServicesContainer.get_instance()
         await services_container.initialize_services(settings)
@@ -41,7 +45,10 @@ async def lifespan(app: FastMCP) -> AsyncIterator[FastMCP]:
         registry.check_for_name_collisions()
         mark_pipefy_tool_registration_started(app, set(registry.pipefy_tool_names))
         mcp = registry.register_tools()
-        mark_pipefy_tool_registration_complete(app, set(registry.pipefy_tool_names))
+        registry.apply_remote_profile(remote_mode=settings.pipefy.mcp_remote_mode)
+        mark_pipefy_tool_registration_complete(
+            app, registry.registered_pipefy_tool_names()
+        )
     except Exception:
         cleanup_failed_pipefy_tool_registration(app)
         logger.exception("Fatal error during server lifespan initialization")

--- a/packages/mcp/src/pipefy_mcp/tools/attachment_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/attachment_tools.py
@@ -66,11 +66,10 @@ class AttachmentTools:
                 **extra,
             )
 
-        # GATED:SELF_HOSTED. This tool accepts only file_path in the
-        # local-subprocess profile. Under a self-hosted profile it would also
-        # accept a file_url, behind a capability flag, with SSRF + size-cap
-        # guards initialized from injected settings (not from a fresh
-        # PipefySettings() env read).
+        # Left unmarked for the remote profile: this tool reads a local
+        # file_path, which has no meaning on a hosted server. The hosted-safe
+        # input path (client-supplied file_url with SSRF and size guards) is
+        # tracked in #305; the tool gets meta=REMOTE only once that ships.
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
         )
@@ -140,8 +139,8 @@ class AttachmentTools:
 
             return _success_envelope(result, data.field_id, {"card_id": data.card_id})
 
-        # GATED:SELF_HOSTED. Same gate as upload_attachment_to_card above;
-        # file_url support would land here too under a hosted profile.
+        # Left unmarked for the remote profile, same as upload_attachment_to_card
+        # above (reads a local file_path); hosted-safe input path tracked in #305.
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
         )

--- a/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
@@ -12,6 +12,7 @@ from pipefy_mcp.tools.introspection_tool_helpers import (
     build_error_payload,
     build_success_payload,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 
 
 class IntrospectionTools:
@@ -23,6 +24,7 @@ class IntrospectionTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def introspect_type(
             type_name: str,
@@ -51,6 +53,7 @@ class IntrospectionTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def introspect_mutation(
             mutation_name: str,
@@ -81,6 +84,7 @@ class IntrospectionTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def introspect_query(
             query_name: str,
@@ -109,6 +113,7 @@ class IntrospectionTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def search_schema(
             keyword: str,

--- a/packages/mcp/src/pipefy_mcp/tools/organization_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/organization_tools.py
@@ -10,6 +10,7 @@ from pipefy_mcp.tools.introspection_tool_helpers import (
     build_error_payload,
     build_success_payload,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 
 
 class OrganizationTools:
@@ -21,6 +22,7 @@ class OrganizationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_organization(organization_id: PipefyId) -> dict:
             """Fetch Pipefy organization details by ID.

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -36,6 +36,7 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
     resolve_phase_field_identifiers,
 )
 from pipefy_mcp.tools.pipe_tool_helpers import find_label_dependents
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_error_envelope import (
     is_unified_envelope_enabled,
     tool_error_message,
@@ -462,6 +463,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_phase_cards(
             phase_id: PipefyId,

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -65,6 +65,7 @@ from pipefy_mcp.tools.relation_tool_helpers import (
     build_relation_mutation_success_payload,
     handle_relation_tool_graphql_error,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_error_envelope import (
     is_unified_envelope_enabled,
     tool_error,
@@ -276,6 +277,7 @@ class PipeTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_card(
             ctx: Context[ServerSession, None],
@@ -591,6 +593,7 @@ class PipeTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_cards(
             ctx: Context[ServerSession, None],
@@ -664,6 +667,7 @@ class PipeTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def find_cards(
             pipe_id: PipefyId,
@@ -724,6 +728,7 @@ class PipeTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_pipe(
             ctx: Context[ServerSession, None],
@@ -992,6 +997,7 @@ class PipeTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_start_form_fields(
             pipe_id: PipefyId, required_only: bool = False
@@ -1024,6 +1030,7 @@ class PipeTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_phase_fields(
             phase_id: PipefyId, required_only: bool = False
@@ -1146,6 +1153,7 @@ class PipeTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def search_pipes(
             pipe_name: str | None = None,

--- a/packages/mcp/src/pipefy_mcp/tools/registry.py
+++ b/packages/mcp/src/pipefy_mcp/tools/registry.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
 from mcp.server.fastmcp import FastMCP
 
 from pipefy_mcp.core.container import ServicesContainer
+from pipefy_mcp.core.fastmcp_tool_lifecycle import remove_fastmcp_tools_by_name
 from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
 from pipefy_mcp.tools.ai_automation_tools import AiAutomationTools
 from pipefy_mcp.tools.attachment_tools import AttachmentTools
@@ -16,9 +21,15 @@ from pipefy_mcp.tools.pipe_config_tools import PipeConfigTools
 from pipefy_mcp.tools.pipe_tools import PipeTools
 from pipefy_mcp.tools.portal_tools import PortalTools
 from pipefy_mcp.tools.relation_tools import RelationTools
+from pipefy_mcp.tools.remote_profile import is_remote_tool
 from pipefy_mcp.tools.report_tools import ReportTools
 from pipefy_mcp.tools.table_tools import TableTools
 from pipefy_mcp.tools.webhook_tools import WebhookTools
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp.tools.base import Tool
+
+logger = logging.getLogger(__name__)
 
 # Keep PIPEFY_TOOL_NAMES in sync with docs/parity.md and README MCP totals.
 PIPEFY_TOOL_NAMES = frozenset(
@@ -244,3 +255,51 @@ class ToolRegistry:
         AiAgentTools.register(self.mcp, self.services_container.pipefy_client)
 
         return self.mcp
+
+    def registered_pipefy_tool_names(self) -> set[str]:
+        """Pipefy tools currently registered on the app.
+
+        In the local profile this is the full set; after
+        :meth:`apply_remote_profile` in remote mode it is the surviving subset.
+        The registry owns this query so callers do not reconstruct it from set
+        arithmetic on ``pipefy_tool_names``.
+        """
+        return {
+            tool.name
+            for tool in self.mcp._tool_manager.list_tools()
+            if tool.name in self.pipefy_tool_names
+        }
+
+    def retain_only(self, predicate: Callable[[Tool], bool]) -> set[str]:
+        """Remove every Pipefy tool that does not satisfy ``predicate``.
+
+        Runs after :meth:`register_tools`: the marker rides on the ``@mcp.tool``
+        decorator, so a tool must be registered before its marker can be read.
+        Only names in ``pipefy_tool_names`` are eligible for removal, so
+        third-party or test-registered tools are never touched.
+
+        Returns the set of withheld (removed) tool names.
+        """
+        withheld = {
+            tool.name
+            for tool in self.mcp._tool_manager.list_tools()
+            if tool.name in self.pipefy_tool_names and not predicate(tool)
+        }
+        remove_fastmcp_tools_by_name(self.mcp, withheld)
+        return withheld
+
+    def apply_remote_profile(self, *, remote_mode: bool) -> set[str]:
+        """When ``remote_mode`` is on, withhold every tool not marked remote-safe.
+
+        Default-deny: only tools carrying ``meta=REMOTE`` survive. When off, a
+        no-op that returns an empty set (local stdio profile keeps all tools).
+        """
+        if not remote_mode:
+            return set()
+        withheld = self.retain_only(is_remote_tool)
+        logger.info(
+            "Remote profile: exposed %d, withheld %d Pipefy tools.",
+            len(self.pipefy_tool_names) - len(withheld),
+            len(withheld),
+        )
+        return withheld

--- a/packages/mcp/src/pipefy_mcp/tools/remote_profile.py
+++ b/packages/mcp/src/pipefy_mcp/tools/remote_profile.py
@@ -1,0 +1,31 @@
+"""Remote-profile exposure marker for MCP tools.
+
+Default-deny model for the hosted/remote profile: a tool is exposed in remote
+mode only if its registration carries ``meta=REMOTE``. Any unmarked tool is
+implicitly withheld. The marker is the single co-located source of truth (it
+rides on the ``@mcp.tool`` decorator), and is enforced at registration time by
+:meth:`pipefy_mcp.tools.registry.ToolRegistry.apply_remote_profile`.
+
+The marker is greppable (``rg 'meta=REMOTE'``) and machine-enforced, unlike the
+retired ``GATED:<PROFILE>`` comment convention it replaces.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp.tools.base import Tool
+
+REMOTE_META_KEY = "remote"
+
+# The only marker. Pass to ``meta=`` on a tool whose decorator opts it into the
+# remote profile. The dict shape is forward-compatible: a later toolset feature
+# can add keys (e.g. ``{"remote": True, "toolset": "automation"}``) without
+# breaking ``is_remote_tool``, which reads only ``REMOTE_META_KEY``.
+REMOTE: dict[str, Any] = {REMOTE_META_KEY: True}
+
+
+def is_remote_tool(tool: Tool) -> bool:
+    """Return True when ``tool`` is marked remote-safe via ``meta=REMOTE``."""
+    return (tool.meta or {}).get(REMOTE_META_KEY) is True

--- a/packages/mcp/src/pipefy_mcp/tools/table_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/table_tools.py
@@ -25,6 +25,7 @@ from pipefy_mcp.tools.pagination_helpers import (
     build_pagination_info,
     validate_page_size,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.table_tool_helpers import (
     build_delete_table_error_payload,
     build_delete_table_success_payload,
@@ -65,6 +66,7 @@ class TableTools:
     def register(mcp: FastMCP, client: PipefyClient) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def search_tables(
             table_name: str | None = None,
@@ -122,6 +124,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_table(table_id: PipefyId) -> dict[str, Any]:
             """Load one database table: name, description, fields, and authorization.
@@ -161,6 +164,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_tables(table_ids: list[PipefyId]) -> dict[str, Any]:
             """Load several database tables by ID (same shape as get_table per table).
@@ -197,6 +201,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_table_records(
             table_id: PipefyId,
@@ -263,6 +268,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_table_record(record_id: PipefyId) -> dict[str, Any]:
             """Load a single database table record with its field values.
@@ -301,6 +307,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def find_records(
             table_id: PipefyId,

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -85,6 +85,93 @@ async def test_repeat_lifespan_preserves_foreign_tools_and_stable_pipefy_names()
     assert "create_card" in second_names
 
 
+@pytest.mark.anyio
+async def test_lifespan_remote_mode_exposes_only_remote_safe_tools():
+    """With remote mode on, the lifespan withholds every tool not marked remote."""
+    from pipefy_mcp.server import lifespan
+
+    remote_settings = Settings(
+        pipefy=PipefySettings(base_url="https://api.pipefy.com", mcp_remote_mode=True),
+        auth=AuthSettings(),
+    )
+
+    app = FastMCP("remote-lifespan-test")
+
+    @app.tool()
+    async def foreign_mcp_tool() -> str:
+        """Outside ToolRegistry: must survive remote-mode filtering."""
+        return "ok"
+
+    mock_container = MagicMock()
+    mock_container.initialize_services = AsyncMock()
+    mock_container.pipefy_client = MagicMock()
+
+    with (
+        patch("pipefy_mcp.server.settings", remote_settings),
+        patch(
+            "pipefy_mcp.server.ServicesContainer.get_instance",
+            return_value=mock_container,
+        ),
+    ):
+        async with lifespan(app):
+            registered = {t.name for t in app._tool_manager.list_tools()}
+
+    exposed_pipefy = registered & PIPEFY_TOOL_NAMES
+    # Only the small remote-safe seed survives; the bulk is withheld.
+    assert 0 < len(exposed_pipefy) < len(PIPEFY_TOOL_NAMES)
+    assert "get_organization" in exposed_pipefy
+    assert "upload_attachment_to_card" not in exposed_pipefy
+    assert "execute_graphql" not in exposed_pipefy
+    # Foreign tools are never touched by the profile filter.
+    assert "foreign_mcp_tool" in registered
+
+
+@pytest.mark.anyio
+async def test_repeat_lifespan_in_remote_mode_does_not_accumulate_withheld_tools():
+    """A second remote-mode visit re-applies the filter cleanly; withheld tools do not leak back.
+
+    Guards the registration-completion record: each visit removes the previously
+    owned (surviving) set, re-registers, and re-filters, so the exposed set stays
+    stable instead of growing by the withheld tools removed on the prior visit.
+    """
+    from pipefy_mcp.server import lifespan
+
+    remote_settings = Settings(
+        pipefy=PipefySettings(base_url="https://api.pipefy.com", mcp_remote_mode=True),
+        auth=AuthSettings(),
+    )
+
+    app = FastMCP("remote-repeat-lifespan-test")
+
+    @app.tool()
+    async def foreign_mcp_tool() -> str:
+        """Outside ToolRegistry: must survive both visits."""
+        return "ok"
+
+    mock_container = MagicMock()
+    mock_container.initialize_services = AsyncMock()
+    mock_container.pipefy_client = MagicMock()
+
+    with (
+        patch("pipefy_mcp.server.settings", remote_settings),
+        patch(
+            "pipefy_mcp.server.ServicesContainer.get_instance",
+            return_value=mock_container,
+        ),
+    ):
+        async with lifespan(app):
+            first = {t.name for t in app._tool_manager.list_tools()}
+        async with lifespan(app):
+            second = {t.name for t in app._tool_manager.list_tools()}
+
+    # Stable across visits: no withheld tool leaked back, none were lost.
+    assert first == second
+    assert "foreign_mcp_tool" in second
+    exposed_pipefy = second & PIPEFY_TOOL_NAMES
+    assert 0 < len(exposed_pipefy) < len(PIPEFY_TOOL_NAMES)
+    assert "upload_attachment_to_card" not in second
+
+
 @pytest.mark.unit
 @pytest.mark.anyio
 async def test_lifespan_logs_error_when_initialization_raises():
@@ -170,6 +257,7 @@ async def test_lifespan_retry_after_failed_register_tools_succeeds():
         mock_ok = MagicMock()
         mock_ok.register_tools.return_value = app
         mock_ok.pipefy_tool_names = frozenset({"create_card"})
+        mock_ok.registered_pipefy_tool_names.return_value = {"create_card"}
         mock_registry_cls.side_effect = [mock_fail, mock_ok]
 
         with pytest.raises(RuntimeError, match="register failed"):

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -1,0 +1,128 @@
+"""Tests for the default-deny remote-profile tool allowlist (#304)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
+
+from mcp.server.fastmcp import FastMCP
+
+from pipefy_mcp.core.container import ServicesContainer
+from pipefy_mcp.tools.registry import PIPEFY_TOOL_NAMES, ToolRegistry
+from pipefy_mcp.tools.remote_profile import REMOTE, REMOTE_META_KEY, is_remote_tool
+
+# Expected remote-safe seed. Every addition here is a deliberate, reviewed change:
+# a tool earns a place only by carrying meta=REMOTE on its registration AND being
+# listed here, and the drift guard below asserts the two stay in lockstep.
+REMOTE_SEED = frozenset(
+    {
+        "search_pipes",
+        "get_organization",
+        "get_pipe",
+        "get_card",
+        "get_cards",
+        "find_cards",
+        "find_records",
+        "get_table",
+        "get_tables",
+        "get_table_record",
+        "get_table_records",
+        "get_phase_cards",
+        "get_phase_fields",
+        "get_start_form_fields",
+        "search_tables",
+        "search_schema",
+        "introspect_query",
+        "introspect_mutation",
+        "introspect_type",
+    }
+)
+
+
+def _registry_with_all_tools() -> tuple[ToolRegistry, FastMCP]:
+    """Register every Pipefy tool on a real FastMCP, as the lifespan does."""
+    mcp = FastMCP("remote-profile-test")
+    container = Mock(spec=ServicesContainer)
+    container.pipefy_client = MagicMock()
+    registry = ToolRegistry(mcp=mcp, services_container=container)
+    registry.register_tools()
+    return registry, mcp
+
+
+def _registered_names(mcp: FastMCP) -> set[str]:
+    return {tool.name for tool in mcp._tool_manager.list_tools()}
+
+
+class TestIsRemoteTool:
+    def test_marked_tool_is_remote(self):
+        assert is_remote_tool(SimpleNamespace(meta=REMOTE)) is True
+        assert is_remote_tool(SimpleNamespace(meta={REMOTE_META_KEY: True})) is True
+
+    def test_unmarked_tool_is_not_remote(self):
+        assert is_remote_tool(SimpleNamespace(meta=None)) is False
+        assert is_remote_tool(SimpleNamespace(meta={})) is False
+        assert is_remote_tool(SimpleNamespace(meta={"other": True})) is False
+        assert is_remote_tool(SimpleNamespace(meta={REMOTE_META_KEY: False})) is False
+
+
+class TestApplyRemoteProfile:
+    def test_off_is_noop_keeps_all_tools(self):
+        registry, mcp = _registry_with_all_tools()
+
+        withheld = registry.apply_remote_profile(remote_mode=False)
+
+        assert withheld == set()
+        assert _registered_names(mcp) & PIPEFY_TOOL_NAMES == set(PIPEFY_TOOL_NAMES)
+
+    def test_on_exposes_seed_and_withholds_the_rest(self):
+        registry, mcp = _registry_with_all_tools()
+
+        withheld = registry.apply_remote_profile(remote_mode=True)
+
+        exposed = _registered_names(mcp) & set(PIPEFY_TOOL_NAMES)
+        assert exposed == set(REMOTE_SEED)
+        assert withheld == set(PIPEFY_TOOL_NAMES) - set(REMOTE_SEED)
+        # Filesystem-bound tools must never be exposed remotely.
+        assert "upload_attachment_to_card" not in exposed
+        assert "upload_attachment_to_table_record" not in exposed
+
+
+class TestSeedDriftGuard:
+    def test_seed_is_subset_of_all_tool_names(self):
+        assert REMOTE_SEED <= PIPEFY_TOOL_NAMES
+
+    def test_marked_tools_equal_the_seed(self):
+        """The tools carrying meta=REMOTE must be exactly REMOTE_SEED.
+
+        Adding meta=REMOTE to a tool without updating REMOTE_SEED (or vice
+        versa) fails here, forcing every allowlist change through review.
+        """
+        _, mcp = _registry_with_all_tools()
+
+        marked = {
+            tool.name for tool in mcp._tool_manager.list_tools() if is_remote_tool(tool)
+        }
+
+        assert marked == set(REMOTE_SEED)
+
+
+class TestRetainOnlyReuse:
+    def test_arbitrary_predicate_keeps_only_matches_and_spares_foreign(self):
+        """retain_only is the reusable seam #308 (dynamic toolsets) builds on.
+
+        It is independent of the remote marker: any predicate works, and tools
+        outside PIPEFY_TOOL_NAMES (third-party, test) are never removed.
+        """
+        registry, mcp = _registry_with_all_tools()
+
+        @mcp.tool()
+        def foreign_probe() -> str:
+            return "x"
+
+        keep = {"get_card", "get_pipe"}
+        withheld = registry.retain_only(lambda tool: tool.name in keep)
+
+        registered = _registered_names(mcp)
+        assert registered & set(PIPEFY_TOOL_NAMES) == keep
+        assert withheld == set(PIPEFY_TOOL_NAMES) - keep
+        # Foreign tool is outside pipefy_tool_names, so it is never touched.
+        assert "foreign_probe" in registered
+        assert "foreign_probe" not in withheld

--- a/packages/sdk/src/pipefy_sdk/settings.py
+++ b/packages/sdk/src/pipefy_sdk/settings.py
@@ -148,6 +148,16 @@ class PipefySettings(BaseSettings):
         ),
     )
 
+    mcp_remote_mode: bool = Field(
+        default=False,
+        description=(
+            "When true (env: PIPEFY_MCP_REMOTE_MODE), the server runs the hosted/remote "
+            "profile and exposes ONLY tools explicitly marked remote-safe (default-deny). "
+            "When false (default), all tools register (local stdio profile). Read at "
+            "registration time, a startup decision, not per call."
+        ),
+    )
+
     @field_validator("base_url", "org_id", mode="before")
     @classmethod
     def _strip_str(cls, value: object) -> object:


### PR DESCRIPTION
Implements #304 from the hosted MCP server proposal (#297): a default-deny tool allowlist for the hosted/remote profile.

## What this does

When `PIPEFY_MCP_REMOTE_MODE` is set, the server exposes only tools explicitly marked remote-safe and withholds everything else at registration time. When the flag is off (the default, local stdio profile), all tools register and behavior is byte-identical to today.

This is the gate the rest of the remote work depends on. It is self-contained: a registration-time filter keyed on a settings flag plus a FastMCP `meta` marker, with no dependency on the HTTP transport or auth spine (#300-302), and fully testable on the in-memory transport.

## Changes

- Add `mcp_remote_mode` flag to `PipefySettings` (env `PIPEFY_MCP_REMOTE_MODE`, default `False`).
- Add `tools/remote_profile.py`: the `REMOTE` marker, `REMOTE_META_KEY`, and `is_remote_tool`. The marker dict is forward-compatible for a later `toolset` key.
- Mark 19 read-only seed tools remote-safe with `meta=REMOTE` (organization, pipe, pipe-config, table, introspection tools).
- Add `ToolRegistry.retain_only(predicate)` as the reusable subsetting seam and `apply_remote_profile(remote_mode=...)` as the thin caller; wire both into the lifespan. The decision (reading the flag) stays in `server.py`; the registry owns `registered_pipefy_tool_names()` so the lifespan does not reconstruct the registered set from arithmetic.
- Retire the `GATED:<PROFILE>` comment convention in favor of the machine-enforced `meta` marker. The attachment tools stay unmarked with a comment pointing at #305. `AGENTS.md` documents the marker, the default-deny model, and the exposure-vs-input-restriction distinction.

## Design notes

- Register-then-remove, not never-register: the marker rides on the `@mcp.tool` decorator, so a tool must be registered before its marker can be read. The removal completes inside lifespan startup before the server serves anything, so withheld tools are never advertised and never invocable. The exposure property is identical to never-registering.
- `retain_only` is predicate-based so #308 (dynamic toolsets) can reuse the same seam with a toolset predicate instead of reinventing it.

## Tests

- New `tests/tools/test_remote_profile.py`: off is a no-op (all tools kept), on exposes only the seed and withholds the complement, `is_remote_tool` cases, a `REMOTE_SEED` drift guard (the set of `meta=REMOTE` tools must equal the declared seed, so every allowlist change is a reviewed test change), and a `retain_only` reuse case.
- `tests/test_server.py`: updated the `ToolRegistry` mock for the new lifespan call and added a real-lifespan `remote_mode=True` test covering the wiring.
- Full package suite passes (1369), ruff check and format clean.