### PR TITLE
test(mcp): assert delete_phase parallelism via a barrier, not wall time

### DIFF
--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -1,7 +1,6 @@
 """Tests for pipe configuration MCP tools (mocked PipefyClient)."""
 
 import asyncio
-import time
 from datetime import timedelta
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
@@ -588,41 +587,38 @@ async def test_delete_phase_preview_all_sublookups_fail(
 async def test_delete_phase_sublookups_run_in_parallel(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
-    """Four slow sub-lookups; wall time should be ~one delay, not four."""
+    """All four sub-lookups must be in flight at once, not awaited serially.
 
-    async def _slow_get_field_conditions(*_a, **_kw):
-        await asyncio.sleep(0.05)
-        return {"phase": {"fieldConditions": []}}
+    Each mock blocks on a shared four-party barrier, so a parallel ``gather``
+    releases it while a serial rewrite deadlocks at the first lookup; ``wait_for``
+    turns that deadlock into a clean failure. It is four because ``get_automations``
+    returns ``[]``, so the inner per-automation gather never adds a fifth party.
+    """
+    barrier = asyncio.Barrier(4)
 
-    async def _slow_get_automations(*_a, **_kw):
-        await asyncio.sleep(0.05)
-        return []
+    def _rendezvous(value):
+        async def _side_effect(*_a, **_kw):
+            await barrier.wait()
+            return value
 
-    async def _slow_get_phase_cards_count(*_a, **_kw):
-        await asyncio.sleep(0.05)
-        return 0
+        return _side_effect
 
-    async def _slow_get_phase_fields(*_a, **_kw):
-        await asyncio.sleep(0.05)
-        return {"fields": []}
-
-    mock_pipe_config_client.get_field_conditions.side_effect = (
-        _slow_get_field_conditions
+    mock_pipe_config_client.get_field_conditions.side_effect = _rendezvous(
+        {"phase": {"fieldConditions": []}}
     )
-    mock_pipe_config_client.get_automations.side_effect = _slow_get_automations
-    mock_pipe_config_client.get_phase_cards_count.side_effect = (
-        _slow_get_phase_cards_count
-    )
-    mock_pipe_config_client.get_phase_fields.side_effect = _slow_get_phase_fields
-    t0 = time.perf_counter()
+    mock_pipe_config_client.get_automations.side_effect = _rendezvous([])
+    mock_pipe_config_client.get_phase_cards_count.side_effect = _rendezvous(0)
+    mock_pipe_config_client.get_phase_fields.side_effect = _rendezvous({"fields": []})
+
     async with pipe_config_session as session:
-        result = await session.call_tool(
-            "delete_phase",
-            {"phase_id": 55, "pipe_id": 1, "confirm": False},
+        result = await asyncio.wait_for(
+            session.call_tool(
+                "delete_phase",
+                {"phase_id": 55, "pipe_id": 1, "confirm": False},
+            ),
+            timeout=5.0,
         )
-    elapsed = time.perf_counter() - t0
     assert extract_payload(result)["success"] is False
-    assert elapsed < 0.15
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Problem

`test_delete_phase_sublookups_run_in_parallel` (`packages/mcp/tests/tools/test_pipe_config_tools.py`) was a timing-based test that intermittently failed on CI:

```
assert elapsed < 0.15
E   assert 0.21790534400000183 < 0.15
```

The timed window includes the in-memory session `initialize` handshake, not just the tool call. With four mocked sub-lookups and a budget sized as a multiple of the per-lookup delay, the test relied on the fixed handshake overhead being small. On a slow or contended CI runner that overhead (~0.16s) crossed the budget on its own, even though the lookups genuinely ran in parallel.

The deeper issue: wall-clock time is only an indirect proxy for what the test cares about, namely that the four sub-lookups are in flight at once. The parallel-vs-serial signal can be smaller than the handshake jitter, so no time threshold reliably separates the two. Scaling the delay only relocates the flake; it does not remove the dependence on machine speed.

## Fix

Stop measuring a timing proxy and assert the concurrency property directly.

Each mocked lookup now blocks on a shared four-party `asyncio.Barrier`:

- Parallel (`asyncio.gather`, the production path): all four parties reach the barrier, it releases, and the call returns.
- Serial (a regression): the first lookup waits at the barrier forever because the other three never start. The call deadlocks, and `asyncio.wait_for` turns that into a clean failure.

Wall-clock speed no longer enters the assertion, so there is no threshold to tune per machine. The `wait_for` timeout is a safety net for the deadlock case, not the signal.

`Barrier(4)` encodes that exactly four coroutines reach a mock. That holds today because `get_automations` returns `[]`, so the inner per-automation gather never fires; a future change to the lookup set surfaces here as a deadlock rather than a silent pass. This is documented in the test docstring.

No production code changes; this is a test-robustness fix only.

## Verification

- The full `delete_phase` suite passes (25/25).
- Reverting the production `gather` to serial `await`s trips the test with `TimeoutError` instead of passing, confirming a real serialization regression is still caught.
- `ruff check` and `ruff format` clean.