### PR TITLE
refactor(mcp): inject per-request client via Context

### DIFF
--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -31,11 +31,18 @@ as the request `lifespan_context`. This follows the FastMCP contract, where the
 lifespan can run per session (per request under Streamable HTTP) and so must not
 mutate the tool table.
 
-To register before services exist, tools bind a `PipefyClientProxy`
-(`core/container.py`) rather than a concrete `PipefyClient`. The proxy resolves
-`container.pipefy_client` on each access, so a service re-initialization (a fresh
-client) is picked up without re-registering tools. That is why there is no
-repeat-visit bookkeeping: registration never repeats.
+Tools take no client at registration. Each tool function declares a
+`ctx: Context` parameter (FastMCP injects it and keeps it out of the tool's
+input schema) and resolves the live client per request with
+`get_pipefy_client(ctx)` (`tools/tool_context.py`), which reads
+`ctx.request_context.lifespan_context.pipefy_client`. Because the client is
+looked up per call, a service re-initialization (a fresh client) is picked up
+without re-registering tools, and a per-request identity (issue #302) can vary
+the client the lifespan yields without touching any tool. That is why there is
+no repeat-visit bookkeeping: registration never repeats.
+
+When adding a tool, give it a `ctx: Context` parameter and start its body with
+`client = get_pipefy_client(ctx)`; do not pass a client through `register`.
 
 ## Remote-profile tool marker
 

--- a/packages/mcp/src/pipefy_mcp/core/container.py
+++ b/packages/mcp/src/pipefy_mcp/core/container.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Self
+from typing import Self
 
 from pipefy_auth import (
     STORED_SESSION_TIER,
@@ -92,28 +92,3 @@ class ServicesContainer:
             allow_insecure_urls=pipefy.allow_insecure_urls,
         )
         self.pipefy_client.set_internal_api_client(internal_client)
-
-
-class PipefyClientProxy:
-    """A stable handle that always resolves the container's current client.
-
-    Tools capture this once, at registration, instead of a concrete
-    :class:`PipefyClient`. Each attribute access forwards to the live
-    ``container.pipefy_client``, so re-initializing services (which builds a
-    fresh client) is picked up without re-registering tools. This is what lets
-    registration happen once at construction rather than inside the lifespan.
-    """
-
-    def __init__(self, container: ServicesContainer) -> None:
-        self._container = container
-
-    def __getattr__(self, name: str) -> Any:
-        # ``_container`` is a real instance attribute, so it never routes here;
-        # any other attribute is delegated to the live client.
-        client = self._container.pipefy_client
-        if client is None:
-            raise RuntimeError(
-                "Pipefy client is not initialized; the server lifespan must "
-                "initialize services before any tool is invoked."
-            )
-        return getattr(client, name)

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -62,8 +62,7 @@ def _register_pipefy_tools(app: FastMCP, *, remote_mode: bool) -> None:
     bookkeeping to maintain.
     """
     install_pipefy_validation_envelope()
-    container = ServicesContainer.get_instance()
-    registry = ToolRegistry(mcp=app, services_container=container)
+    registry = ToolRegistry(mcp=app)
     registry.check_for_name_collisions()
     registry.register_tools()
     registry.apply_remote_profile(remote_mode=remote_mode)

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -28,8 +28,9 @@ async def lifespan(app: FastMCP) -> AsyncIterator[ServicesContainer]:
     ``lifespan_context``. Tools are registered once, up front, by
     :func:`_register_pipefy_tools`, so re-entering this context manager (which
     Streamable HTTP does per session) never re-registers and cannot race on the
-    tool table. Tools resolve the live client through ``PipefyClientProxy``, so a
-    re-entry that rebuilds the client is picked up without re-registration.
+    tool table. Tools resolve the live client per request from this
+    ``lifespan_context`` (see :func:`pipefy_mcp.tools.tool_context.get_pipefy_client`),
+    so a re-entry that rebuilds the client is picked up without re-registration.
     """
     try:
         logger.info("Initializing services")
@@ -53,10 +54,12 @@ async def lifespan(app: FastMCP) -> AsyncIterator[ServicesContainer]:
 def _register_pipefy_tools(app: FastMCP, *, remote_mode: bool) -> None:
     """Register every Pipefy tool on ``app`` exactly once, at construction.
 
-    Tools bind a ``PipefyClientProxy`` (via :class:`ToolRegistry`) rather than a
-    live client, so they can be registered before services are initialized and
-    keep working across a service re-initialization. Registration never repeats,
-    so there is no repeat-visit bookkeeping to maintain.
+    Tools take no client at registration: each resolves the live client per
+    request from the lifespan context (see
+    :func:`pipefy_mcp.tools.tool_context.get_pipefy_client`), so they can be
+    registered before services are initialized and keep working across a service
+    re-initialization. Registration never repeats, so there is no repeat-visit
+    bookkeeping to maintain.
     """
     install_pipefy_validation_envelope()
     container = ServicesContainer.get_instance()

--- a/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -41,6 +41,7 @@ from pipefy_mcp.tools.graphql_error_helpers import (
     enrich_permission_denied_error,
     extract_error_strings,
 )
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 
 VALIDATE_FETCH_TIMEOUT_SECONDS = 30
 
@@ -85,7 +86,7 @@ class AiAgentTools:
     """Declares MCP tools for AI Agent CRUD and status."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         """Register AI Agent tools on the MCP server."""
 
         def error_payload_from_exception(exc: BaseException) -> dict:
@@ -94,7 +95,7 @@ class AiAgentTools:
             return build_ai_tool_error(text)
 
         async def _enrich_with_validation(
-            exc: BaseException, behaviors: list[dict]
+            exc: BaseException, behaviors: list[dict], client: PipefyClient
         ) -> str:
             """Enrich an error with validation context for RECORD_NOT_SAVED.
 
@@ -251,6 +252,7 @@ class AiAgentTools:
                     ``get_phase_fields(phase_id)`` for ``triggerFieldIds`` / ``destinationPhaseId``.
                 data_source_ids: Optional knowledge-source IDs (same as ``update_ai_agent``).
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"create_ai_agent: name={name}, repo_uuid={repo_uuid}, "
                 f"instruction_len={len(instruction)}, behaviors_count={len(behaviors)}, "
@@ -312,7 +314,7 @@ class AiAgentTools:
                     ]
                 pipe_ids = collect_pipe_ids_from_behaviors(resolved)
                 perm_msg = await enrich_permission_denied_error(exc, pipe_ids, client)
-                error_text = await _enrich_with_validation(exc, resolved)
+                error_text = await _enrich_with_validation(exc, resolved, client)
                 if perm_msg:
                     error_text = f"{perm_msg}\n{error_text}"
                 return build_create_agent_partial_failure(
@@ -380,6 +382,7 @@ class AiAgentTools:
                     Discover via: ``get_automation_events(pipe_id)`` and ``get_phase_fields(phase_id)``.
                 data_source_ids: Optional list of data source IDs.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"update_ai_agent: uuid={uuid}, behaviors_count={len(behaviors)}"
             )
@@ -421,7 +424,7 @@ class AiAgentTools:
                     ]
                 pipe_ids = collect_pipe_ids_from_behaviors(resolved)
                 perm_msg = await enrich_permission_denied_error(exc, pipe_ids, client)
-                error_text = await _enrich_with_validation(exc, resolved)
+                error_text = await _enrich_with_validation(exc, resolved, client)
                 if perm_msg:
                     error_text = f"{perm_msg}\n{error_text}"
                 return build_ai_tool_error(error_text)
@@ -448,6 +451,7 @@ class AiAgentTools:
                 uuid: UUID of the agent to enable/disable.
                 active: True to activate, False to deactivate.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(f"toggle_ai_agent_status: uuid={uuid}, active={active}")
             agent_uuid = uuid.strip()
             if not agent_uuid:
@@ -481,6 +485,7 @@ class AiAgentTools:
             Args:
                 uuid: Agent UUID.
             """
+            client = get_pipefy_client(ctx)
             agent_uuid = uuid.strip()
             await ctx.debug(f"get_ai_agent: uuid={agent_uuid}")
             if not agent_uuid:
@@ -502,6 +507,7 @@ class AiAgentTools:
             Args:
                 repo_uuid: UUID of the pipe.
             """
+            client = get_pipefy_client(ctx)
             pipe_uuid = repo_uuid.strip()
             await ctx.debug(f"get_ai_agents: repo_uuid={pipe_uuid}")
             if not pipe_uuid:
@@ -528,6 +534,7 @@ class AiAgentTools:
                 uuid: Agent UUID.
                 confirm: Must be ``True`` to run the delete mutation.
             """
+            client = get_pipefy_client(ctx)
             agent_uuid = uuid.strip()
             await ctx.debug(f"delete_ai_agent: uuid={agent_uuid}")
             if not agent_uuid:
@@ -614,6 +621,7 @@ class AiAgentTools:
                 strict_unknown_action_types: When ``True`` (default), unknown ``actionType`` values
                     are reported in ``problems``. When ``False``, they appear in ``warnings`` only.
             """
+            client = get_pipefy_client(ctx)
             pid = str(pipe_id).strip()
             await ctx.debug(
                 f"validate_ai_agent_behaviors: pipe_id={pid}, "

--- a/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -7,7 +7,6 @@ from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
 from pipefy_sdk import (
     CreateAiAutomationInput,
-    PipefyClient,
     PipefyId,
     UpdateAiAutomationInput,
 )
@@ -29,6 +28,7 @@ from pipefy_mcp.tools.automation_tool_helpers import (
     handle_automation_tool_graphql_error,
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.validation_helpers import (
     validate_optional_tool_id,
@@ -40,7 +40,7 @@ class AiAutomationTools:
     """Declares MCP tools for AI Automation create and update."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         """Register AI Automation tools on the MCP server."""
 
         @mcp.tool(
@@ -83,6 +83,7 @@ class AiAutomationTools:
                 issues, ``warnings`` lists non-blocking notices, ``field_map`` maps
                 referenced numeric IDs to field labels.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"validate_ai_automation_prompt: pipe_id={pipe_id}, "
                 f"field_ids={field_ids}, event_id={event_id}"
@@ -148,6 +149,7 @@ class AiAutomationTools:
                 empty when not found). On validation or GraphQL errors, ``success: False`` with
                 ``error``.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(f"get_ai_automation: automation_id={automation_id}")
             aid, err = validate_tool_id(automation_id, "automation_id")
             if err is not None:
@@ -197,6 +199,7 @@ class AiAutomationTools:
                 automation summaries. On validation or GraphQL errors, ``success: False`` with
                 ``error``.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"get_ai_automations: pipe_id={pipe_id}, organization_id={organization_id}"
             )
@@ -255,6 +258,7 @@ class AiAutomationTools:
                 On success, a mutation success payload. On validation or GraphQL errors,
                 ``success: False`` with ``error``.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(f"delete_ai_automation: automation_id={automation_id}")
 
             rid, rid_err = validate_tool_id(automation_id, "automation_id")
@@ -328,6 +332,7 @@ class AiAutomationTools:
                 condition: Optional trigger condition dict. Omit to use the built-in placeholder (empty expression list) so Pipefy always receives a condition on create. Pass a dict to set a custom condition.
                 debug: When True, append GraphQL error codes and correlation_id to create failures.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"create_ai_automation: name={name}, event_id={event_id}, pipe_id={pipe_id}"
             )
@@ -396,6 +401,7 @@ class AiAutomationTools:
                 condition: New trigger condition dict. Omit to leave the automation's condition unchanged; pass a dict to replace it.
                 debug: When True, append GraphQL error codes and correlation_id to update failures.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(f"update_ai_automation: automation_id={automation_id}")
 
             try:

--- a/packages/mcp/src/pipefy_mcp/tools/attachment_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/attachment_tools.py
@@ -13,7 +13,6 @@ from pipefy_sdk import (
     AttachmentUploadError,
     AttachmentUploadResult,
     CardTarget,
-    PipefyClient,
     PipefyId,
     TableRecordTarget,
     UploadAttachmentToCardInput,
@@ -27,13 +26,14 @@ from pipefy_mcp.tools.attachment_tool_helpers import (
     format_s3_upload_failure,
     map_upload_error_to_message,
 )
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 
 
 class AttachmentTools:
     """MCP tools for orchestrated attachment uploads (presigned URL, S3 PUT, field update)."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         def _upload_error_envelope(exc: AttachmentUploadError) -> dict[str, Any]:
             if exc.step == "file_read":
                 # Preserve the original LocalFileError message (no type prefix or
@@ -99,6 +99,7 @@ class AttachmentTools:
                 file_name: File name including extension. Optional; defaults to the path's basename.
                 content_type: Optional MIME type; sent with the S3 upload and presigned request.
             """
+            client = get_pipefy_client(ctx)
             try:
                 data = UploadAttachmentToCardInput(
                     organization_id=organization_id,
@@ -170,6 +171,7 @@ class AttachmentTools:
                 file_name: File name including extension. Optional; defaults to the path's basename.
                 content_type: Optional MIME type for storage.
             """
+            client = get_pipefy_client(ctx)
             try:
                 data = UploadAttachmentToTableRecordInput(
                     organization_id=organization_id,

--- a/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
@@ -7,7 +7,7 @@ from typing import Any
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
-from pipefy_sdk import CreateSendTaskAutomationInput, PipefyClient, PipefyId
+from pipefy_sdk import CreateSendTaskAutomationInput, PipefyId
 from pipefy_sdk.automation_preflight import AutomationPreflightError
 from pydantic import ValidationError
 
@@ -20,6 +20,7 @@ from pipefy_mcp.tools.automation_tool_helpers import (
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import enrich_permission_denied_error
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.validation_helpers import (
     mutation_error_if_not_optional_dict,
@@ -42,7 +43,7 @@ class AutomationTools:
     """MCP tools for traditional (non-AI) pipe automations."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
         )
@@ -66,6 +67,7 @@ class AutomationTools:
                 ``None`` when not found). On validation or GraphQL errors, ``success: False`` with
                 ``error``.
             """
+            client = get_pipefy_client(ctx)
             aid, aid_err = validate_tool_id(automation_id, "automation_id")
             if aid_err is not None:
                 return aid_err
@@ -114,6 +116,7 @@ class AutomationTools:
                 summaries returned by the API. On validation or GraphQL errors, ``success: False``
                 with ``error``.
             """
+            client = get_pipefy_client(ctx)
             ok_o, org, org_err = validate_optional_tool_id(
                 organization_id, "organization_id"
             )
@@ -165,6 +168,7 @@ class AutomationTools:
             Args:
                 pipe_id: Pipe ID.
             """
+            client = get_pipefy_client(ctx)
             pid, pid_err = validate_tool_id(pipe_id, "pipe_id")
             if pid_err is not None:
                 return pid_err
@@ -198,6 +202,7 @@ class AutomationTools:
             Args:
                 pipe_id: Pipe ID (context for the agent; required by the tool).
             """
+            client = get_pipefy_client(ctx)
             pid, pid_err = validate_tool_id(pipe_id, "pipe_id")
             if pid_err is not None:
                 return pid_err
@@ -232,6 +237,7 @@ class AutomationTools:
             see ``create_automation`` docstring and
             ``docs/mcp/tools/automations-and-ai.md#common-value-tokens-copy_from``.
             """
+            client = get_pipefy_client(ctx)
             try:
                 rows = await client.get_automation_event_attributes()
             except Exception as exc:  # noqa: BLE001
@@ -284,6 +290,7 @@ class AutomationTools:
                 extra_input: Optional map of extra ``CreateAutomationSimulationInput`` fields (merged last).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             pid, pid_err = validate_tool_id(pipe_id, "pipe_id")
             if pid_err is not None:
                 return pid_err
@@ -418,6 +425,7 @@ class AutomationTools:
                 extra_input: Optional extra fields for the mutation input (camelCase keys).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             pid, pid_err = validate_tool_id(pipe_id, "pipe_id")
             if pid_err is not None:
                 return pid_err
@@ -527,6 +535,7 @@ class AutomationTools:
                 event_params: Optional trigger filter payload (camelCase/snake_case as returned by catalog tools).
                 condition: Optional condition expressions payload.
             """
+            client = get_pipefy_client(ctx)
             try:
                 validated = CreateSendTaskAutomationInput(
                     pipe_id=pipe_id,
@@ -589,6 +598,7 @@ class AutomationTools:
                 extra_input: Optional fields to patch on the rule.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             rid, rid_err = validate_tool_id(automation_id, "automation_id")
             if rid_err is not None:
                 return rid_err
@@ -636,6 +646,7 @@ class AutomationTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             rid, rid_err = validate_tool_id(automation_id, "automation_id")
             if rid_err is not None:
                 return rid_err

--- a/packages/mcp/src/pipefy_mcp/tools/field_condition_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/field_condition_tools.py
@@ -7,7 +7,7 @@ from typing import Any
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
-from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk import PipefyId
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.pipe_config_tool_helpers import (
@@ -17,6 +17,7 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
     field_condition_actions_error_message,
     handle_pipe_config_tool_graphql_error,
 )
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.tool_error_envelope import tool_error
 from pipefy_mcp.tools.validation_helpers import (
     validate_tool_id,
@@ -42,7 +43,7 @@ class FieldConditionTools:
     """Declares MCP tools for field conditions (read, create, update, delete)."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(
                 readOnlyHint=True,
@@ -67,6 +68,7 @@ class FieldConditionTools:
                 On success: ``success``, ``message``, and ``field_conditions`` (list from the API).
                 On failure: ``success: False`` and ``error``.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"get_field_conditions: phase_id={phase_id!r}, debug={debug}"
             )
@@ -119,6 +121,7 @@ class FieldConditionTools:
                 On success: ``success``, ``message``, and ``field_condition`` (single object).
                 On failure: ``success: False`` and ``error``.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"get_field_condition: field_condition_id={field_condition_id!r}, debug={debug}"
             )
@@ -222,6 +225,7 @@ class FieldConditionTools:
                 extra_input: Optional extra keys for ``createFieldConditionInput`` (e.g. ``index``).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"create_field_condition: phase_id={phase_id!r}, debug={debug}"
             )
@@ -341,6 +345,7 @@ class FieldConditionTools:
                 extra_input: Additional fields to merge into ``UpdateFieldConditionInput``.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"update_field_condition: condition_id={condition_id!r}, debug={debug}"
             )
@@ -447,6 +452,7 @@ class FieldConditionTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"delete_field_condition: condition_id={condition_id!r}, debug={debug}"
             )

--- a/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
@@ -4,22 +4,22 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
-from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.introspection_tool_helpers import (
     build_error_payload,
     build_success_payload,
 )
 from pipefy_mcp.tools.remote_profile import REMOTE
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 
 
 class IntrospectionTools:
     """Registers MCP tools for schema introspection and ``execute_graphql``."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         """Register introspection-related tools on the MCP server."""
 
         @mcp.tool(
@@ -28,6 +28,7 @@ class IntrospectionTools:
         )
         async def introspect_type(
             type_name: str,
+            ctx: Context,
             max_depth: int = 1,
             include_parsed: bool = False,
         ) -> dict:
@@ -42,6 +43,7 @@ class IntrospectionTools:
                 max_depth: Levels of sub-types to resolve (1 = no recursion, 2+ = inline referenced types).
                 include_parsed: When True, include ``data`` dict alongside ``result``.
             """
+            client = get_pipefy_client(ctx)
             try:
                 result = await client.introspect_type(type_name, max_depth=max_depth)
             except Exception as exc:  # noqa: BLE001
@@ -57,6 +59,7 @@ class IntrospectionTools:
         )
         async def introspect_mutation(
             mutation_name: str,
+            ctx: Context,
             max_depth: int = 1,
             include_parsed: bool = False,
         ) -> dict:
@@ -71,6 +74,7 @@ class IntrospectionTools:
                 max_depth: Levels of sub-types to resolve (1 = no recursion, 2+ = inline referenced types).
                 include_parsed: When True, include ``data`` dict alongside ``result``.
             """
+            client = get_pipefy_client(ctx)
             try:
                 result = await client.introspect_mutation(
                     mutation_name, max_depth=max_depth
@@ -88,6 +92,7 @@ class IntrospectionTools:
         )
         async def introspect_query(
             query_name: str,
+            ctx: Context,
             max_depth: int = 1,
             include_parsed: bool = False,
         ) -> dict:
@@ -102,6 +107,7 @@ class IntrospectionTools:
                 max_depth: Levels of sub-types to resolve (1 = no recursion, 2+ = inline referenced types).
                 include_parsed: When True, include ``data`` dict alongside ``result``.
             """
+            client = get_pipefy_client(ctx)
             try:
                 result = await client.introspect_query(query_name, max_depth=max_depth)
             except Exception as exc:  # noqa: BLE001
@@ -117,6 +123,7 @@ class IntrospectionTools:
         )
         async def search_schema(
             keyword: str,
+            ctx: Context,
             kind: str | None = None,
             include_parsed: bool = False,
         ) -> dict:
@@ -131,6 +138,7 @@ class IntrospectionTools:
                 kind: Optional filter by GraphQL type kind (e.g. OBJECT, INPUT_OBJECT, ENUM, SCALAR).
                 include_parsed: When True, include ``data`` dict alongside ``result``.
             """
+            client = get_pipefy_client(ctx)
             try:
                 result = await client.search_schema(keyword, kind=kind)
             except Exception as exc:  # noqa: BLE001
@@ -145,6 +153,7 @@ class IntrospectionTools:
         )
         async def execute_graphql(
             query: str,
+            ctx: Context,
             variables: dict[str, Any] | None = None,
             include_parsed: bool = False,
         ) -> dict:
@@ -160,6 +169,7 @@ class IntrospectionTools:
                 variables: Optional variable map for the operation.
                 include_parsed: When True, include ``data`` dict alongside ``result``.
             """
+            client = get_pipefy_client(ctx)
             try:
                 result = await client.execute_graphql(query, variables)
             except Exception as exc:  # noqa: BLE001

--- a/packages/mcp/src/pipefy_mcp/tools/member_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/member_tools.py
@@ -21,6 +21,7 @@ from pipefy_mcp.tools.member_tool_helpers import (
     build_member_success_payload,
     handle_member_tool_graphql_error,
 )
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
 
@@ -28,13 +29,14 @@ class MemberTools:
     """MCP tools for inviting, removing, and setting roles for pipe members."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
         )
         async def invite_members(
             pipe_id: PipefyId,
             members: list[dict[str, Any]],
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Invite one or more users to a pipe.
@@ -46,6 +48,7 @@ class MemberTools:
                 members: List of member dicts with `email` and `role_name`.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             pipe_id, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
                 return err
@@ -111,6 +114,7 @@ class MemberTools:
                 confirm: Set to True to execute the removal (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             pipe_id, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
                 return err
@@ -179,6 +183,7 @@ class MemberTools:
             pipe_id: PipefyId,
             member_id: PipefyId,
             role_name: str,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Set a member's role on a pipe.
@@ -193,6 +198,7 @@ class MemberTools:
                 role_name: New role name (e.g. 'member', 'admin').
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             pipe_id, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
                 return err

--- a/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
-from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk import PipefyId
 
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
 from pipefy_mcp.tools.observability_tool_helpers import (
@@ -15,6 +15,7 @@ from pipefy_mcp.tools.observability_tool_helpers import (
     build_observability_read_success_payload,
     handle_observability_tool_graphql_error,
 )
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
 # --- Validation constants ---
@@ -57,12 +58,13 @@ class ObservabilityTools:
     """MCP tools for monitoring AI agent and automation execution."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_ai_agent_logs(
             repo_uuid: str,
+            ctx: Context,
             first: int = 30,
             after: str | None = None,
             status: str | None = None,
@@ -79,6 +81,7 @@ class ObservabilityTools:
                 search_term: Free-text search within logs.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             if not repo_uuid or not isinstance(repo_uuid, str):
                 return build_observability_error_payload(
                     message="Invalid 'repo_uuid': provide a non-empty string.",
@@ -112,6 +115,7 @@ class ObservabilityTools:
         )
         async def get_ai_agent_log_details(
             log_uuid: str,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Get detailed AI agent execution log by UUID. Includes executionTime, finishedAt, and tracingNodes — a step-by-step trace of each action the agent performed with per-node status (success, failed, skipped, conditions_not_met).
@@ -120,6 +124,7 @@ class ObservabilityTools:
                 log_uuid: UUID of the AI agent log entry.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             if not log_uuid or not isinstance(log_uuid, str):
                 return build_observability_error_payload(
                     message="Invalid 'log_uuid': provide a non-empty string.",
@@ -146,6 +151,7 @@ class ObservabilityTools:
         )
         async def get_automation_logs(
             automation_id: PipefyId,
+            ctx: Context,
             first: int = 30,
             after: str | None = None,
             status: str | None = None,
@@ -162,6 +168,7 @@ class ObservabilityTools:
                 search_term: Free-text search within logs.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             if not automation_id:
                 return build_observability_error_payload(
                     message="Invalid 'automation_id': provide a non-empty string.",
@@ -195,6 +202,7 @@ class ObservabilityTools:
         )
         async def get_automation_logs_by_repo(
             repo_id: PipefyId,
+            ctx: Context,
             first: int = 30,
             after: str | None = None,
             status: str | None = None,
@@ -211,6 +219,7 @@ class ObservabilityTools:
                 search_term: Free-text search within logs.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             if not repo_id:
                 return build_observability_error_payload(
                     message="Invalid 'repo_id': provide a non-empty string.",
@@ -246,6 +255,7 @@ class ObservabilityTools:
             organization_uuid: PipefyId,
             filter_date_from: str,
             filter_date_to: str,
+            ctx: Context,
             filters: dict[str, Any] | None = None,
             search: str | None = None,
             sort: dict[str, Any] | None = None,
@@ -262,6 +272,7 @@ class ObservabilityTools:
                 sort: SortCriteria dict (field + direction).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             organization_uuid, err = validate_tool_id(
                 organization_uuid, "organization_uuid"
             )
@@ -298,6 +309,7 @@ class ObservabilityTools:
             organization_uuid: PipefyId,
             filter_date_from: str,
             filter_date_to: str,
+            ctx: Context,
             filters: dict[str, Any] | None = None,
             search: str | None = None,
             sort: dict[str, Any] | None = None,
@@ -314,6 +326,7 @@ class ObservabilityTools:
                 sort: SortCriteria dict (field + direction).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             organization_uuid, err = validate_tool_id(
                 organization_uuid, "organization_uuid"
             )
@@ -349,6 +362,7 @@ class ObservabilityTools:
         async def get_ai_credit_usage(
             organization_uuid: PipefyId,
             period: str,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Get AI credit usage dashboard for an org. Shows credit limit, total consumption, per-resource breakdown (AI Agents vs Assistants), addon status, and free credit info. `period`: 'current_month', 'last_month', or 'last_3_months'.
@@ -359,6 +373,7 @@ class ObservabilityTools:
                 period: PeriodFilter (current_month, last_month, last_3_months).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             organization_uuid, err = validate_tool_id(
                 organization_uuid, "organization_uuid"
             )
@@ -390,6 +405,7 @@ class ObservabilityTools:
         async def export_automation_jobs(
             organization_id: PipefyId,
             period: str,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Trigger async export of automation job history for an org. `period`: 'current_month', 'last_month', or 'last_3_months'. The export file is delivered to the requesting user.
@@ -399,6 +415,7 @@ class ObservabilityTools:
                 period: PeriodFilter (current_month, last_month, last_3_months).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             organization_id, err = validate_tool_id(organization_id, "organization_id")
             if err is not None:
                 return err
@@ -426,6 +443,7 @@ class ObservabilityTools:
         )
         async def get_automation_jobs_export(
             export_id: PipefyId,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Poll an automation jobs export by id. Returns `status` (`created`, `processing`, `finished`, `failed`) and `fileUrl` when the API provides a signed download link (often after `finished`). Use after `export_automation_jobs`; repeat until `finished` or `failed`. The tool does not download the file — use `fileUrl` over HTTP if needed.
@@ -434,6 +452,7 @@ class ObservabilityTools:
                 export_id: Export id from `export_automation_jobs` result (`automationJobsExport.id`).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             if not export_id:
                 return build_observability_error_payload(
                     message="Invalid 'export_id': provide a non-empty string.",
@@ -457,6 +476,7 @@ class ObservabilityTools:
         )
         async def get_automation_jobs_export_csv(
             export_id: PipefyId,
+            ctx: Context,
             max_output_chars: int = _DEFAULT_CSV_CHARS,
             max_download_bytes: int = _DEFAULT_EXPORT_DOWNLOAD_BYTES,
             debug: bool = False,
@@ -469,6 +489,7 @@ class ObservabilityTools:
                 max_download_bytes: Max xlsx size to download (4 KiB–80 MiB); default 50 MiB.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             if not export_id:
                 return build_observability_error_payload(
                     message="Invalid 'export_id': provide a non-empty string.",

--- a/packages/mcp/src/pipefy_mcp/tools/organization_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/organization_tools.py
@@ -2,29 +2,30 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
-from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk import PipefyId
 
 from pipefy_mcp.tools.introspection_tool_helpers import (
     build_error_payload,
     build_success_payload,
 )
 from pipefy_mcp.tools.remote_profile import REMOTE
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 
 
 class OrganizationTools:
     """Registers MCP tools for organization operations."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         """Register organization-related tools on the MCP server."""
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
             meta=REMOTE,
         )
-        async def get_organization(organization_id: PipefyId) -> dict:
+        async def get_organization(organization_id: PipefyId, ctx: Context) -> dict:
             """Fetch Pipefy organization details by ID.
 
             Returns id, uuid, name, plan, role, members count, pipes count,
@@ -34,6 +35,7 @@ class OrganizationTools:
             Args:
                 organization_id: Numeric organization ID.
             """
+            client = get_pipefy_client(ctx)
             try:
                 result = await client.get_organization(organization_id)
             except Exception as exc:  # noqa: BLE001

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -37,6 +37,7 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
 )
 from pipefy_mcp.tools.pipe_tool_helpers import find_label_dependents
 from pipefy_mcp.tools.remote_profile import REMOTE
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.tool_error_envelope import (
     is_unified_envelope_enabled,
     tool_error_message,
@@ -123,7 +124,7 @@ class PipeConfigTools:
     """MCP tools for pipe, phase, field, and label configuration (builder CRUD)."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(
                 readOnlyHint=False,
@@ -132,6 +133,7 @@ class PipeConfigTools:
         async def create_pipe(
             name: str,
             organization_id: PipefyId,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Create a new empty pipe in an organization.
@@ -143,6 +145,7 @@ class PipeConfigTools:
                 organization_id: Organization ID that will own the pipe.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             if not isinstance(name, str) or not name.strip():
                 return build_pipe_tool_error_payload(
                     message="Invalid 'name': provide a non-empty string.",
@@ -173,6 +176,7 @@ class PipeConfigTools:
         )
         async def update_pipe(
             pipe_id: PipefyId,
+            ctx: Context,
             name: str | None = None,
             icon: str | None = None,
             color: str | None = None,
@@ -192,6 +196,7 @@ class PipeConfigTools:
                 preferences: Repo preferences object, if changing.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             pipe_id_str, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
                 return err
@@ -245,6 +250,7 @@ class PipeConfigTools:
                 confirm: When True, performs the deletion after explicit user confirmation.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             pipe_id_str, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
                 return build_delete_pipe_error_payload(message=tool_error_message(err))
@@ -315,6 +321,7 @@ class PipeConfigTools:
         )
         async def clone_pipe(
             pipe_template_id: PipefyId,
+            ctx: Context,
             organization_id: PipefyId | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -330,6 +337,7 @@ class PipeConfigTools:
                 organization_id: Optional organization ID for the clone operation.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             pipe_template_id, err = validate_tool_id(
                 pipe_template_id, "pipe_template_id"
             )
@@ -365,6 +373,7 @@ class PipeConfigTools:
         )
         async def get_phase_allowed_move_targets(
             phase_id: PipefyId,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """List phases a card may move to from a source phase (UI transition rules).
@@ -385,6 +394,7 @@ class PipeConfigTools:
                 and ``allowed_phases`` (list of ``{id, name}``). Empty
                 ``allowed_phases`` means no outbound transitions are configured.
             """
+            client = get_pipefy_client(ctx)
             phase_id_str, err = validate_tool_id(phase_id, "phase_id")
             if err is not None:
                 return err
@@ -416,6 +426,7 @@ class PipeConfigTools:
         )
         async def get_phase_cards_count(
             phase_id: PipefyId,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Return the native ``Phase.cards_count`` for a phase (fast inventory).
@@ -434,6 +445,7 @@ class PipeConfigTools:
                 ``success: true`` with ``data`` containing ``phase_id``, ``phase_name``,
                 and ``cards_count``.
             """
+            client = get_pipefy_client(ctx)
             phase_id_str, err = validate_tool_id(phase_id, "phase_id")
             if err is not None:
                 return err
@@ -467,6 +479,7 @@ class PipeConfigTools:
         )
         async def get_phase_cards(
             phase_id: PipefyId,
+            ctx: Context,
             first: int = 50,
             after: str | None = None,
             include_fields: bool = False,
@@ -492,6 +505,7 @@ class PipeConfigTools:
                 (``edges``, ``pageInfo``, ``totalCount``). With unified envelope enabled,
                 that dict is under ``data`` and includes pagination hints.
             """
+            client = get_pipefy_client(ctx)
             phase_id_str, err = validate_tool_id(phase_id, "phase_id")
             if err is not None:
                 return err
@@ -541,6 +555,7 @@ class PipeConfigTools:
         async def create_phase(
             pipe_id: PipefyId,
             name: str,
+            ctx: Context,
             done: bool = False,
             index: float | int | None = None,
             description: str | None = None,
@@ -556,6 +571,7 @@ class PipeConfigTools:
                 description: Optional phase description.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             pipe_id, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
                 return err
@@ -592,6 +608,7 @@ class PipeConfigTools:
         )
         async def update_phase(
             phase_id: PipefyId,
+            ctx: Context,
             name: str | None = None,
             description: str | None = None,
             done: bool | None = None,
@@ -619,6 +636,7 @@ class PipeConfigTools:
                 only_admin_can_move_to_previous: If changing (deprecated in API).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             phase_id, err = validate_tool_id(phase_id, "phase_id")
             if err is not None:
                 return err
@@ -710,6 +728,7 @@ class PipeConfigTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             phase_id, err = validate_tool_id(phase_id, "phase_id")
             if err is not None:
                 return err
@@ -760,6 +779,7 @@ class PipeConfigTools:
             phase_id: PipefyId,
             label: str,
             field_type: str,
+            ctx: Context,
             options: list[str] | None = None,
             description: str | None = None,
             required: bool | None = None,
@@ -785,6 +805,7 @@ class PipeConfigTools:
                 extra_input: Additional ``CreatePhaseFieldInput`` fields, if any.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             phase_id, err = validate_tool_id(phase_id, "phase_id")
             if err is not None:
                 return err
@@ -837,6 +858,7 @@ class PipeConfigTools:
         async def update_phase_field(
             field_id: PipefyId,
             label: str,
+            ctx: Context,
             description: str | None = None,
             required: bool | None = None,
             options: list[Any] | dict[str, Any] | None = None,
@@ -873,6 +895,7 @@ class PipeConfigTools:
                 extra_input: Additional UpdatePhaseFieldInput fields, if any.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             field_id, err = validate_tool_id(field_id, "field_id")
             if err is not None:
                 return err
@@ -990,6 +1013,7 @@ class PipeConfigTools:
                     field conditions (``confirm=False`` only).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             field_id, err = validate_tool_id(field_id, "field_id")
             if err is not None:
                 return err
@@ -1070,6 +1094,7 @@ class PipeConfigTools:
             pipe_id: PipefyId,
             name: str,
             color: str,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Create a label on a pipe.
@@ -1081,6 +1106,7 @@ class PipeConfigTools:
                     ``#FF0000``); color names such as ``red`` are rejected before GraphQL.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             pipe_id, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
                 return err
@@ -1127,6 +1153,7 @@ class PipeConfigTools:
             label_id: PipefyId,
             name: str,
             color: str,
+            ctx: Context,
             extra_input: dict[str, Any] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -1145,6 +1172,7 @@ class PipeConfigTools:
                 extra_input: Additional UpdateLabelInput fields, if any.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             label_id, err = validate_tool_id(label_id, "label_id")
             if err is not None:
                 return err
@@ -1211,6 +1239,7 @@ class PipeConfigTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             label_id, err = validate_tool_id(label_id, "label_id")
             if err is not None:
                 return err

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -11,7 +11,6 @@ from pipefy_sdk import (
     CardSearch,
     CommentInput,
     DeleteCommentInput,
-    PipefyClient,
     PipefyId,
     UpdateCommentInput,
     copy_card_search,
@@ -66,6 +65,7 @@ from pipefy_mcp.tools.relation_tool_helpers import (
     handle_relation_tool_graphql_error,
 )
 from pipefy_mcp.tools.remote_profile import REMOTE
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.tool_error_envelope import (
     is_unified_envelope_enabled,
     tool_error,
@@ -82,7 +82,7 @@ class PipeTools:
     """Declares tools to be used in the Pipe context."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         """Register the tools in the MCP server"""
 
         @mcp.tool(
@@ -145,6 +145,7 @@ class PipeTools:
                     merged from ``fields`` when provided. For agent seeding, set
                     ``skip_elicitation=true``. Discover via: ``get_pipe(pipe_id).phases[].id``.
             """
+            client = get_pipefy_client(ctx)
             card_data = fields or {}
             can_elicit = supports_elicitation(ctx)
 
@@ -301,6 +302,7 @@ class PipeTools:
                 dict: GraphQL ``card`` query payload (typically ``card`` with ``id``, ``title``,
                 ``phase``, ``assignees``, ``labels``, and—when requested—``fields``).
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(f"get_card: card_id={card_id}")
             card_id_str, err = validate_tool_id(card_id, "card_id")
             if err is not None:
@@ -341,6 +343,7 @@ class PipeTools:
                 (API fields ``child_relations`` / ``parent_relations`` on ``Card``). On failure:
                 ``success: False`` and ``error``.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(f"get_card_relations: card_id={card_id}")
             card_id_str, err = validate_tool_id(card_id, "card_id")
             if err is not None:
@@ -384,7 +387,7 @@ class PipeTools:
             structured_output=False,
         )
         async def add_card_comment(
-            card_id: PipefyId, text: str
+            card_id: PipefyId, text: str, ctx: Context[ServerSession, None]
         ) -> AddCardCommentPayload:
             """Add a text comment to a Pipefy card.
 
@@ -392,6 +395,7 @@ class PipeTools:
                 card_id: The ID of the card to comment on
                 text: The comment text to post (1-1000 characters)
             """
+            client = get_pipefy_client(ctx)
             # Privacy: never log the full comment text (it may contain sensitive data).
             try:
                 comment_input = CommentInput(card_id=card_id, text=text)
@@ -420,7 +424,7 @@ class PipeTools:
             structured_output=False,
         )
         async def update_comment(
-            comment_id: PipefyId, text: str
+            comment_id: PipefyId, text: str, ctx: Context[ServerSession, None]
         ) -> UpdateCommentPayload:
             """Update an existing comment by its ID.
 
@@ -428,6 +432,7 @@ class PipeTools:
                 comment_id: The ID of the comment to update.
                 text: The new comment text (1-1000 characters).
             """
+            client = get_pipefy_client(ctx)
             # Privacy: do not log full comment text.
             try:
                 update_input = UpdateCommentInput(comment_id=comment_id, text=text)
@@ -473,6 +478,7 @@ class PipeTools:
                 comment_id: The ID of the comment to delete.
                 confirm: Must be ``True`` to run the delete mutation.
             """
+            client = get_pipefy_client(ctx)
             try:
                 delete_input = DeleteCommentInput(comment_id=comment_id)
             except ValidationError:
@@ -532,6 +538,7 @@ class PipeTools:
             Returns:
                 Success payload with mutation result, or ``success: False`` with ``error``.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"delete_card_relation: child_id={child_id}, parent_id={parent_id}, "
                 f"source_id={source_id}, confirm={confirm}"
@@ -623,6 +630,7 @@ class PipeTools:
                 first: Max cards to return per page (1-500).
                 after: Cursor for fetching the next page (from ``pageInfo.endCursor`` of a previous call).
             """
+            client = get_pipefy_client(ctx)
             if first is not None:
                 validated_first, err = validate_page_size(first)
                 if err is not None:
@@ -673,6 +681,7 @@ class PipeTools:
             pipe_id: PipefyId,
             field_id: str,
             field_value: str,
+            ctx: Context[ServerSession, None],
             include_fields: bool = False,
             first: int | None = None,
             after: str | None = None,
@@ -702,6 +711,7 @@ class PipeTools:
                 after: Cursor from ``pageInfo.endCursor`` for the next page (optional).
                 debug: When True, append GraphQL codes and correlation_id on errors.
             """
+            client = get_pipefy_client(ctx)
             try:
                 response = await client.find_cards(
                     pipe_id,
@@ -751,6 +761,7 @@ class PipeTools:
                 ``phases`` (workflow phases; each includes ``cards_count``),
                 ``labels``, ``start_form_fields``, and related metadata from the API.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(f"get_pipe: pipe_id={pipe_id}")
             pipe_id_str, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
@@ -789,6 +800,7 @@ class PipeTools:
                 On success: ``success``, ``message``, and ``labels`` (list of ``{id, name}``).
                 On failure: ``success: False`` and ``error``.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(f"get_labels: pipe_id={pipe_id}")
             pipe_id_str, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
@@ -842,6 +854,7 @@ class PipeTools:
                 dict: GraphQL payload whose ``pipe.members`` entries include ``user``
                 (``id``, ``uuid``, ``name``, ``email``) and ``role_name`` per member.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(f"get_pipe_members: pipe_id={pipe_id}")
             pipe_id_str, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
@@ -861,7 +874,9 @@ class PipeTools:
             annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True),
         )
         async def move_card_to_phase(
-            card_id: PipefyId, destination_phase_id: PipefyId
+            card_id: PipefyId,
+            destination_phase_id: PipefyId,
+            ctx: Context[ServerSession, None],
         ) -> dict:
             """Move a card to a target phase (Kanban column) within the same pipe.
 
@@ -881,7 +896,7 @@ class PipeTools:
                 a structured payload with ``success: false`` and ``valid_destinations`` when the
                 destination phase is not allowed from the current phase.
             """
-
+            client = get_pipefy_client(ctx)
             try:
                 return await client.move_card_to_phase(card_id, destination_phase_id)
             except Exception as exc:  # noqa: BLE001
@@ -901,6 +916,7 @@ class PipeTools:
             card_id: PipefyId,
             field_id: str,
             new_value: Any,
+            ctx: Context[ServerSession, None],
             debug: bool = False,
         ) -> dict:
             """Update a single field of a card.
@@ -926,6 +942,7 @@ class PipeTools:
                 dict: GraphQL response with success status and updated card information
                       including the card's id, title, fields, and updated_at timestamp
             """
+            client = get_pipefy_client(ctx)
             try:
                 return await client.update_card_field(card_id, field_id, new_value)
             except Exception as exc:  # noqa: BLE001
@@ -941,6 +958,7 @@ class PipeTools:
         )
         async def update_card(
             card_id: PipefyId,
+            ctx: Context[ServerSession, None],
             title: str | None = None,
             assignee_ids: list[PipefyId] | None = None,
             label_ids: list[PipefyId] | None = None,
@@ -984,6 +1002,7 @@ class PipeTools:
                     {"field_id": "tags", "value": "urgent", "operation": "ADD"},
                 ])
             """
+            client = get_pipefy_client(ctx)
             return await client.update_card(
                 card_id=card_id,
                 title=title,
@@ -1000,7 +1019,9 @@ class PipeTools:
             meta=REMOTE,
         )
         async def get_start_form_fields(
-            pipe_id: PipefyId, required_only: bool = False
+            pipe_id: PipefyId,
+            ctx: Context[ServerSession, None],
+            required_only: bool = False,
         ) -> dict:
             """Get the start form fields of a pipe.
 
@@ -1024,6 +1045,7 @@ class PipeTools:
                       - description: Field description text
                       - help: Help text for the field
             """
+            client = get_pipefy_client(ctx)
             return await client.get_start_form_fields(pipe_id, required_only)
 
         @mcp.tool(
@@ -1033,7 +1055,9 @@ class PipeTools:
             meta=REMOTE,
         )
         async def get_phase_fields(
-            phase_id: PipefyId, required_only: bool = False
+            phase_id: PipefyId,
+            ctx: Context[ServerSession, None],
+            required_only: bool = False,
         ) -> dict:
             """Get the fields available in a specific phase.
 
@@ -1060,6 +1084,7 @@ class PipeTools:
                       - description: Field description text
                       - help: Help text for the field
             """
+            client = get_pipefy_client(ctx)
             return await client.get_phase_fields(phase_id, required_only)
 
         @mcp.tool(
@@ -1099,6 +1124,7 @@ class PipeTools:
             Returns:
                 dict: GraphQL response with success status and updated card information.
             """
+            client = get_pipefy_client(ctx)
             try:
                 phase_fields_result = await client.get_phase_fields(
                     phase_id, required_fields_only
@@ -1156,6 +1182,7 @@ class PipeTools:
             meta=REMOTE,
         )
         async def search_pipes(
+            ctx: Context[ServerSession, None],
             pipe_name: str | None = None,
             max_pipes_per_org: int = 500,
         ) -> dict:
@@ -1193,6 +1220,7 @@ class PipeTools:
                           - match_score: Fuzzy match score (0-100) when pipe_name is provided.
                       And ``search_limits`` with applied caps.
             """
+            client = get_pipefy_client(ctx)
             mpc = max(1, min(500, int(max_pipes_per_org)))
             return await client.search_pipes(pipe_name, max_pipes_per_org=mpc)
 
@@ -1226,6 +1254,7 @@ class PipeTools:
             Returns:
                 Success/error status of the deletion.
             """
+            client = get_pipefy_client(ctx)
             card_id_str, err = validate_tool_id(card_id, "card_id")
             if err is not None:
                 return build_delete_card_error_payload(message=tool_error_message(err))

--- a/packages/mcp/src/pipefy_mcp/tools/portal_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/portal_tools.py
@@ -7,7 +7,7 @@ from typing import Any
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
-from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk import PipefyId
 from pipefy_sdk.models.portal import (
     CreatePortalElementInput,
     PortalElementType,
@@ -31,6 +31,7 @@ from pipefy_mcp.tools.portal_tool_helpers import (
     validate_sort_page_ids_no_duplicates,
     validate_tool_ids,
 )
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.tool_error_envelope import tool_error
 from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
@@ -39,7 +40,7 @@ class PortalTools:
     """Registers MCP tools for portal read, metadata CRUD, and page operations."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         """Register portal-related tools on the MCP server."""
 
         @mcp.tool(
@@ -63,6 +64,7 @@ class PortalTools:
                     (string or unquoted integer via MCP clients).
                 search_term: Optional name filter.
             """
+            client = get_pipefy_client(ctx)
             organization_uuid, err = validate_tool_id(
                 organization_uuid, "organization_uuid"
             )
@@ -105,6 +107,7 @@ class PortalTools:
             Args:
                 portal_uuid: Portal interface UUID.
             """
+            client = get_pipefy_client(ctx)
             portal_uuid, err = validate_tool_id(portal_uuid, "portal_uuid")
             if err is not None:
                 return err
@@ -131,6 +134,7 @@ class PortalTools:
             Args:
                 organization_uuid: Organization UUID, or numeric organization id.
             """
+            client = get_pipefy_client(ctx)
             organization_uuid, err = validate_tool_id(
                 organization_uuid, "organization_uuid"
             )
@@ -168,6 +172,7 @@ class PortalTools:
                 icon: Optional icon identifier.
                 display_pipefy_header: Whether to show the Pipefy header.
             """
+            client = get_pipefy_client(ctx)
             portal_uuid, err = validate_tool_id(portal_uuid, "portal_uuid")
             if err is not None:
                 return err
@@ -225,6 +230,7 @@ class PortalTools:
                 portal_uuid: Portal interface UUID to delete.
                 confirm: Set to True to execute the deletion (step 2).
             """
+            client = get_pipefy_client(ctx)
             portal_uuid, err = validate_tool_id(portal_uuid, "portal_uuid")
             if err is not None:
                 return err
@@ -272,6 +278,7 @@ class PortalTools:
                 description: Optional page description.
                 index: Optional sort index.
             """
+            client = get_pipefy_client(ctx)
             portal_uuid, err = validate_tool_id(portal_uuid, "portal_uuid")
             if err is not None:
                 return err
@@ -325,6 +332,7 @@ class PortalTools:
                 description: Optional new description.
                 index: Optional sort index.
             """
+            client = get_pipefy_client(ctx)
             portal_uuid, err = validate_tool_id(portal_uuid, "portal_uuid")
             if err is not None:
                 return err
@@ -389,6 +397,7 @@ class PortalTools:
                 page_id: Page UUID to delete.
                 confirm: Set to True to execute the deletion (step 2).
             """
+            client = get_pipefy_client(ctx)
             portal_uuid, err = validate_tool_id(portal_uuid, "portal_uuid")
             if err is not None:
                 return err
@@ -435,6 +444,7 @@ class PortalTools:
                 portal_uuid: Parent portal interface UUID.
                 page_ids: Ordered list of page UUIDs (new sort order).
             """
+            client = get_pipefy_client(ctx)
             portal_uuid, err = validate_tool_id(portal_uuid, "portal_uuid")
             if err is not None:
                 return err
@@ -483,6 +493,7 @@ class PortalTools:
                 page_id: Page UUID.
                 layout: Layout JSON (full layout object for the page).
             """
+            client = get_pipefy_client(ctx)
             page_id, err = validate_tool_id(page_id, "page_id")
             if err is not None:
                 return err
@@ -527,6 +538,7 @@ class PortalTools:
                 editable: Optional editable flag.
                 layout: Optional layout JSON.
             """
+            client = get_pipefy_client(ctx)
             page_id, err = validate_tool_id(page_id, "page_id")
             if err is not None:
                 return err
@@ -600,6 +612,7 @@ class PortalTools:
                 data_sources: Optional data source bindings.
                 editable: Optional editable flag.
             """
+            client = get_pipefy_client(ctx)
             element_id, err = validate_tool_id(element_id, "element_id")
             if err is not None:
                 return err
@@ -662,6 +675,7 @@ class PortalTools:
                 page_id: Parent page UUID.
                 confirm: Set to True to execute the deletion (step 2).
             """
+            client = get_pipefy_client(ctx)
             element_id, err = validate_tool_id(element_id, "element_id")
             if err is not None:
                 return err
@@ -714,6 +728,7 @@ class PortalTools:
                 portal_uuid: Portal interface UUID that owns the page.
                 page_id: Page UUID that contains the element.
             """
+            client = get_pipefy_client(ctx)
             element_id, err = validate_tool_id(element_id, "element_id")
             if err is not None:
                 return err
@@ -756,6 +771,7 @@ class PortalTools:
                 main_portal_uuid: Parent main portal interface UUID.
                 name: Optional display name.
             """
+            client = get_pipefy_client(ctx)
             main_portal_uuid, err = validate_tool_id(
                 main_portal_uuid, "main_portal_uuid"
             )
@@ -796,6 +812,7 @@ class PortalTools:
                 element_id: Page element UUID (e.g. templated ``forms`` slot).
                 sub_portal_uuid: Sub-portal UUID to attach.
             """
+            client = get_pipefy_client(ctx)
             return await run_sub_portal_internal_api_tool(
                 ids={
                     "portal_uuid": portal_uuid,
@@ -839,6 +856,7 @@ class PortalTools:
                 element_id: Page element UUID (e.g. templated ``forms`` slot).
                 sub_portal_uuid: Sub-portal UUID to publish on the element.
             """
+            client = get_pipefy_client(ctx)
             return await run_sub_portal_internal_api_tool(
                 ids={
                     "portal_uuid": portal_uuid,
@@ -880,6 +898,7 @@ class PortalTools:
                 portal_uuid: Main portal interface UUID.
                 element_id: Page element UUID to unpublish.
             """
+            client = get_pipefy_client(ctx)
             return await run_sub_portal_internal_api_tool(
                 ids={
                     "portal_uuid": portal_uuid,
@@ -924,6 +943,7 @@ class PortalTools:
                 element_id: Page element UUID to detach.
                 confirm: Set to True to execute the detach (step 2).
             """
+            client = get_pipefy_client(ctx)
             ids, err = validate_tool_ids(
                 {"portal_uuid": portal_uuid, "element_id": element_id}
             )
@@ -982,6 +1002,7 @@ class PortalTools:
                 sub_portal_uuid: Sub-portal UUID to delete permanently.
                 confirm: Set to True to execute the deletion (step 2).
             """
+            client = get_pipefy_client(ctx)
             ids, err = validate_tool_ids({"sub_portal_uuid": sub_portal_uuid})
             if err is not None or ids is None:
                 return err or build_error_payload("Invalid tool IDs.")

--- a/packages/mcp/src/pipefy_mcp/tools/registry.py
+++ b/packages/mcp/src/pipefy_mcp/tools/registry.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from mcp.server.fastmcp import FastMCP
 
-from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.core.fastmcp_tool_lifecycle import remove_fastmcp_tools_by_name
 from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
 from pipefy_mcp.tools.ai_automation_tools import AiAutomationTools
@@ -215,9 +214,8 @@ _TOOLSETS = (
 class ToolRegistry:
     """Responsible for registering tools with the MCP server."""
 
-    def __init__(self, mcp: FastMCP, services_container: ServicesContainer):
+    def __init__(self, mcp: FastMCP):
         self.mcp = mcp
-        self.services_container = services_container
         self.pipefy_tool_names: frozenset[str] = PIPEFY_TOOL_NAMES
 
     @staticmethod

--- a/packages/mcp/src/pipefy_mcp/tools/registry.py
+++ b/packages/mcp/src/pipefy_mcp/tools/registry.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from mcp.server.fastmcp import FastMCP
-from pipefy_sdk import PipefyClient
 
-from pipefy_mcp.core.container import PipefyClientProxy, ServicesContainer
+from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.core.fastmcp_tool_lifecycle import remove_fastmcp_tools_by_name
 from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
 from pipefy_mcp.tools.ai_automation_tools import AiAutomationTools
@@ -243,15 +242,14 @@ class ToolRegistry:
     def register_tools(self) -> None:
         """Register tools with the MCP server.
 
-        Tools bind a :class:`PipefyClientProxy`, not a concrete client, so they
-        can be registered before services are initialized and keep working after
-        a service re-initialization (which swaps the underlying client). This is
-        what lets registration run once, at construction, rather than inside the
+        Tool functions resolve the live Pipefy client per request from the MCP
+        lifespan context (see
+        :func:`pipefy_mcp.tools.tool_context.get_pipefy_client`), so registration
+        needs no client and runs once, at construction, rather than inside the
         lifespan.
         """
-        client = cast(PipefyClient, PipefyClientProxy(self.services_container))
         for toolset in _TOOLSETS:
-            toolset.register(self.mcp, client)
+            toolset.register(self.mcp)
 
     def retain_only(self, predicate: Callable[[Tool], bool]) -> set[str]:
         """Remove every Pipefy tool that does not satisfy ``predicate``.

--- a/packages/mcp/src/pipefy_mcp/tools/relation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/relation_tools.py
@@ -7,7 +7,7 @@ from typing import Any
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
-from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk import PipefyId
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.relation_tool_helpers import (
@@ -16,6 +16,7 @@ from pipefy_mcp.tools.relation_tool_helpers import (
     build_relation_read_success_payload,
     handle_relation_tool_graphql_error,
 )
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import (
     mutation_error_if_not_optional_dict,
     validate_tool_id,
@@ -26,11 +27,11 @@ class RelationTools:
     """MCP tools for relations between pipes/tables and linked cards."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
         )
-        async def get_pipe_relations(pipe_id: PipefyId) -> dict[str, Any]:
+        async def get_pipe_relations(pipe_id: PipefyId, ctx: Context) -> dict[str, Any]:
             """List pipe relations for a pipe (parent and child links, config, and repo refs).
 
             Takes a **pipe** ID. Each relation's ``id`` in the response is a **pipe relation**
@@ -40,6 +41,7 @@ class RelationTools:
             Args:
                 pipe_id: Pipe ID.
             """
+            client = get_pipefy_client(ctx)
             pipe_id, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
                 return err
@@ -60,10 +62,12 @@ class RelationTools:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
         )
-        async def get_table_relations(relation_ids: list[PipefyId]) -> dict[str, Any]:
+        async def get_table_relations(
+            relation_ids: list[PipefyId], ctx: Context
+        ) -> dict[str, Any]:
             """Load table relations by ID (Pipefy root ``table_relations``).
 
-            **Do not pass** ``table_id`` or a database table ID — this tool only accepts
+            **Do not pass** ``table_id`` or a database table ID, this tool only accepts
             **table relation** identifiers (the link object between tables). To resolve
             table IDs for schema/records, use ``get_table`` / ``search_tables`` instead.
             Obtain table-relation IDs from the Pipefy UI, your saved metadata, or GraphQL
@@ -72,6 +76,7 @@ class RelationTools:
             Args:
                 relation_ids: Non-empty list of **table relation** IDs (never the database table ID).
             """
+            client = get_pipefy_client(ctx)
             if not isinstance(relation_ids, list) or not relation_ids:
                 return build_relation_error_payload(
                     message="Invalid 'relation_ids': provide a non-empty list of table relation IDs.",
@@ -102,6 +107,7 @@ class RelationTools:
             parent_id: PipefyId,
             child_id: PipefyId,
             name: str,
+            ctx: Context,
             extra_input: Any | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -119,6 +125,7 @@ class RelationTools:
                 extra_input: Optional extra fields for the mutation input.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             parent_id, err = validate_tool_id(parent_id, "parent_id")
             if err is not None:
                 return err
@@ -160,6 +167,7 @@ class RelationTools:
         async def update_pipe_relation(
             relation_id: PipefyId,
             name: str,
+            ctx: Context,
             extra_input: Any | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -174,6 +182,7 @@ class RelationTools:
                 extra_input: Optional extra fields for the mutation input.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             relation_id, err = validate_tool_id(relation_id, "relation_id")
             if err is not None:
                 return err
@@ -229,6 +238,7 @@ class RelationTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             relation_id, err = validate_tool_id(relation_id, "relation_id")
             if err is not None:
                 return err
@@ -263,6 +273,7 @@ class RelationTools:
             parent_id: PipefyId,
             child_id: PipefyId,
             source_id: PipefyId,
+            ctx: Context,
             extra_input: Any | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -281,6 +292,7 @@ class RelationTools:
                 extra_input: Optional ``CreateCardRelationInput`` fields (camelCase), e.g. ``sourceType`` (default ``PipeRelation``).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             parent_id, err = validate_tool_id(parent_id, "parent_id")
             if err is not None:
                 return err

--- a/packages/mcp/src/pipefy_mcp/tools/report_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/report_tools.py
@@ -7,7 +7,7 @@ from typing import Any
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
-from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk import PipefyId
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.pagination_helpers import (
@@ -20,6 +20,7 @@ from pipefy_mcp.tools.report_tool_helpers import (
     build_report_read_success_payload,
     handle_report_tool_graphql_error,
 )
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.tool_error_envelope import (
     is_unified_envelope_enabled,
     tool_success,
@@ -38,12 +39,13 @@ class ReportTools:
     """MCP tools for reading, managing, and exporting pipe and organization reports."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_pipe_reports(
             pipe_uuid: str,
+            ctx: Context,
             first: int = 30,
             after: str | None = None,
             search: str | None = None,
@@ -62,6 +64,7 @@ class ReportTools:
                 order: Sort order, e.g. {"field": "name", "direction": "asc"}.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(pipe_uuid, "pipe_uuid")
             if err is not None:
                 return err
@@ -118,6 +121,7 @@ class ReportTools:
                 report_id: Pipe report ID.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"get_pipe_report: pipe_uuid={pipe_uuid}, report_id={report_id}"
             )
@@ -161,6 +165,7 @@ class ReportTools:
         )
         async def get_pipe_report_columns(
             pipe_uuid: str,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Get available columns for a pipe report. Each item includes `name` (internal field id for `fields`) and `label`.
@@ -172,6 +177,7 @@ class ReportTools:
                 pipe_uuid: Pipe UUID.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(pipe_uuid, "pipe_uuid")
             if err is not None:
                 return err
@@ -195,6 +201,7 @@ class ReportTools:
         )
         async def get_pipe_report_filterable_fields(
             pipe_uuid: str,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Get filterable fields for a pipe report (nested groups; use `name` for filter fields).
@@ -205,6 +212,7 @@ class ReportTools:
                 pipe_uuid: Pipe UUID.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(pipe_uuid, "pipe_uuid")
             if err is not None:
                 return err
@@ -228,6 +236,7 @@ class ReportTools:
         )
         async def get_organization_report(
             report_id: PipefyId,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Get a single organization report by ID.
@@ -236,6 +245,7 @@ class ReportTools:
                 report_id: Organization report ID.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(report_id, "report_id")
             if err is not None:
                 return err
@@ -259,6 +269,7 @@ class ReportTools:
         )
         async def get_organization_reports(
             organization_id: PipefyId,
+            ctx: Context,
             first: int = 30,
             after: str | None = None,
             debug: bool = False,
@@ -271,6 +282,7 @@ class ReportTools:
                 after: Cursor for next page.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(organization_id, "organization_id")
             if err is not None:
                 return err
@@ -308,6 +320,7 @@ class ReportTools:
         )
         async def get_pipe_report_export(
             export_id: PipefyId,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Check the status of a pipe report export. Poll this after calling `export_pipe_report`. States: processing -> done (with fileURL) -> failed.
@@ -316,6 +329,7 @@ class ReportTools:
                 export_id: Pipe report export ID.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(export_id, "export_id")
             if err is not None:
                 return err
@@ -339,6 +353,7 @@ class ReportTools:
         )
         async def get_organization_report_export(
             export_id: PipefyId,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Check the status of an org report export. Poll this after calling `export_organization_report`.
@@ -347,6 +362,7 @@ class ReportTools:
                 export_id: Organization report export ID.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(export_id, "export_id")
             if err is not None:
                 return err
@@ -371,6 +387,7 @@ class ReportTools:
         async def create_pipe_report(
             pipe_id: PipefyId,
             name: str,
+            ctx: Context,
             fields: list[str] | None = None,
             filter: dict | None = None,
             formulas: list[list[str]] | None = None,
@@ -390,6 +407,7 @@ class ReportTools:
                 formulas: Formula definitions (list of [field, operator, ...] tuples).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(pipe_id, "pipe_id")
             if err is not None:
                 return err
@@ -420,6 +438,7 @@ class ReportTools:
         )
         async def update_pipe_report(
             report_id: PipefyId,
+            ctx: Context,
             name: str | None = None,
             color: str | None = None,
             fields: list[str] | None = None,
@@ -443,6 +462,7 @@ class ReportTools:
                 featured_field: Featured field name.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(report_id, "report_id")
             if err is not None:
                 return err
@@ -494,6 +514,7 @@ class ReportTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(report_id, "report_id")
             if err is not None:
                 return err
@@ -528,6 +549,7 @@ class ReportTools:
             organization_id: PipefyId,
             name: str,
             pipe_ids: list[str],
+            ctx: Context,
             fields: list[str] | None = None,
             filter: dict | None = None,
             debug: bool = False,
@@ -546,6 +568,7 @@ class ReportTools:
                 filter: Report filter (ReportCardsFilter shape).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(organization_id, "organization_id")
             if err is not None:
                 return err
@@ -580,6 +603,7 @@ class ReportTools:
         )
         async def update_organization_report(
             report_id: PipefyId,
+            ctx: Context,
             name: str | None = None,
             color: str | None = None,
             fields: list[str] | None = None,
@@ -602,6 +626,7 @@ class ReportTools:
                 pipe_ids: Pipe IDs to include.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(report_id, "report_id")
             if err is not None:
                 return err
@@ -652,6 +677,7 @@ class ReportTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(report_id, "report_id")
             if err is not None:
                 return err
@@ -685,6 +711,7 @@ class ReportTools:
         async def export_pipe_report(
             pipe_id: PipefyId,
             pipe_report_id: PipefyId,
+            ctx: Context,
             sort_by: dict | None = None,
             filter: dict | None = None,
             columns: list[str] | None = None,
@@ -704,6 +731,7 @@ class ReportTools:
                 columns: Column field IDs for the export file.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(pipe_id, "pipe_id")
             if err is not None:
                 return err
@@ -738,6 +766,7 @@ class ReportTools:
         )
         async def export_organization_report(
             organization_id: PipefyId,
+            ctx: Context,
             organization_report_id: PipefyId | None = None,
             pipe_ids: list[PipefyId] | None = None,
             sort_by: dict | None = None,
@@ -761,6 +790,7 @@ class ReportTools:
                 columns: Column field IDs for the export file.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             organization_id, err = validate_tool_id(organization_id, "organization_id")
             if err is not None:
                 return err
@@ -793,6 +823,7 @@ class ReportTools:
         )
         async def export_pipe_audit_logs(
             pipe_uuid: str,
+            ctx: Context,
             search_term: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -803,6 +834,7 @@ class ReportTools:
                 search_term: Optional filter on audit log content.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             err = _blank_field_error(pipe_uuid, "pipe_uuid")
             if err is not None:
                 return err

--- a/packages/mcp/src/pipefy_mcp/tools/table_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/table_tools.py
@@ -10,7 +10,6 @@ from mcp.types import ToolAnnotations
 from pipefy_sdk import (
     UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS,
     UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE,
-    PipefyClient,
     PipefyId,
 )
 
@@ -36,6 +35,7 @@ from pipefy_mcp.tools.table_tool_helpers import (
     handle_table_tool_graphql_error,
     map_delete_table_error_to_message,
 )
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.tool_error_envelope import (
     is_unified_envelope_enabled,
     tool_error_message,
@@ -63,12 +63,13 @@ class TableTools:
     """MCP tools for database tables and records (reads and mutations)."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
             meta=REMOTE,
         )
         async def search_tables(
+            ctx: Context,
             table_name: str | None = None,
             first: int = 100,
         ) -> dict[str, Any]:
@@ -106,6 +107,7 @@ class TableTools:
                                          100 for substring matches, fuzzy score otherwise.
                       And ``search_limits`` (``tables_first``, ``tables_has_next_page``).
             """
+            client = get_pipefy_client(ctx)
             nfirst, err = validate_page_size(first, max_size=_SEARCH_TABLES_FIRST_MAX)
             if err is not None:
                 return err
@@ -126,7 +128,7 @@ class TableTools:
             annotations=ToolAnnotations(readOnlyHint=True),
             meta=REMOTE,
         )
-        async def get_table(table_id: PipefyId) -> dict[str, Any]:
+        async def get_table(table_id: PipefyId, ctx: Context) -> dict[str, Any]:
             """Load one database table: name, description, fields, and authorization.
 
             Use this after ``search_tables`` (or when you already have a table ID) to inspect
@@ -145,6 +147,7 @@ class TableTools:
                 ``authorization``). On validation or GraphQL errors, ``success: False`` with an
                 ``error`` message.
             """
+            client = get_pipefy_client(ctx)
             table_id, err = validate_tool_id(table_id, "table_id")
             if err is not None:
                 return build_table_read_error_payload(message=tool_error_message(err))
@@ -166,7 +169,7 @@ class TableTools:
             annotations=ToolAnnotations(readOnlyHint=True),
             meta=REMOTE,
         )
-        async def get_tables(table_ids: list[PipefyId]) -> dict[str, Any]:
+        async def get_tables(table_ids: list[PipefyId], ctx: Context) -> dict[str, Any]:
             """Load several database tables by ID (same shape as get_table per table).
 
             IDs are **database table** ids, not table-**relation** ids (see ``get_table_relations``).
@@ -174,6 +177,7 @@ class TableTools:
             Args:
                 table_ids: Non-empty list of table IDs.
             """
+            client = get_pipefy_client(ctx)
             if not isinstance(table_ids, list) or not table_ids:
                 return build_table_read_error_payload(
                     message="Invalid 'table_ids': provide a non-empty list of IDs.",
@@ -205,6 +209,7 @@ class TableTools:
         )
         async def get_table_records(
             table_id: PipefyId,
+            ctx: Context,
             first: int = 50,
             after: str | None = None,
         ) -> dict[str, Any]:
@@ -227,6 +232,7 @@ class TableTools:
                 first: Page size (1–200, default 50).
                 after: Cursor from the previous page (`endCursor`), if any.
             """
+            client = get_pipefy_client(ctx)
             table_id, err = validate_tool_id(table_id, "table_id")
             if err is not None:
                 return build_table_read_error_payload(message=tool_error_message(err))
@@ -270,7 +276,7 @@ class TableTools:
             annotations=ToolAnnotations(readOnlyHint=True),
             meta=REMOTE,
         )
-        async def get_table_record(record_id: PipefyId) -> dict[str, Any]:
+        async def get_table_record(record_id: PipefyId, ctx: Context) -> dict[str, Any]:
             """Load a single database table record with its field values.
 
             Use this when you have a record ID (e.g. from ``get_table_records`` or ``find_records``)
@@ -288,6 +294,7 @@ class TableTools:
                 ``table_record`` (``id``, ``title``, ``record_fields``). On errors,
                 ``success: False`` with ``error``.
             """
+            client = get_pipefy_client(ctx)
             record_id, err = validate_tool_id(record_id, "record_id")
             if err is not None:
                 return build_table_read_error_payload(message=tool_error_message(err))
@@ -313,6 +320,7 @@ class TableTools:
             table_id: PipefyId,
             field_id: str,
             field_value: str,
+            ctx: Context,
             first: int | None = None,
             after: str | None = None,
         ) -> dict[str, Any]:
@@ -330,6 +338,7 @@ class TableTools:
                 first: Optional page size for pagination (1-200 when set).
                 after: Optional cursor from ``pagination.end_cursor`` of a prior response.
             """
+            client = get_pipefy_client(ctx)
             table_id, err = validate_tool_id(table_id, "table_id")
             if err is not None:
                 return build_table_read_error_payload(message=tool_error_message(err))
@@ -392,6 +401,7 @@ class TableTools:
         async def create_table(
             name: str,
             organization_id: PipefyId,
+            ctx: Context,
             extra_input: Any | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -403,6 +413,7 @@ class TableTools:
                 extra_input: Additional `CreateTableInput` fields (e.g. description, authorization).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             if not isinstance(name, str) or not name.strip():
                 return build_table_mutation_error_payload(
                     message="Invalid 'name': provide a non-empty string.",
@@ -441,6 +452,7 @@ class TableTools:
         )
         async def update_table(
             table_id: PipefyId,
+            ctx: Context,
             name: str | None = None,
             description: str | None = None,
             extra_input: Any | None = None,
@@ -455,6 +467,7 @@ class TableTools:
                 extra_input: Other `UpdateTableInput` keys to merge (e.g. public, icon).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             table_id, err = validate_tool_id(table_id, "table_id")
             if err is not None:
                 return build_table_mutation_error_payload(
@@ -518,6 +531,7 @@ class TableTools:
                 confirm: When True, performs deletion after explicit user confirmation.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             table_id, err = validate_tool_id(table_id, "table_id")
             if err is not None:
                 return build_delete_table_error_payload(message=tool_error_message(err))
@@ -587,6 +601,7 @@ class TableTools:
         async def create_table_record(
             table_id: PipefyId,
             fields: Any,
+            ctx: Context,
             title: str | None = None,
             extra_input: Any | None = None,
             debug: bool = False,
@@ -604,6 +619,7 @@ class TableTools:
                 extra_input: Other `CreateTableRecordInput` keys (e.g. label_ids).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             table_id, err = validate_tool_id(table_id, "table_id")
             if err is not None:
                 return build_table_mutation_error_payload(
@@ -669,6 +685,7 @@ class TableTools:
         async def update_table_record(
             record_id: PipefyId,
             fields: dict[str, Any],
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Update a table record (title, due_date, status_id per Pipefy `UpdateTableRecordInput`).
@@ -682,6 +699,7 @@ class TableTools:
                 fields: Keys may include title, due_date, status_id (or statusId).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             record_id, err = validate_tool_id(record_id, "record_id")
             if err is not None:
                 return build_table_mutation_error_payload(
@@ -736,6 +754,7 @@ class TableTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             record_id, err = validate_tool_id(record_id, "record_id")
             if err is not None:
                 return build_table_mutation_error_payload(
@@ -772,6 +791,7 @@ class TableTools:
             record_id: PipefyId,
             field_id: PipefyId,
             value: Any,
+            ctx: Context,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Update a single custom field on a table record.
@@ -785,6 +805,7 @@ class TableTools:
                 value: New value (string/number/list as required by the field type).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             record_id, err = validate_tool_id(record_id, "record_id")
             if err is not None:
                 return build_table_mutation_error_payload(
@@ -824,6 +845,7 @@ class TableTools:
             table_id: PipefyId,
             label: str,
             field_type: str,
+            ctx: Context,
             extra_input: Any | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -844,6 +866,7 @@ class TableTools:
                 extra_input: Additional CreateTableFieldInput keys to merge (e.g. required, options).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             table_id, err = validate_tool_id(table_id, "table_id")
             if err is not None:
                 return build_table_mutation_error_payload(
@@ -891,6 +914,7 @@ class TableTools:
         )
         async def update_table_field(
             field_id: PipefyId,
+            ctx: Context,
             table_id: PipefyId | None = None,
             label: str | None = None,
             description: str | None = None,
@@ -913,6 +937,7 @@ class TableTools:
                 extra_input: Other UpdateTableFieldInput keys to merge (e.g. table_id if not provided as parameter).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             field_id, err = validate_tool_id(field_id, "field_id")
             if err is not None:
                 return build_table_mutation_error_payload(
@@ -999,6 +1024,7 @@ class TableTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             field_id, err = validate_tool_id(field_id, "field_id")
             if err is not None:
                 return build_table_mutation_error_payload(

--- a/packages/mcp/src/pipefy_mcp/tools/tool_context.py
+++ b/packages/mcp/src/pipefy_mcp/tools/tool_context.py
@@ -1,0 +1,27 @@
+"""Resolve request-scoped resources from the MCP lifespan context."""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import Context
+from pipefy_sdk import PipefyClient
+
+from pipefy_mcp.core.container import ServicesContainer
+
+
+def get_pipefy_client(ctx: Context) -> PipefyClient:
+    """Return the live Pipefy client for the in-flight request.
+
+    The server lifespan initializes services and yields the
+    :class:`ServicesContainer` as the request ``lifespan_context``. Tools read the
+    client from it per call rather than closing over one at registration, so a
+    request-scoped identity (issue #302) can vary the client without
+    re-registering the tool table.
+    """
+    container: ServicesContainer = ctx.request_context.lifespan_context
+    client = container.pipefy_client
+    if client is None:
+        raise RuntimeError(
+            "Pipefy client is not initialized; the server lifespan must "
+            "initialize services before any tool is invoked."
+        )
+    return client

--- a/packages/mcp/src/pipefy_mcp/tools/tool_context.py
+++ b/packages/mcp/src/pipefy_mcp/tools/tool_context.py
@@ -14,8 +14,8 @@ def get_pipefy_client(ctx: Context) -> PipefyClient:
     The server lifespan initializes services and yields the
     :class:`ServicesContainer` as the request ``lifespan_context``. Tools read the
     client from it per call rather than closing over one at registration, so a
-    request-scoped identity (issue #302) can vary the client without
-    re-registering the tool table.
+    request-scoped identity can vary the client without re-registering the tool
+    table.
     """
     container: ServicesContainer = ctx.request_context.lifespan_context
     client = container.pipefy_client

--- a/packages/mcp/src/pipefy_mcp/tools/webhook_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/webhook_tools.py
@@ -7,9 +7,10 @@ from typing import Any
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import ToolAnnotations
-from pipefy_sdk import PipefyClient, PipefyId
+from pipefy_sdk import PipefyId
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
+from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import (
     mutation_error_if_not_optional_dict,
     validate_tool_id,
@@ -25,12 +26,13 @@ class WebhookTools:
     """MCP tools for sending emails from card inboxes and managing webhooks."""
 
     @staticmethod
-    def register(mcp: FastMCP, client: PipefyClient) -> None:
+    def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
         )
         async def get_email_templates(
             repo_id: PipefyId,
+            ctx: Context,
             filter_by_name: str | None = None,
             first: int = 50,
             debug: bool = False,
@@ -46,6 +48,7 @@ class WebhookTools:
                 first: Max templates to return (default 50).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             rid, err = validate_tool_id(repo_id, "repo_id")
             if err is not None:
                 return err
@@ -73,6 +76,7 @@ class WebhookTools:
         )
         async def get_card_inbox_emails(
             card_id: PipefyId,
+            ctx: Context,
             email_type: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -86,6 +90,7 @@ class WebhookTools:
                 email_type: Optional filter: 'sent' or 'received' to get only that type.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             cid, err = validate_tool_id(card_id, "card_id")
             if err is not None:
                 return err
@@ -124,6 +129,7 @@ class WebhookTools:
             subject: str,
             body: str,
             from_: str,
+            ctx: Context,
             extra_input: dict[str, Any] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -140,6 +146,7 @@ class WebhookTools:
                 extra_input: Optional extra CreateAndSendInboxEmailInput fields (html, cc, bcc).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             cid, err = validate_tool_id(card_id, "card_id")
             if err is not None:
                 return err
@@ -196,6 +203,7 @@ class WebhookTools:
         async def send_email_with_template(
             card_id: PipefyId,
             email_template_id: PipefyId,
+            ctx: Context,
             to: list[str] | None = None,
             from_: str | None = None,
             extra_input: dict[str, Any] | None = None,
@@ -215,6 +223,7 @@ class WebhookTools:
                 extra_input: Optional extra CreateAndSendInboxEmailInput fields (cc, bcc).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             cid, err = validate_tool_id(card_id, "card_id")
             if err is not None:
                 return err
@@ -274,6 +283,7 @@ class WebhookTools:
                 pipe_id: ID of the pipe.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             await ctx.debug(f"get_webhooks: pipe_id={pipe_id}")
             pid, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
@@ -300,6 +310,7 @@ class WebhookTools:
             pipe_id: PipefyId,
             url: str,
             actions: list[str],
+            ctx: Context,
             extra_input: dict[str, Any] | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
@@ -316,6 +327,7 @@ class WebhookTools:
                 extra_input: Optional extra CreateWebhookInput fields (name, filters, headers).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             pid, err = validate_tool_id(pipe_id, "pipe_id")
             if err is not None:
                 return err
@@ -363,6 +375,7 @@ class WebhookTools:
         )
         async def update_webhook(
             webhook_id: PipefyId,
+            ctx: Context,
             name: str | None = None,
             url: str | None = None,
             actions: list[str] | None = None,
@@ -383,6 +396,7 @@ class WebhookTools:
                 headers: Optional JSON object of custom HTTP headers for the webhook request.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             wid, err = validate_tool_id(webhook_id, "webhook_id")
             if err is not None:
                 return err
@@ -467,6 +481,7 @@ class WebhookTools:
                 confirm: Set to True to execute the deletion (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
+            client = get_pipefy_client(ctx)
             wid, err = validate_tool_id(webhook_id, "webhook_id")
             if err is not None:
                 return err

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -14,7 +14,7 @@ from pipefy_auth.storage import StoredSession
 from pipefy_sdk import PipefyClient, PipefySettings
 
 from pipefy_mcp._docs import DOCS_SETUP_REF
-from pipefy_mcp.core.container import PipefyClientProxy, ServicesContainer
+from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.settings import Settings
 
 _AUTH_ENV_KEYS = (
@@ -281,41 +281,3 @@ class TestServicesContainer:
         assert "invalid_grant" in hint_message
         assert "pipefy auth login" in hint_message
         assert DOCS_SETUP_REF in hint_message
-
-
-class TestPipefyClientProxy:
-    """The proxy that lets tools bind once and follow client re-initialization."""
-
-    @pytest.mark.unit
-    def test_forwards_attribute_access_to_current_client(self):
-        container = ServicesContainer()
-        client = Mock()
-        container.pipefy_client = client
-
-        proxy = PipefyClientProxy(container)
-
-        assert proxy.get_organization is client.get_organization
-
-    @pytest.mark.unit
-    def test_follows_client_swap_without_rebinding(self):
-        """A re-init that swaps the client is picked up by the same proxy."""
-        container = ServicesContainer()
-        first, second = Mock(), Mock()
-
-        proxy = PipefyClientProxy(container)
-
-        container.pipefy_client = first
-        assert proxy.get_organization is first.get_organization
-
-        container.pipefy_client = second
-        assert proxy.get_organization is second.get_organization
-
-    @pytest.mark.unit
-    def test_raises_when_no_client_initialized_yet(self):
-        container = ServicesContainer()
-        container.pipefy_client = None
-
-        proxy = PipefyClientProxy(container)
-
-        with pytest.raises(RuntimeError, match="client is not initialized"):
-            _ = proxy.get_organization

--- a/packages/mcp/tests/tools/conftest.py
+++ b/packages/mcp/tests/tools/conftest.py
@@ -1,10 +1,33 @@
 """Shared fixtures for tool tests."""
 
 import json
+from contextlib import asynccontextmanager
 
 import pytest
+from mcp.server.fastmcp import FastMCP
 
+from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.settings import settings
+
+
+def build_tool_test_server(name, register, client):
+    """Build a FastMCP server whose lifespan yields a container holding ``client``.
+
+    Tools resolve the live client from the request ``lifespan_context`` (see
+    :func:`pipefy_mcp.tools.tool_context.get_pipefy_client`), so a test injects
+    its mock by presetting it on the container the lifespan yields. ``register``
+    is a tool group's ``register`` staticmethod, called with the app alone.
+    """
+
+    @asynccontextmanager
+    async def _lifespan(_app):
+        container = ServicesContainer()
+        container.pipefy_client = client
+        yield container
+
+    mcp = FastMCP(name, lifespan=_lifespan)
+    register(mcp)
+    return mcp
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_ai_agent_tools.py
+++ b/packages/mcp/tests/tools/test_ai_agent_tools.py
@@ -14,7 +14,6 @@ from _shared.fixture_ids import (
     make_pipe_id,
 )
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -23,7 +22,10 @@ from pipefy_sdk.models.ai_agent import UpdateAiAgentInput
 import pipefy_mcp.settings as _settings_mod
 from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
-from tools.conftest import assert_invalid_arguments_envelope
+from tools.conftest import (
+    assert_invalid_arguments_envelope,
+    build_tool_test_server,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -51,9 +53,9 @@ def mock_pipefy_client():
 
 @pytest.fixture
 def mcp_server(mock_pipefy_client):
-    mcp = FastMCP("AI Agent Tools Test")
-    AiAgentTools.register(mcp, mock_pipefy_client)
-    return mcp
+    return build_tool_test_server(
+        "AI Agent Tools Test", AiAgentTools.register, mock_pipefy_client
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_ai_automation_tools.py
+++ b/packages/mcp/tests/tools/test_ai_automation_tools.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -13,7 +12,10 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.ai_automation_tools import AiAutomationTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
-from tools.conftest import assert_invalid_arguments_envelope
+from tools.conftest import (
+    assert_invalid_arguments_envelope,
+    build_tool_test_server,
+)
 
 
 @pytest.fixture
@@ -42,16 +44,20 @@ def mock_pipefy_client_no_ai():
 
 @pytest.fixture
 def mcp_server(mock_pipefy_client):
-    mcp = FastMCP("AI Automation Tools Test")
-    AiAutomationTools.register(mcp, mock_pipefy_client)
-    return mcp
+    return build_tool_test_server(
+        "AI Automation Tools Test",
+        AiAutomationTools.register,
+        mock_pipefy_client,
+    )
 
 
 @pytest.fixture
 def mcp_server_no_ai(mock_pipefy_client_no_ai):
-    mcp = FastMCP("AI Automation Tools Test (no AI)")
-    AiAutomationTools.register(mcp, mock_pipefy_client_no_ai)
-    return mcp
+    return build_tool_test_server(
+        "AI Automation Tools Test (no AI)",
+        AiAutomationTools.register,
+        mock_pipefy_client_no_ai,
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_attachment_tools.py
+++ b/packages/mcp/tests/tools/test_attachment_tools.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -21,6 +20,7 @@ from pipefy_sdk.models.attachment import infer_content_type
 
 from pipefy_mcp.tools.attachment_tools import AttachmentTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from tools.conftest import build_tool_test_server
 
 
 @pytest.fixture
@@ -47,9 +47,9 @@ def mock_attachment_client():
 
 @pytest.fixture
 def attachment_mcp_server(mock_attachment_client):
-    mcp = FastMCP("Attachment Tools Test")
-    AttachmentTools.register(mcp, mock_attachment_client)
-    return mcp
+    return build_tool_test_server(
+        "Attachment Tools Test", AttachmentTools.register, mock_attachment_client
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_attachment_tools_live.py
+++ b/packages/mcp/tests/tools/test_attachment_tools_live.py
@@ -17,7 +17,6 @@ from unittest.mock import patch
 
 import pytest
 from _shared.live_settings import live_resolved_auth, require_live_creds
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -26,6 +25,7 @@ from pipefy_sdk import PipefyClient
 from pipefy_mcp.server import build_pipefy_mcp_server
 from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.attachment_tools import AttachmentTools
+from tools.conftest import build_tool_test_server
 
 mcp_server = build_pipefy_mcp_server()
 
@@ -75,9 +75,9 @@ def live_pipefy_client():
 
 @pytest.fixture
 def live_attachment_mcp(live_pipefy_client):
-    mcp = FastMCP("Attachment tools live")
-    AttachmentTools.register(mcp, live_pipefy_client)
-    return mcp
+    return build_tool_test_server(
+        "Attachment tools live", AttachmentTools.register, live_pipefy_client
+    )
 
 
 @pytest.mark.integration

--- a/packages/mcp/tests/tools/test_automation_tools.py
+++ b/packages/mcp/tests/tools/test_automation_tools.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -13,7 +12,7 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.automation_tools import AutomationTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
-from tools.conftest import assert_invalid_arguments_envelope
+from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
 
 
 @pytest.fixture
@@ -36,9 +35,9 @@ def mock_automation_client():
 
 @pytest.fixture
 def automation_mcp_server(mock_automation_client):
-    mcp = FastMCP("Automation Tools Test")
-    AutomationTools.register(mcp, mock_automation_client)
-    return mcp
+    return build_tool_test_server(
+        "Automation Tools Test", AutomationTools.register, mock_automation_client
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_field_condition_tools.py
+++ b/packages/mcp/tests/tools/test_field_condition_tools.py
@@ -2,18 +2,17 @@
 
 from datetime import timedelta
 from random import randint
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
 from pipefy_sdk import PipefyClient
 
-from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.tools.field_condition_tools import FieldConditionTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from tools.conftest import build_tool_test_server
 
 
 @pytest.fixture
@@ -24,22 +23,13 @@ def mock_pipefy_client():
     return client
 
 
-@pytest.fixture(autouse=True)
-def mock_services_container(mocker, mock_pipefy_client):
-    container = Mock(ServicesContainer)
-    container.pipefy_client = mock_pipefy_client
-
-    return mocker.patch(
-        "pipefy_mcp.core.container.ServicesContainer.get_instance",
-        return_value=container,
-    )
-
-
 @pytest.fixture
 def mcp_server(mock_pipefy_client):
-    mcp = FastMCP("Field Condition Tools Test")
-    FieldConditionTools.register(mcp, mock_pipefy_client)
-    return mcp
+    return build_tool_test_server(
+        "Field Condition Tools Test",
+        FieldConditionTools.register,
+        mock_pipefy_client,
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_introspection_scenarios.py
+++ b/packages/mcp/tests/tools/test_introspection_scenarios.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -12,6 +11,7 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.introspection_tools import IntrospectionTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from tools.conftest import build_tool_test_server
 
 
 @pytest.fixture
@@ -26,9 +26,11 @@ def scenario_client():
 
 @pytest.fixture
 def scenario_mcp(scenario_client):
-    mcp = FastMCP("Introspection scenarios")
-    IntrospectionTools.register(mcp, scenario_client)
-    return mcp
+    return build_tool_test_server(
+        "Introspection scenarios",
+        IntrospectionTools.register,
+        scenario_client,
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_introspection_tools.py
+++ b/packages/mcp/tests/tools/test_introspection_tools.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -13,6 +12,7 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.introspection_tools import IntrospectionTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from tools.conftest import build_tool_test_server
 
 
 @pytest.fixture
@@ -28,9 +28,11 @@ def mock_introspection_client():
 
 @pytest.fixture
 def introspection_mcp_server(mock_introspection_client):
-    mcp = FastMCP("Pipefy Introspection Tools Test")
-    IntrospectionTools.register(mcp, mock_introspection_client)
-    return mcp
+    return build_tool_test_server(
+        "Pipefy Introspection Tools Test",
+        IntrospectionTools.register,
+        mock_introspection_client,
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_introspection_tools_live.py
+++ b/packages/mcp/tests/tools/test_introspection_tools_live.py
@@ -15,13 +15,13 @@ from _shared.live_settings import (
     live_resolved_auth,
     require_live_creds,
 )
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
 from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.introspection_tools import IntrospectionTools
+from tools.conftest import build_tool_test_server
 
 
 @pytest.fixture
@@ -32,9 +32,11 @@ def live_pipefy_client():
 
 @pytest.fixture
 def live_introspection_mcp(live_pipefy_client):
-    mcp = FastMCP("Introspection tools live")
-    IntrospectionTools.register(mcp, live_pipefy_client)
-    return mcp
+    return build_tool_test_server(
+        "Introspection tools live",
+        IntrospectionTools.register,
+        live_pipefy_client,
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_member_tools.py
+++ b/packages/mcp/tests/tools/test_member_tools.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -14,6 +13,7 @@ from pipefy_sdk import PipefyClient
 import pipefy_mcp.settings as _settings_mod
 from pipefy_mcp.tools.member_tools import MemberTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from tools.conftest import build_tool_test_server
 
 
 @pytest.fixture(autouse=True)
@@ -37,9 +37,9 @@ def mock_member_client():
 
 @pytest.fixture
 def member_mcp_server(mock_member_client):
-    mcp = FastMCP("Member Tools Test")
-    MemberTools.register(mcp, mock_member_client)
-    return mcp
+    return build_tool_test_server(
+        "Member Tools Test", MemberTools.register, mock_member_client
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_observability_tools.py
+++ b/packages/mcp/tests/tools/test_observability_tools.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from _shared.fixture_ids import EXAMPLE_NUMERIC_ORG_ID
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -14,7 +13,10 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.observability_tools import _MAX_PAGE_SIZE, ObservabilityTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
-from tools.conftest import assert_invalid_arguments_envelope
+from tools.conftest import (
+    assert_invalid_arguments_envelope,
+    build_tool_test_server,
+)
 
 
 @pytest.fixture
@@ -35,9 +37,11 @@ def mock_observability_client():
 
 @pytest.fixture
 def observability_mcp_server(mock_observability_client):
-    mcp = FastMCP("Observability Tools Test")
-    ObservabilityTools.register(mcp, mock_observability_client)
-    return mcp
+    return build_tool_test_server(
+        "Observability Tools Test",
+        ObservabilityTools.register,
+        mock_observability_client,
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_organization_tools.py
+++ b/packages/mcp/tests/tools/test_organization_tools.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -13,6 +12,7 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.organization_tools import OrganizationTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
+from tools.conftest import build_tool_test_server
 
 
 @pytest.fixture
@@ -24,9 +24,11 @@ def mock_org_client():
 
 @pytest.fixture
 def org_mcp_server(mock_org_client):
-    mcp = FastMCP("Pipefy Organization Tools Test")
-    OrganizationTools.register(mcp, mock_org_client)
-    return mcp
+    return build_tool_test_server(
+        "Pipefy Organization Tools Test",
+        OrganizationTools.register,
+        mock_org_client,
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -25,7 +24,7 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
 )
 from pipefy_mcp.tools.pipe_config_tools import PipeConfigTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error, tool_error_message
-from tools.conftest import assert_invalid_arguments_envelope
+from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
 
 
 @pytest.mark.unit
@@ -101,9 +100,12 @@ def mock_pipe_config_client():
 
 @pytest.fixture
 def pipe_config_mcp_server(mock_pipe_config_client):
-    mcp = FastMCP("Pipe Config Tools Test")
-    PipeConfigTools.register(mcp, mock_pipe_config_client)
-    FieldConditionTools.register(mcp, mock_pipe_config_client)
+    mcp = build_tool_test_server(
+        "Pipe Config Tools Test",
+        PipeConfigTools.register,
+        mock_pipe_config_client,
+    )
+    FieldConditionTools.register(mcp)
     return mcp
 
 

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 from mcp import ClientSession
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.context import RequestContext
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
@@ -25,6 +24,7 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
 )
 from pipefy_mcp.tools.pipe_tools import FIND_CARDS_RESPONSE_KEY, PipeTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error, tool_error_message
+from tools.conftest import build_tool_test_server
 
 # =============================================================================
 # Fixtures
@@ -33,10 +33,9 @@ from pipefy_mcp.tools.tool_error_envelope import tool_error, tool_error_message
 
 @pytest.fixture
 def mcp_server(mock_pipefy_client):
-    mcp = FastMCP("Pipefy MCP Test Server")
-    PipeTools.register(mcp, mock_pipefy_client)
-
-    return mcp
+    return build_tool_test_server(
+        "Pipefy MCP Test Server", PipeTools.register, mock_pipefy_client
+    )
 
 
 @pytest.fixture
@@ -260,12 +259,17 @@ class TestCreateCardTool:
             "createCard": {"card": {"id": "789"}}
         }
 
-        mcp = FastMCP("Pipefy MCP Test Server")
-        PipeTools.register(mcp, mock_pipefy_client)
+        mcp = build_tool_test_server(
+            "Pipefy MCP Test Server", PipeTools.register, mock_pipefy_client
+        )
+
+        container = ServicesContainer()
+        container.pipefy_client = mock_pipefy_client
 
         ctx = MagicMock()
         ctx.debug = AsyncMock()
         ctx.session = SimpleNamespace(client_params=SimpleNamespace())
+        ctx.request_context = SimpleNamespace(lifespan_context=container)
 
         result = await mcp._tool_manager.call_tool(
             "create_card",

--- a/packages/mcp/tests/tools/test_portal_tools.py
+++ b/packages/mcp/tests/tools/test_portal_tools.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from _shared.fixture_ids import EXAMPLE_NUMERIC_ORG_ID, EXAMPLE_PIPE_REPO_ID
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -17,7 +16,7 @@ from pipefy_sdk.exceptions import PortalPermissionError
 
 from pipefy_mcp.tools.portal_tools import PortalTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
-from tools.conftest import assert_invalid_arguments_envelope
+from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
 
 _PORTAL_LIST_NODE = {
     "id": "portal-uuid-1",
@@ -143,9 +142,9 @@ def mock_portal_client():
 
 @pytest.fixture
 def portal_mcp_server(mock_portal_client):
-    mcp = FastMCP("Pipefy Portal Tools Test")
-    PortalTools.register(mcp, mock_portal_client)
-    return mcp
+    return build_tool_test_server(
+        "Pipefy Portal Tools Test", PortalTools.register, mock_portal_client
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_registry.py
+++ b/packages/mcp/tests/tools/test_registry.py
@@ -1,9 +1,8 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 from mcp.server.fastmcp import FastMCP
 
-from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.tools.registry import PIPEFY_TOOL_NAMES, ToolRegistry
 
 
@@ -11,14 +10,12 @@ class TestToolRegistry:
     """Test cases for ToolRegistry"""
 
     def test_init_sets_attributes(self):
-        """Test that __init__ sets mcp and services_container attributes"""
+        """Test that __init__ sets mcp and pipefy_tool_names attributes"""
         mock_mcp = Mock(spec=FastMCP)
-        mock_container = Mock(spec=ServicesContainer)
 
-        registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
+        registry = ToolRegistry(mcp=mock_mcp)
 
         assert registry.mcp is mock_mcp
-        assert registry.services_container is mock_container
         assert registry.pipefy_tool_names == PIPEFY_TOOL_NAMES
 
     @patch("pipefy_mcp.tools.registry.ObservabilityTools.register")
@@ -50,10 +47,8 @@ class TestToolRegistry:
     ):
         """Each tool group is registered once, with the app and no client."""
         mock_mcp = Mock(spec=FastMCP)
-        mock_container = Mock(spec=ServicesContainer)
-        mock_container.pipefy_client = Mock()
 
-        registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
+        registry = ToolRegistry(mcp=mock_mcp)
         registry.register_tools()
 
         # Registration passes only the app: tools resolve the live client per
@@ -75,8 +70,8 @@ class TestToolRegistry:
             mock_register.assert_called_once_with(mock_mcp)
         assert registry.pipefy_tool_names == PIPEFY_TOOL_NAMES
 
-    def test_register_tools_does_not_touch_the_container_client(self):
-        """Registration never reads the client, so a None client is irrelevant.
+    def test_register_tools_takes_no_client(self):
+        """Registration never receives a client, so it can run before services exist.
 
         Tools resolve the client per request from the lifespan context, which is
         what lets registration run once at construction, before the lifespan has
@@ -84,10 +79,8 @@ class TestToolRegistry:
         tool is actually invoked.
         """
         mock_mcp = Mock(spec=FastMCP)
-        mock_container = Mock(spec=ServicesContainer)
-        mock_container.pipefy_client = None
 
-        registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
+        registry = ToolRegistry(mcp=mock_mcp)
 
         assert registry.register_tools() is None
 
@@ -123,10 +116,8 @@ class TestToolRegistry:
         mock_observability_tools_register,
     ):
         mock_mcp = Mock(spec=FastMCP)
-        mock_container = Mock(spec=ServicesContainer)
-        mock_container.pipefy_client = Mock()
 
-        registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
+        registry = ToolRegistry(mcp=mock_mcp)
         registry.register_tools()
 
         for mock_register in (
@@ -150,9 +141,7 @@ class TestToolRegistry:
 
     def test_register_tools_records_pipefy_tool_names_on_real_fastmcp(self):
         mcp = FastMCP("tool-registry-names")
-        mock_container = Mock(spec=ServicesContainer)
-        mock_container.pipefy_client = MagicMock()
-        registry = ToolRegistry(mcp=mcp, services_container=mock_container)
+        registry = ToolRegistry(mcp=mcp)
         registry.register_tools()
 
         assert registry.pipefy_tool_names == PIPEFY_TOOL_NAMES
@@ -161,8 +150,7 @@ class TestToolRegistry:
 
     def test_check_for_name_collisions_raises_when_pipefy_name_already_registered(self):
         mock_mcp = Mock(spec=FastMCP)
-        mock_container = Mock(spec=ServicesContainer)
-        registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
+        registry = ToolRegistry(mcp=mock_mcp)
         with patch.object(
             ToolRegistry,
             "_snapshot_tool_names",
@@ -175,8 +163,7 @@ class TestToolRegistry:
 
     def test_check_for_name_collisions_ok_when_no_overlap(self):
         mock_mcp = Mock(spec=FastMCP)
-        mock_container = Mock(spec=ServicesContainer)
-        registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
+        registry = ToolRegistry(mcp=mock_mcp)
         with patch.object(
             ToolRegistry,
             "_snapshot_tool_names",

--- a/packages/mcp/tests/tools/test_registry.py
+++ b/packages/mcp/tests/tools/test_registry.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from mcp.server.fastmcp import FastMCP
 
-from pipefy_mcp.core.container import PipefyClientProxy, ServicesContainer
+from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.tools.registry import PIPEFY_TOOL_NAMES, ToolRegistry
 
 
@@ -48,7 +48,7 @@ class TestToolRegistry:
         mock_introspection_tools_register,
         mock_observability_tools_register,
     ):
-        """Each tool group is registered once with the shared client proxy."""
+        """Each tool group is registered once, with the app and no client."""
         mock_mcp = Mock(spec=FastMCP)
         mock_container = Mock(spec=ServicesContainer)
         mock_container.pipefy_client = Mock()
@@ -56,11 +56,8 @@ class TestToolRegistry:
         registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
         registry.register_tools()
 
-        # Tools bind a single PipefyClientProxy, not the concrete client, so a
-        # later service re-init is picked up without re-registering.
-        proxy = mock_pipe_tools_register.call_args.args[1]
-        assert isinstance(proxy, PipefyClientProxy)
-
+        # Registration passes only the app: tools resolve the live client per
+        # request from the lifespan context, not from a registration argument.
         for mock_register in (
             mock_pipe_tools_register,
             mock_pipe_config_tools_register,
@@ -75,15 +72,16 @@ class TestToolRegistry:
             mock_introspection_tools_register,
             mock_observability_tools_register,
         ):
-            mock_register.assert_called_once_with(mock_mcp, proxy)
+            mock_register.assert_called_once_with(mock_mcp)
         assert registry.pipefy_tool_names == PIPEFY_TOOL_NAMES
 
-    def test_register_tools_succeeds_when_pipefy_client_is_none(self):
-        """Registration binds a proxy, so it works before services are initialized.
+    def test_register_tools_does_not_touch_the_container_client(self):
+        """Registration never reads the client, so a None client is irrelevant.
 
-        The proxy defers client resolution to call time, which is what lets
-        tools register once at construction (before the lifespan runs). The
-        absence of a live client only surfaces when a tool is actually invoked.
+        Tools resolve the client per request from the lifespan context, which is
+        what lets registration run once at construction, before the lifespan has
+        initialized services. The absence of a live client only surfaces when a
+        tool is actually invoked.
         """
         mock_mcp = Mock(spec=FastMCP)
         mock_container = Mock(spec=ServicesContainer)
@@ -131,9 +129,6 @@ class TestToolRegistry:
         registry = ToolRegistry(mcp=mock_mcp, services_container=mock_container)
         registry.register_tools()
 
-        proxy = mock_pipe_tools_register.call_args.args[1]
-        assert isinstance(proxy, PipefyClientProxy)
-
         for mock_register in (
             mock_pipe_tools_register,
             mock_pipe_config_tools_register,
@@ -150,7 +145,7 @@ class TestToolRegistry:
             mock_ai_automation_tools_register,
             mock_ai_agent_tools_register,
         ):
-            mock_register.assert_called_once_with(mock_mcp, proxy)
+            mock_register.assert_called_once_with(mock_mcp)
         assert registry.pipefy_tool_names == PIPEFY_TOOL_NAMES
 
     def test_register_tools_records_pipefy_tool_names_on_real_fastmcp(self):

--- a/packages/mcp/tests/tools/test_relation_tools.py
+++ b/packages/mcp/tests/tools/test_relation_tools.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -13,7 +12,7 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.relation_tools import RelationTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
-from tools.conftest import assert_invalid_arguments_envelope
+from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
 
 
 @pytest.fixture
@@ -30,9 +29,9 @@ def mock_relation_client():
 
 @pytest.fixture
 def relation_mcp_server(mock_relation_client):
-    mcp = FastMCP("Relation Tools Test")
-    RelationTools.register(mcp, mock_relation_client)
-    return mcp
+    return build_tool_test_server(
+        "Relation Tools Test", RelationTools.register, mock_relation_client
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -1,11 +1,9 @@
 """Tests for the default-deny remote-profile tool allowlist (#304)."""
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, Mock
 
 from mcp.server.fastmcp import FastMCP
 
-from pipefy_mcp.core.container import ServicesContainer
 from pipefy_mcp.tools.registry import PIPEFY_TOOL_NAMES, ToolRegistry
 from pipefy_mcp.tools.remote_profile import REMOTE, REMOTE_META_KEY, is_remote_tool
 
@@ -40,9 +38,7 @@ REMOTE_SEED = frozenset(
 def _registry_with_all_tools() -> tuple[ToolRegistry, FastMCP]:
     """Register every Pipefy tool on a real FastMCP, as the lifespan does."""
     mcp = FastMCP("remote-profile-test")
-    container = Mock(spec=ServicesContainer)
-    container.pipefy_client = MagicMock()
-    registry = ToolRegistry(mcp=mcp, services_container=container)
+    registry = ToolRegistry(mcp=mcp)
     registry.register_tools()
     return registry, mcp
 

--- a/packages/mcp/tests/tools/test_report_tools.py
+++ b/packages/mcp/tests/tools/test_report_tools.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -14,7 +13,7 @@ from pipefy_sdk.report_filter_preflight import EXAMPLE_PHASE_FILTER
 
 from pipefy_mcp.tools.report_tools import ReportTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
-from tools.conftest import assert_invalid_arguments_envelope
+from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
 
 GOLDEN_REPORT_PHASE_FILTER = {
     **EXAMPLE_PHASE_FILTER,
@@ -51,9 +50,9 @@ def mock_report_client():
 
 @pytest.fixture
 def report_mcp_server(mock_report_client):
-    mcp = FastMCP("Report Tools Test")
-    ReportTools.register(mcp, mock_report_client)
-    return mcp
+    return build_tool_test_server(
+        "Report Tools Test", ReportTools.register, mock_report_client
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_table_tools.py
+++ b/packages/mcp/tests/tools/test_table_tools.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from _shared.pagination_test_defaults import DEFAULT_FIRST
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -14,7 +13,7 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.table_tools import TableTools
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
-from tools.conftest import assert_invalid_arguments_envelope
+from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
 
 
 @pytest.fixture
@@ -41,9 +40,9 @@ def mock_table_client():
 
 @pytest.fixture
 def table_mcp_server(mock_table_client):
-    mcp = FastMCP("Table Tools Test")
-    TableTools.register(mcp, mock_table_client)
-    return mcp
+    return build_tool_test_server(
+        "Table Tools Test", TableTools.register, mock_table_client
+    )
 
 
 @pytest.fixture

--- a/packages/mcp/tests/tools/test_tool_context.py
+++ b/packages/mcp/tests/tools/test_tool_context.py
@@ -1,0 +1,48 @@
+"""Tests for resolving the request-scoped client from the lifespan context."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from pipefy_mcp.core.container import ServicesContainer
+from pipefy_mcp.tools.tool_context import get_pipefy_client
+
+
+def _ctx_with_container(container: ServicesContainer) -> Mock:
+    """A minimal Context whose request_context carries ``container``."""
+    ctx = Mock()
+    ctx.request_context = SimpleNamespace(lifespan_context=container)
+    return ctx
+
+
+@pytest.mark.unit
+def test_returns_the_client_held_by_the_lifespan_container():
+    container = ServicesContainer()
+    client = Mock()
+    container.pipefy_client = client
+
+    assert get_pipefy_client(_ctx_with_container(container)) is client
+
+
+@pytest.mark.unit
+def test_follows_a_client_swap_on_the_same_container():
+    """A re-initialized container is picked up; nothing is bound at registration."""
+    container = ServicesContainer()
+    first, second = Mock(), Mock()
+    ctx = _ctx_with_container(container)
+
+    container.pipefy_client = first
+    assert get_pipefy_client(ctx) is first
+
+    container.pipefy_client = second
+    assert get_pipefy_client(ctx) is second
+
+
+@pytest.mark.unit
+def test_raises_when_no_client_initialized_yet():
+    container = ServicesContainer()
+    container.pipefy_client = None
+
+    with pytest.raises(RuntimeError, match="client is not initialized"):
+        get_pipefy_client(_ctx_with_container(container))

--- a/packages/mcp/tests/tools/test_webhook_tools.py
+++ b/packages/mcp/tests/tools/test_webhook_tools.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from _shared.pagination_test_defaults import DEFAULT_FIRST
 from gql.transport.exceptions import TransportQueryError
-from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
@@ -14,7 +13,7 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.webhook_tools import WebhookTools
-from tools.conftest import assert_invalid_arguments_envelope
+from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
 
 
 @pytest.fixture
@@ -33,9 +32,9 @@ def mock_webhook_client():
 
 @pytest.fixture
 def webhook_mcp_server(mock_webhook_client):
-    mcp = FastMCP("Webhook Tools Test")
-    WebhookTools.register(mcp, mock_webhook_client)
-    return mcp
+    return build_tool_test_server(
+        "Webhook Tools Test", WebhookTools.register, mock_webhook_client
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## What

Tools stop closing over a `client` passed to `register(...)`. Each tool function declares a `ctx: Context` parameter and resolves the live Pipefy client per request with `get_pipefy_client(ctx)` (new `tools/tool_context.py`), which reads `ctx.request_context.lifespan_context.pipefy_client`.

This is the official FastMCP lifespan/Context pattern: the lifespan owns resources and yields the `ServicesContainer` as the request `lifespan_context`; tools read the client from it per call.

## Why

It is the plumbing for per-request, on-behalf-of identity (#302): the client the lifespan yields can now vary per request without touching any tool. It also removes the construction-time `PipefyClientProxy`, an interim bridge that only resolved the process-global singleton.

## Changes

- New `tools/tool_context.py` with `get_pipefy_client(ctx)`.
- All 16 tool groups: `register(mcp)` (no client param); each tool gets `ctx: Context` and `client = get_pipefy_client(ctx)`. Tools that already carried `ctx` for elicitation reuse it.
- `ToolRegistry.register_tools()` calls `register(mcp)` and no longer builds a client/proxy.
- `PipefyClientProxy` removed from `core/container.py`.
- Tests inject a mock client through a lifespan that yields a container holding it, via the new `build_tool_test_server` conftest helper. New `test_tool_context.py`. `AGENTS.md` tool-registration docs updated.

## Out of scope

This is the tool-side plumbing only. The request-scoped bearer wiring (`CallableBearerAuth`) and token verification that complete on-behalf-of remain #301/#302.

## Verification

- `ruff check` and `ruff format --check`: clean.
- Full `packages/mcp` suite: 1371 passed, 16 skipped (live tests skip without credentials).
- `packages/sdk` untouched.