### PR TITLE
fix(plugin): rename /login slash command to /pipefy-login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Releases are versioned in lockstep across workspace members (`pipefy-sdk`, `pipe
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- **Plugin (Claude Code)**: renamed the OAuth slash command from `/login` to `/pipefy-login` (`commands/login.md` → `commands/pipefy-login.md`, frontmatter `name: pipefy-login`). The old `name: login` claimed the `/login` trigger and shadowed Claude Code's built-in `/login` (Claude account sign-in): selecting the built-in entry in the command picker still ran the Pipefy command, so Claude login was unreachable via `/login` while the plugin was installed. Closes #331.
+
 ## [0.2.0-beta.4] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ After install, run `pipefy auth login` to authenticate (`--device` on headless s
 /pipefy:pipefy-login
 ```
 
-`/plugin install pipefy` registers the MCP server and the `/pipefy:install` + `/pipefy-login` slash commands. `/pipefy:install` runs `uv tool install` once to put `pipefy` on PATH (idempotent). `/pipefy-login` runs the OAuth browser flow. For hand-wired setups (paste-into-config blocks per client, the macOS `errSecParam` keychain note, the local-clone alternative for contributors), see [`packages/mcp/README.md`](packages/mcp/README.md).
+`/plugin install pipefy` registers the MCP server and the `/pipefy:install` + `/pipefy:pipefy-login` slash commands. `/pipefy:install` runs `uv tool install` once to put `pipefy` on PATH (idempotent). `/pipefy:pipefy-login` runs the OAuth browser flow. For hand-wired setups (paste-into-config blocks per client, the macOS `errSecParam` keychain note, the local-clone alternative for contributors), see [`packages/mcp/README.md`](packages/mcp/README.md).
 
 ### CLI
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Feedback and issues: [GitHub Issues](https://github.com/pipefy/ai-toolkit/issues
 
 Two auth paths:
 
-- **Human OAuth (interactive)**: `pipefy auth login` runs the browser flow and stores a session in your OS keychain. Works anywhere the `pipefy` CLI is on PATH (`uv tool install` once, any client can invoke it). Claude Code additionally exposes it as the `/pipefy-login` slash command via the plugin marketplace. Pipe membership is whatever the signed-in user already has.
+- **Human OAuth (interactive)**: `pipefy auth login` runs the browser flow and stores a session in your OS keychain. Works anywhere the `pipefy` CLI is on PATH (`uv tool install` once, any client can invoke it). Claude Code additionally exposes it as the `/pipefy:pipefy-login` slash command via the plugin marketplace. Pipe membership is whatever the signed-in user already has.
 - **Service account (unattended / CI)**: provision a Service Account in [Pipefy Admin](https://app.pipefy.com/) (Admin → Service Accounts) and add that account to every pipe the tools should touch. Wire `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` and `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` into the client config below.
 
 Full env-var reference and `config.toml` precedence: [`docs/config.md`](docs/config.md).

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ After install, run `pipefy auth login` to authenticate (`--device` on headless s
 /plugin marketplace add pipefy/ai-toolkit
 /plugin install pipefy
 /pipefy:install
-/pipefy-login
+/pipefy:pipefy-login
 ```
 
 `/plugin install pipefy` registers the MCP server and the `/pipefy:install` + `/pipefy-login` slash commands. `/pipefy:install` runs `uv tool install` once to put `pipefy` on PATH (idempotent). `/pipefy-login` runs the OAuth browser flow. For hand-wired setups (paste-into-config blocks per client, the macOS `errSecParam` keychain note, the local-clone alternative for contributors), see [`packages/mcp/README.md`](packages/mcp/README.md).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Feedback and issues: [GitHub Issues](https://github.com/pipefy/ai-toolkit/issues
 
 Two auth paths:
 
-- **Human OAuth (interactive)**: `pipefy auth login` runs the browser flow and stores a session in your OS keychain. Works anywhere the `pipefy` CLI is on PATH (`uv tool install` once, any client can invoke it). Claude Code additionally exposes it as the `/pipefy:login` slash command via the plugin marketplace. Pipe membership is whatever the signed-in user already has.
+- **Human OAuth (interactive)**: `pipefy auth login` runs the browser flow and stores a session in your OS keychain. Works anywhere the `pipefy` CLI is on PATH (`uv tool install` once, any client can invoke it). Claude Code additionally exposes it as the `/pipefy-login` slash command via the plugin marketplace. Pipe membership is whatever the signed-in user already has.
 - **Service account (unattended / CI)**: provision a Service Account in [Pipefy Admin](https://app.pipefy.com/) (Admin → Service Accounts) and add that account to every pipe the tools should touch. Wire `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` and `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` into the client config below.
 
 Full env-var reference and `config.toml` precedence: [`docs/config.md`](docs/config.md).
@@ -83,10 +83,10 @@ After install, run `pipefy auth login` to authenticate (`--device` on headless s
 /plugin marketplace add pipefy/ai-toolkit
 /plugin install pipefy
 /pipefy:install
-/pipefy:login
+/pipefy-login
 ```
 
-`/plugin install pipefy` registers the MCP server and the `/pipefy:install` + `/pipefy:login` slash commands. `/pipefy:install` runs `uv tool install` once to put `pipefy` on PATH (idempotent). `/pipefy:login` runs the OAuth browser flow. For hand-wired setups (paste-into-config blocks per client, the macOS `errSecParam` keychain note, the local-clone alternative for contributors), see [`packages/mcp/README.md`](packages/mcp/README.md).
+`/plugin install pipefy` registers the MCP server and the `/pipefy:install` + `/pipefy-login` slash commands. `/pipefy:install` runs `uv tool install` once to put `pipefy` on PATH (idempotent). `/pipefy-login` runs the OAuth browser flow. For hand-wired setups (paste-into-config blocks per client, the macOS `errSecParam` keychain note, the local-clone alternative for contributors), see [`packages/mcp/README.md`](packages/mcp/README.md).
 
 ### CLI
 

--- a/commands/pipefy-login.md
+++ b/commands/pipefy-login.md
@@ -1,5 +1,5 @@
 ---
-name: login
+name: pipefy-login
 description: Authenticate with Pipefy via OAuth and store the session in the OS keychain.
 disable-model-invocation: true
 argument-hint: "[--no-browser] [--callback-timeout <seconds>]"

--- a/install.sh
+++ b/install.sh
@@ -455,7 +455,7 @@ print_next_steps() {
     say "  Default (browser):   pipefy auth login"
     say "  Headless (device):   pipefy auth login --device"
     if [ "$CLIENT" = "claude-code" ]; then
-        say "  Via Claude Code:     /pipefy:login"
+        say "  Via Claude Code:     /pipefy-login"
     fi
 }
 


### PR DESCRIPTION
## What

Renames the plugin's OAuth slash command from `login` to `pipefy-login`:

- `commands/login.md` -> `commands/pipefy-login.md`, frontmatter `name: pipefy-login`
- README, `install.sh`, and CHANGELOG references updated to `/pipefy-login`

## Why

The command was named `login`, so it claimed the `/login` trigger in Claude Code's command picker and shadowed the built-in `/login` (Claude account sign-in). Reproduced on Claude Code 2.1.185 with pipefy@pipefy 0.2.0-beta.1: typing `/login` shows two `/login` rows, and selecting either one (including the row labeled "Sign in with your Anthropic account") dispatches `/pipefy:login`. The built-in Claude login is unreachable via `/login` while the plugin is installed. Full repro in #331.

This is a known Claude Code dispatch bug for plugin commands that collide with built-ins (see anthropics/claude-code#62500 and anthropics/claude-code#62409), not yet acknowledged by Anthropic. The practical fix on our side is to not claim a built-in's trigger. `/pipefy-login` no longer collides.

## Notes

- Invocation form: this uses the bare `/pipefy-login` rather than the namespaced `/pipefy:pipefy-login`. Both resolve to the same command; the bare form reads cleaner and avoids the redundant double "pipefy". `/pipefy:install` is left unchanged.
- The `pipefy auth login` CLI command is unaffected; only the slash command name changed.
- No CI covers `commands/` (skills-lint is scoped to `skills/**`), so nothing else needs updating.

Closes #331.
