### PR TITLE
refactor(sdk,mcp,cli): consolidate internal API client construction and ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **SDK**: `PipefyClient` now constructs its internal API client during `__init__` (built from the same `settings` and `auth` as every other endpoint client), so `PipefyClient(settings, auth=...)` is fully wired after construction. The `set_internal_api_client` methods on `PipefyClient` and `PortalService` are removed; pass the internal API client through the `PortalService` constructor when composing it directly. The `PipefyClient.internal_api_available` property is also removed: the internal API client is always present, so the property was always `True`.
 - **Plugin (Claude Code)**: renamed the OAuth slash command from `/login` to `/pipefy-login` (`commands/login.md` → `commands/pipefy-login.md`, frontmatter `name: pipefy-login`). The old `name: login` claimed the `/login` trigger and shadowed Claude Code's built-in `/login` (Claude account sign-in): selecting the built-in entry in the command picker still ran the Pipefy command, so Claude login was unreachable via `/login` while the plugin was installed. Closes #331.
 
 ## [0.2.0-beta.4] - 2026-06-19

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -29,7 +29,6 @@ from pipefy_auth import (
     tier_for,
 )
 from pipefy_sdk import (
-    InternalApiClient,
     PipefyClient,
     PipefySettings,
 )
@@ -185,12 +184,6 @@ def get_authenticated_client(
         return _cached_client
 
     client = PipefyClient(pipefy_settings, auth=resolved)
-    internal_client = InternalApiClient(
-        url=pipefy_settings.internal_api_url,
-        auth=resolved,
-        allow_insecure_urls=pipefy_settings.allow_insecure_urls,
-    )
-    client.set_internal_api_client(internal_client)
     _cached_signature = key
     _cached_client = client
     return client

--- a/packages/cli/src/pipefy_cli/commands/relation.py
+++ b/packages/cli/src/pipefy_cli/commands/relation.py
@@ -156,7 +156,7 @@ def relation_card_delete(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
-    """Remove a card relation (requires service-account credentials; internal API)."""
+    """Remove a card relation (internal API, requires OAuth)."""
 
     confirm_destructive(
         yes=yes,

--- a/packages/cli/src/pipefy_cli/commands/relation.py
+++ b/packages/cli/src/pipefy_cli/commands/relation.py
@@ -7,7 +7,6 @@ from pipefy_sdk import PipefyClient
 
 from pipefy_cli.commands._common import (
     ID_POSITIONAL_CONTEXT_SETTINGS,
-    authenticated_client_from_ctx,
     confirm_destructive,
     parse_json_object,
     resource_id_argument,
@@ -158,17 +157,6 @@ def relation_card_delete(
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Remove a card relation (requires service-account credentials; internal API)."""
-
-    client = authenticated_client_from_ctx(ctx)
-    if not client.internal_api_available:
-        typer.echo(
-            "delete_card_relation requires service-account credentials "
-            "(PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
-            "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET). "
-            "The deleteCardRelation mutation is only available on the internal API.",
-            err=True,
-        )
-        raise typer.Exit(2)
 
     confirm_destructive(
         yes=yes,

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -2414,8 +2414,7 @@ Usage: pipefy relation card [OPTIONS] COMMAND [ARGS]...
 │ list     List parent and child relations for a card (raw                     │
 │          ``get_card_relations`` payload).                                    │
 │ create   Link two cards via an existing pipe relation.                       │
-│ delete   Remove a card relation (requires service-account credentials;       │
-│          internal API).                                                      │
+│ delete   Remove a card relation (internal API, requires OAuth).              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP relation/card/create
@@ -2436,7 +2435,7 @@ Usage: pipefy relation card create [OPTIONS]
 ### HELP relation/card/delete
 Usage: pipefy relation card delete [OPTIONS]
 
- Remove a card relation (requires service-account credentials; internal API).
+ Remove a card relation (internal API, requires OAuth).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --child           TEXT  Child card id. [required]                         │

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -77,43 +77,11 @@ def test_get_authenticated_client_passes_auth_to_pipefy_client(clean_pipefy_env)
         assert client is mock_pc.return_value
 
 
-def test_get_authenticated_client_service_account_wires_internal_api(clean_pipefy_env):
-    settings = _minimal_settings()
-    with (
-        patch("pipefy_cli.auth.PipefyClient") as mock_pc,
-        patch("pipefy_cli.auth.InternalApiClient") as mock_internal,
-    ):
-        mock_pc.return_value = MagicMock()
-        get_authenticated_client(settings, _auth())
-        mock_pc.assert_called_once()
-        mock_internal.assert_called_once()
-
-
-def test_get_authenticated_client_bearer_path_shares_auth_with_internal_api(
-    clean_pipefy_env,
-):
-    """Both clients receive the SAME ``auth`` instance on the bearer path."""
-    settings = _minimal_settings()
-    with (
-        patch("pipefy_cli.auth.PipefyClient") as mock_pc,
-        patch("pipefy_cli.auth.InternalApiClient") as mock_internal,
-    ):
-        mock_pc.return_value = MagicMock()
-        get_authenticated_client(settings, _auth(bearer_token="tok"))
-        pc_auth = mock_pc.call_args.kwargs["auth"]
-        internal_auth = mock_internal.call_args.kwargs["auth"]
-        assert isinstance(pc_auth, StaticBearerAuth)
-        assert internal_auth is pc_auth
-
-
 def test_cache_returns_same_instance_for_identical_service_account_settings(
     clean_pipefy_env,
 ):
     settings = _minimal_settings()
-    with (
-        patch("pipefy_cli.auth.PipefyClient") as mock_pc,
-        patch("pipefy_cli.auth.InternalApiClient"),
-    ):
+    with patch("pipefy_cli.auth.PipefyClient") as mock_pc:
         mock_pc.return_value = MagicMock()
         first = get_authenticated_client(settings, _auth())
         second = get_authenticated_client(settings, _auth())
@@ -238,7 +206,6 @@ def test_bearer_token_wins_over_stored_session(clean_pipefy_env):
     settings = _minimal_settings()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
-        patch("pipefy_cli.auth.InternalApiClient"),
         patch("pipefy_auth.resolver.load_session") as mock_load,
         patch("pipefy_cli.auth.ensure_fresh_session") as mock_ensure,
     ):
@@ -261,7 +228,6 @@ def test_service_account_creds_win_over_stored_session(clean_pipefy_env):
     settings = _minimal_settings()
     with (
         patch("pipefy_cli.auth.PipefyClient") as mock_pc,
-        patch("pipefy_cli.auth.InternalApiClient"),
         patch("pipefy_auth.resolver.load_session") as mock_load,
         patch("pipefy_cli.auth.ensure_fresh_session") as mock_ensure,
     ):

--- a/packages/cli/tests/test_relation_member_commands.py
+++ b/packages/cli/tests/test_relation_member_commands.py
@@ -22,36 +22,6 @@ def test_relation_pipe_list_json(runner, clean_pipefy_env, saved_cwd, oauth_env)
     mock_client.get_pipe_relations.assert_awaited_once_with("10")
 
 
-def test_relation_card_delete_requires_internal_api(
-    runner, clean_pipefy_env, saved_cwd, oauth_env
-):
-    oauth_env("rel-c")
-    mock_client = MagicMock()
-    mock_client.internal_api_available = False
-    with patch(
-        "pipefy_cli.commands._common.get_authenticated_client",
-        return_value=mock_client,
-    ):
-        result = runner.invoke(
-            app,
-            [
-                "relation",
-                "card",
-                "delete",
-                "--child",
-                "1",
-                "--parent",
-                "2",
-                "--source",
-                "3",
-                "--yes",
-                "--json",
-            ],
-        )
-    assert result.exit_code == 2
-    mock_client.delete_card_relation.assert_not_called()
-
-
 def test_member_remove_blocks_service_account(
     runner, clean_pipefy_env, saved_cwd, oauth_env, monkeypatch
 ):
@@ -177,7 +147,6 @@ def test_relation_card_delete_internal_api_json(
 ):
     oauth_env("rel-cc-del")
     mock_client = MagicMock()
-    mock_client.internal_api_available = True
     mock_client.delete_card_relation = AsyncMock(
         return_value={"deleteCardRelation": {}}
     )

--- a/packages/mcp/src/pipefy_mcp/core/container.py
+++ b/packages/mcp/src/pipefy_mcp/core/container.py
@@ -12,7 +12,7 @@ from pipefy_auth import (
     resolve_pipefy_auth,
     tier_for,
 )
-from pipefy_sdk import InternalApiClient, PipefyClient
+from pipefy_sdk import PipefyClient
 
 from pipefy_mcp._docs import DOCS_SETUP_REF
 from pipefy_mcp.settings import Settings
@@ -81,9 +81,3 @@ class ServicesContainer:
                 raise
             logger.info("Pipefy stored session warmed up at startup")
         self.pipefy_client = PipefyClient(settings=pipefy, auth=resolved)
-        internal_client = InternalApiClient(
-            url=pipefy.internal_api_url,
-            auth=resolved,
-            allow_insecure_urls=pipefy.allow_insecure_urls,
-        )
-        self.pipefy_client.set_internal_api_client(internal_client)

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -544,17 +544,6 @@ class PipeTools:
                 f"source_id={source_id}, confirm={confirm}"
             )
 
-            if not client.internal_api_available:
-                return build_relation_error_payload(
-                    message=(
-                        "delete_card_relation requires service-account credentials "
-                        "(PIPEFY_SERVICE_ACCOUNT_CLIENT_ID, "
-                        "PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET). "
-                        "The deleteCardRelation mutation is only available on the "
-                        "internal API. Check .env.example for the required variables."
-                    ),
-                )
-
             cid, err = validate_tool_id(child_id, "child_id")
             if err is not None:
                 return err

--- a/packages/mcp/tests/core/test_container.py
+++ b/packages/mcp/tests/core/test_container.py
@@ -69,12 +69,10 @@ class TestServicesContainer:
 
         assert container.pipefy_client is None
 
-    @patch("pipefy_mcp.core.container.InternalApiClient")
     @patch("pipefy_mcp.core.container.PipefyClient")
     async def test_initialize_services_creates_pipefy_client(
         self,
         mock_pipefy_client_class,
-        mock_internal_api_client_class,
     ):
         """Test that initialize_services creates and assigns PipefyClient"""
         mock_client = Mock(spec=PipefyClient)
@@ -95,43 +93,12 @@ class TestServicesContainer:
         assert "auth" in kwargs
         assert container.pipefy_client is mock_client
 
-    @patch("pipefy_mcp.core.container.InternalApiClient")
-    @patch("pipefy_mcp.core.container.PipefyClient")
-    async def test_initialize_services_attaches_internal_api_client(
-        self,
-        mock_pipefy_client_class,
-        mock_internal_api_client_class,
-    ):
-        mock_client = Mock(spec=PipefyClient)
-        mock_client.client = Mock()
-        mock_pipefy_client_class.return_value = mock_client
-
-        settings = Settings(
-            pipefy=PipefySettings(base_url="https://api.pipefy.com"),
-            auth=_service_account_auth_settings(),
-        )
-
-        container = ServicesContainer()
-        await container.initialize_services(settings)
-
-        mock_internal_api_client_class.assert_called_once()
-        mock_client.set_internal_api_client.assert_called_once_with(
-            mock_internal_api_client_class.return_value
-        )
-
-    @patch("pipefy_mcp.core.container.InternalApiClient")
     @patch("pipefy_mcp.core.container.PipefyClient")
     async def test_initialize_services_picks_up_pipefy_token_over_service_account(
         self,
         mock_pipefy_client_class,
-        mock_internal_api_client_class,
     ):
-        """``PIPEFY_TOKEN`` outranks ``PIPEFY_SERVICE_ACCOUNT_*`` (same precedence as the CLI).
-
-        Also asserts that the bearer path wires ``InternalApiClient`` with the
-        SAME ``auth`` instance ``PipefyClient`` got, so GraphQL auth and the
-        internal API client can't drift.
-        """
+        """``PIPEFY_TOKEN`` outranks ``PIPEFY_SERVICE_ACCOUNT_*`` (same precedence as the CLI)."""
         mock_client = Mock(spec=PipefyClient)
         mock_client.client = Mock()
         mock_pipefy_client_class.return_value = mock_client
@@ -144,22 +111,15 @@ class TestServicesContainer:
         await ServicesContainer().initialize_services(settings)
         pc_auth = mock_pipefy_client_class.call_args.kwargs["auth"]
         assert isinstance(pc_auth, StaticBearerAuth)
-        mock_internal_api_client_class.assert_called_once()
-        assert mock_internal_api_client_class.call_args.kwargs["auth"] is pc_auth
-        mock_client.set_internal_api_client.assert_called_once_with(
-            mock_internal_api_client_class.return_value
-        )
 
     # Patch ``load_session``: ``auth_url``'s prod default makes the stored-session
     # tier always reachable, so a host with a real keychain entry would otherwise
     # satisfy resolution and break the assertion.
     @patch("pipefy_auth.resolver.load_session", lambda **_: None)
-    @patch("pipefy_mcp.core.container.InternalApiClient")
     @patch("pipefy_mcp.core.container.PipefyClient")
     async def test_initialize_services_raises_when_no_auth_source_configured(
         self,
         mock_pipefy_client_class,
-        mock_internal_api_client_class,
     ):
         """No PIPEFY_TOKEN and no service-account triple → runtime error."""
         settings = Settings(

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -60,7 +60,6 @@ def mock_pipefy_client():
     client.delete_card_relation = AsyncMock(
         return_value={"deleteCardRelation": {"success": True}}
     )
-    client.internal_api_available = True
     client.update_card = AsyncMock()
     client.get_pipe_members = AsyncMock()
 
@@ -2604,31 +2603,6 @@ class TestDeleteCardRelation:
         payload = extract_payload(result)
         assert payload["success"] is False
         assert "did not succeed" in tool_error_message(payload).lower()
-
-    @pytest.mark.parametrize("client_session", [None], indirect=True)
-    async def test_not_configured_returns_service_account_message(
-        self,
-        client_session,
-        mock_pipefy_client,
-        extract_payload,
-    ) -> None:
-        """delete_card_relation requires internal API (service-account) credentials."""
-        mock_pipefy_client.internal_api_available = False
-        async with client_session as session:
-            result = await session.call_tool(
-                "delete_card_relation",
-                {
-                    "child_id": "1",
-                    "parent_id": "2",
-                    "source_id": "3",
-                    "confirm": True,
-                },
-            )
-        assert result.isError is False
-        mock_pipefy_client.delete_card_relation.assert_not_called()
-        payload = extract_payload(result)
-        assert payload["success"] is False
-        assert "service-account credentials" in tool_error_message(payload)
 
 
 @pytest.mark.anyio

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -941,11 +941,7 @@ class PipefyClient:
         parent_id: str | int,
         source_id: str | int,
     ) -> dict:
-        """Delete a relation link between two cards (internal API, requires OAuth).
-
-        The ``deleteCardRelation`` mutation is not exposed on the public GraphQL
-        schema, only on the internal API (core_api / internal_v1).
-        """
+        """Delete a relation link between two cards (internal API, requires OAuth)."""
         return await self._relation_service.delete_card_relation(
             child_id, parent_id, source_id
         )

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -124,22 +124,16 @@ class PipefyClient:
         self._introspection_service = SchemaIntrospectionService(
             settings=settings, auth=auth
         )
-        self._internal_api_client: InternalApiClient | None = None
-        self._portal_service = PortalService(settings=settings, auth=auth)
-
-    @property
-    def internal_api_available(self) -> bool:
-        """Whether the internal API client is configured (OAuth credentials present)."""
-        return self._internal_api_client is not None
-
-    def set_internal_api_client(self, client: InternalApiClient) -> None:
-        """Attach the internal API client (requires OAuth credentials).
-
-        Args:
-            client: Configured :class:`InternalApiClient` instance.
-        """
-        self._internal_api_client = client
-        self._portal_service.set_internal_api_client(client)
+        self._internal_api_client = InternalApiClient(
+            url=settings.internal_api_url,
+            auth=auth,
+            allow_insecure_urls=settings.allow_insecure_urls,
+        )
+        self._portal_service = PortalService(
+            settings=settings,
+            auth=auth,
+            internal_api_client=self._internal_api_client,
+        )
 
     async def get_pipe(self, pipe_id: str | int) -> dict:
         """Get a pipe by ID, including phases, labels, and start form fields."""
@@ -949,9 +943,8 @@ class PipefyClient:
         """Delete a relation link between two cards (internal API, requires OAuth).
 
         The ``deleteCardRelation`` mutation is not exposed on the public GraphQL
-        schema — only on the internal API (core_api / internal_v1).
+        schema, only on the internal API (core_api / internal_v1).
         """
-        assert self._internal_api_client is not None  # noqa: S101
         return await self._internal_api_client.execute_query(
             INTERNAL_DELETE_CARD_RELATION_MUTATION,
             {

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -95,11 +95,7 @@ class PipefyClient:
             settings=settings, auth=auth, pipe_service=self._pipe_service
         )
         self._table_service = TableService(settings=settings, auth=auth)
-        self._internal_api_client = InternalApiClient(
-            url=settings.internal_api_url,
-            auth=auth,
-            allow_insecure_urls=settings.allow_insecure_urls,
-        )
+        self._internal_api_client = InternalApiClient(settings, auth=auth)
         self._relation_service = RelationService(
             settings=settings,
             auth=auth,

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -25,9 +25,6 @@ from pipefy_sdk.models.attachment import (
     AttachmentTarget,
     AttachmentUploadResult,
 )
-from pipefy_sdk.queries.card_queries import (
-    INTERNAL_DELETE_CARD_RELATION_MUTATION,
-)
 from pipefy_sdk.services.ai_agent_service import AiAgentService
 from pipefy_sdk.services.attachment_service import AttachmentService
 from pipefy_sdk.services.automation_graphql_types import (
@@ -98,7 +95,16 @@ class PipefyClient:
             settings=settings, auth=auth, pipe_service=self._pipe_service
         )
         self._table_service = TableService(settings=settings, auth=auth)
-        self._relation_service = RelationService(settings=settings, auth=auth)
+        self._internal_api_client = InternalApiClient(
+            url=settings.internal_api_url,
+            auth=auth,
+            allow_insecure_urls=settings.allow_insecure_urls,
+        )
+        self._relation_service = RelationService(
+            settings=settings,
+            auth=auth,
+            internal_api_client=self._internal_api_client,
+        )
         self._member_service = MemberService(
             settings=settings,
             auth=auth,
@@ -123,11 +129,6 @@ class PipefyClient:
         )
         self._introspection_service = SchemaIntrospectionService(
             settings=settings, auth=auth
-        )
-        self._internal_api_client = InternalApiClient(
-            url=settings.internal_api_url,
-            auth=auth,
-            allow_insecure_urls=settings.allow_insecure_urls,
         )
         self._portal_service = PortalService(
             settings=settings,
@@ -945,13 +946,8 @@ class PipefyClient:
         The ``deleteCardRelation`` mutation is not exposed on the public GraphQL
         schema, only on the internal API (core_api / internal_v1).
         """
-        return await self._internal_api_client.execute_query(
-            INTERNAL_DELETE_CARD_RELATION_MUTATION,
-            {
-                "childId": str(child_id),
-                "parentId": str(parent_id),
-                "sourceId": str(source_id),
-            },
+        return await self._relation_service.delete_card_relation(
+            child_id, parent_id, source_id
         )
 
     async def get_start_form_fields(

--- a/packages/sdk/src/pipefy_sdk/queries/card_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/card_queries.py
@@ -265,30 +265,6 @@ UPDATE_FIELDS_VALUES_MUTATION = gql(
     """
 )
 
-# ---------------------------------------------------------------------------
-# Internal API mutations
-#
-# ``deleteCardRelation`` is only available on the internal GraphQL schema
-# (core_api / internal_v1), not the public API. It runs through
-# ``InternalApiClient``, which accepts a ``gql()`` query like every other client.
-# ---------------------------------------------------------------------------
-
-INTERNAL_DELETE_CARD_RELATION_MUTATION = gql("""
-mutation deleteCardRelation(
-  $childId: ID!,
-  $parentId: ID!,
-  $sourceId: ID!
-) {
-  deleteCardRelation(input: {
-    child_id: $childId,
-    parent_id: $parentId,
-    source_id: $sourceId
-  }) {
-    success
-  }
-}
-""")
-
 __all__ = [
     "CREATE_CARD_MUTATION",
     "CREATE_COMMENT_MUTATION",
@@ -298,7 +274,6 @@ __all__ = [
     "GET_CARD_QUERY",
     "GET_CARD_RELATIONS_QUERY",
     "GET_CARDS_QUERY",
-    "INTERNAL_DELETE_CARD_RELATION_MUTATION",
     "MOVE_CARD_TO_PHASE_MUTATION",
     "UPDATE_CARD_FIELD_MUTATION",
     "UPDATE_CARD_MUTATION",

--- a/packages/sdk/src/pipefy_sdk/queries/relation_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/relation_queries.py
@@ -176,11 +176,33 @@ CREATE_CARD_RELATION_MUTATION = gql(
     """
 )
 
+# ``deleteCardRelation`` is only available on the internal GraphQL schema
+# (core_api / internal_v1), not the public API. It runs through
+# ``InternalApiClient``, which accepts a ``gql()`` query like every other client.
+INTERNAL_DELETE_CARD_RELATION_MUTATION = gql(
+    """
+    mutation deleteCardRelation(
+      $childId: ID!,
+      $parentId: ID!,
+      $sourceId: ID!
+    ) {
+      deleteCardRelation(input: {
+        child_id: $childId,
+        parent_id: $parentId,
+        source_id: $sourceId
+      }) {
+        success
+      }
+    }
+    """
+)
+
 __all__ = [
     "CREATE_CARD_RELATION_MUTATION",
     "CREATE_PIPE_RELATION_MUTATION",
     "DELETE_PIPE_RELATION_MUTATION",
     "GET_PIPE_RELATIONS_QUERY",
     "GET_TABLE_RELATIONS_QUERY",
+    "INTERNAL_DELETE_CARD_RELATION_MUTATION",
     "UPDATE_PIPE_RELATION_MUTATION",
 ]

--- a/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
+++ b/packages/sdk/src/pipefy_sdk/services/internal_api_client.py
@@ -9,7 +9,6 @@ is decorated with ``[code=...]`` / ``[correlation_id=...]`` suffixes drawn from
 from __future__ import annotations
 
 from httpx import Auth
-from pipefy_infra import security
 
 from pipefy_sdk.base_client import BasePipefyClient
 from pipefy_sdk.settings import PipefySettings
@@ -38,30 +37,20 @@ class InternalApiClient(BasePipefyClient):
     ``_format_internal_api_error``.
     """
 
-    def __init__(
-        self,
-        url: str,
-        *,
-        auth: Auth,
-        allow_insecure_urls: bool = False,
-    ) -> None:
+    def __init__(self, settings: PipefySettings, *, auth: Auth) -> None:
         """Create an internal API client.
 
         Args:
-            url: URL of the internal_api endpoint (e.g. https://app.pipefy.com/internal_api).
+            settings: Pipefy endpoints and credentials, shared with the other
+                endpoint clients. ``settings.internal_api_url`` (derived from
+                ``base_url``, which the settings model validated for HTTPS and
+                host-root shape at construction) targets the internal_api
+                endpoint, so no per-client URL re-validation is needed here.
             auth: Pre-constructed ``httpx.Auth`` (e.g. from ``pipefy_auth.resolve``).
-            allow_insecure_urls: When True, allow http and internal hosts.
         """
-        security.validate_https_url(
-            url.strip(), "internal_api URL", allow_insecure=allow_insecure_urls
-        )
-        # ``url`` already SSRF-validated above; ``allow_insecure_urls=True`` on
-        # the throwaway settings skips a redundant re-check. ``url_override``
-        # ships the URL without building a full purpose-specific ``PipefySettings``.
-        settings = PipefySettings(allow_insecure_urls=True)
         super().__init__(
             settings,
             auth=auth,
-            url_override=url.strip(),
+            url_override=settings.internal_api_url,
             on_graphql_error=_format_internal_api_error,
         )

--- a/packages/sdk/src/pipefy_sdk/services/portal_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/portal_service.py
@@ -275,14 +275,6 @@ class PortalService:
             raise ValueError(INTERNAL_API_CLIENT_NOT_CONFIGURED)
         return await self._internal_api_client.execute_query(query, variables)
 
-    def set_internal_api_client(self, client: InternalApiClient) -> None:
-        """Attach the internal API client for sub-portal mutations.
-
-        Args:
-            client: Configured :class:`InternalApiClient` instance.
-        """
-        self._internal_api_client = client
-
     async def list_portals(
         self,
         organization_uuid: str | int,

--- a/packages/sdk/src/pipefy_sdk/services/portal_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/portal_service.py
@@ -46,8 +46,6 @@ from pipefy_sdk.utils.organization_identifiers import resolve_organization_uuid
 
 logger = logging.getLogger(__name__)
 
-INTERNAL_API_CLIENT_NOT_CONFIGURED = "Internal API client is not configured."
-
 
 def _with_uuid_alias(record: dict[str, Any]) -> dict[str, Any]:
     """Expose GraphQL ``id`` as ``uuid`` in portal payloads."""
@@ -224,9 +222,9 @@ class PortalService:
         settings: PipefySettings,
         *,
         auth: Auth,
-        internal_api_client: InternalApiClient | None = None,
+        internal_api_client: InternalApiClient,
     ) -> None:
-        """Wire clients for Interfaces schema and optional internal_api mutations.
+        """Wire clients for the Interfaces schema and internal_api mutations.
 
         Args:
             settings: Pipefy endpoints and credentials.
@@ -267,12 +265,7 @@ class PortalService:
         Args:
             query: GraphQL document string.
             variables: Variable map for the operation.
-
-        Raises:
-            ValueError: When no internal API client was injected.
         """
-        if self._internal_api_client is None:
-            raise ValueError(INTERNAL_API_CLIENT_NOT_CONFIGURED)
         return await self._internal_api_client.execute_query(query, variables)
 
     async def list_portals(

--- a/packages/sdk/src/pipefy_sdk/services/relation_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/relation_service.py
@@ -28,8 +28,6 @@ from pipefy_sdk.queries.relation_queries import (
 from pipefy_sdk.services.internal_api_client import InternalApiClient
 from pipefy_sdk.settings import PipefySettings
 
-INTERNAL_API_CLIENT_NOT_CONFIGURED = "Internal API client is not configured."
-
 _PIPE_RELATION_CONSTRAINT_DEFAULTS: dict[str, Any] = {
     "allChildrenMustBeDoneToFinishParent": False,
     "allChildrenMustBeDoneToMoveParent": False,
@@ -52,7 +50,7 @@ class RelationService(BasePipefyClient):
         settings: PipefySettings,
         *,
         auth: Auth,
-        internal_api_client: InternalApiClient | None = None,
+        internal_api_client: InternalApiClient,
     ) -> None:
         super().__init__(settings=settings, auth=auth)
         self._internal_api_client = internal_api_client
@@ -192,12 +190,7 @@ class RelationService(BasePipefyClient):
             child_id: Child card ID.
             parent_id: Parent card ID.
             source_id: Pipe relation ID linking the two cards.
-
-        Raises:
-            ValueError: When no internal API client was injected.
         """
-        if self._internal_api_client is None:
-            raise ValueError(INTERNAL_API_CLIENT_NOT_CONFIGURED)
         return await self._internal_api_client.execute_query(
             INTERNAL_DELETE_CARD_RELATION_MUTATION,
             {

--- a/packages/sdk/src/pipefy_sdk/services/relation_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/relation_service.py
@@ -22,9 +22,13 @@ from pipefy_sdk.queries.relation_queries import (
     DELETE_PIPE_RELATION_MUTATION,
     GET_PIPE_RELATIONS_QUERY,
     GET_TABLE_RELATIONS_QUERY,
+    INTERNAL_DELETE_CARD_RELATION_MUTATION,
     UPDATE_PIPE_RELATION_MUTATION,
 )
+from pipefy_sdk.services.internal_api_client import InternalApiClient
 from pipefy_sdk.settings import PipefySettings
+
+INTERNAL_API_CLIENT_NOT_CONFIGURED = "Internal API client is not configured."
 
 _PIPE_RELATION_CONSTRAINT_DEFAULTS: dict[str, Any] = {
     "allChildrenMustBeDoneToFinishParent": False,
@@ -48,8 +52,10 @@ class RelationService(BasePipefyClient):
         settings: PipefySettings,
         *,
         auth: Auth,
+        internal_api_client: InternalApiClient | None = None,
     ) -> None:
         super().__init__(settings=settings, auth=auth)
+        self._internal_api_client = internal_api_client
 
     async def get_pipe_relations(self, pipe_id: str | int) -> dict[str, Any]:
         """Fetch parent and child pipe relations for a pipe (`parentsRelations`, `childrenRelations`).
@@ -168,4 +174,35 @@ class RelationService(BasePipefyClient):
         return await self.execute_query(
             CREATE_CARD_RELATION_MUTATION,
             {"input": input_obj},
+        )
+
+    async def delete_card_relation(
+        self,
+        child_id: str | int,
+        parent_id: str | int,
+        source_id: str | int,
+    ) -> dict[str, Any]:
+        """Delete a relation link between two cards (internal API, requires OAuth).
+
+        The ``deleteCardRelation`` mutation is not exposed on the public GraphQL
+        schema, only on the internal API (core_api / internal_v1), so it routes
+        through the injected ``InternalApiClient`` rather than ``execute_query``.
+
+        Args:
+            child_id: Child card ID.
+            parent_id: Parent card ID.
+            source_id: Pipe relation ID linking the two cards.
+
+        Raises:
+            ValueError: When no internal API client was injected.
+        """
+        if self._internal_api_client is None:
+            raise ValueError(INTERNAL_API_CLIENT_NOT_CONFIGURED)
+        return await self._internal_api_client.execute_query(
+            INTERNAL_DELETE_CARD_RELATION_MUTATION,
+            {
+                "childId": str(child_id),
+                "parentId": str(parent_id),
+                "sourceId": str(source_id),
+            },
         )

--- a/packages/sdk/tests/_shared/mock_clients.py
+++ b/packages/sdk/tests/_shared/mock_clients.py
@@ -1,0 +1,23 @@
+"""Shared test doubles for the SDK's endpoint clients.
+
+Lives in ``_shared`` so the InternalApiClient stand-in is defined once and
+reused across the service test modules (``test_relation_service``,
+``test_portal_service``) rather than re-rolled per file.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from pipefy_sdk.services.internal_api_client import InternalApiClient
+
+
+def mock_internal_api_client(return_value: dict | None = None) -> MagicMock:
+    """A MagicMock standing in for InternalApiClient with execute_query async.
+
+    Pass ``return_value`` to set what ``execute_query`` resolves to; the default
+    suits callers that only need a constructor stand-in and never assert on it.
+    """
+    mock = MagicMock(spec=InternalApiClient)
+    mock.execute_query = AsyncMock(return_value=return_value)
+    return mock

--- a/packages/sdk/tests/services/pipefy/test_portal_service.py
+++ b/packages/sdk/tests/services/pipefy/test_portal_service.py
@@ -14,6 +14,7 @@ from _shared.fixture_ids import (
     EXAMPLE_OTHER_ORG_UUID,
     EXAMPLE_PIPE_REPO_ID,
 )
+from _shared.mock_clients import mock_internal_api_client
 from gql.transport.exceptions import TransportQueryError
 from httpx_auth import OAuth2ClientCredentials
 from pydantic import ValidationError
@@ -21,7 +22,6 @@ from pydantic import ValidationError
 from pipefy_sdk.exceptions import PortalPermissionError
 from pipefy_sdk.queries.observability_queries import RESOLVE_ORGANIZATION_UUID_QUERY
 from pipefy_sdk.queries.portal_queries import GET_PORTAL_QUERY, LIST_PORTALS_QUERY
-from pipefy_sdk.services.internal_api_client import InternalApiClient
 from pipefy_sdk.services.portal_service import PortalService
 from pipefy_sdk.settings import PipefySettings
 
@@ -46,9 +46,7 @@ def mock_auth() -> OAuth2ClientCredentials:
 
 
 def _mock_internal_api_client() -> MagicMock:
-    mock = MagicMock(spec=InternalApiClient)
-    mock.execute_query = AsyncMock(return_value={"updateSubPortalElement": {}})
-    return mock
+    return mock_internal_api_client({"updateSubPortalElement": {}})
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/pipefy/test_portal_service_integration.py
+++ b/packages/sdk/tests/services/pipefy/test_portal_service_integration.py
@@ -41,7 +41,7 @@ def _skip_or_fail_internal_api_error(exc: BaseException, *, context: str) -> Non
     if isinstance(exc, ValueError) and str(exc) == INTERNAL_API_CLIENT_NOT_CONFIGURED:
         pytest.fail(
             f"{context}: PortalService internal_api client was not wired "
-            "(PipefyClient.set_internal_api_client must forward to PortalService).",
+            "(PortalService must receive an internal_api_client at construction).",
             pytrace=False,
         )
     if isinstance(exc, ValueError):

--- a/packages/sdk/tests/services/pipefy/test_portal_service_integration.py
+++ b/packages/sdk/tests/services/pipefy/test_portal_service_integration.py
@@ -30,22 +30,11 @@ from gql.transport.exceptions import TransportQueryError
 
 from pipefy_sdk.exceptions import PortalPermissionError
 from pipefy_sdk.services.internal_api_client import InternalApiClient
-from pipefy_sdk.services.portal_service import (
-    INTERNAL_API_CLIENT_NOT_CONFIGURED,
-    PortalService,
-)
+from pipefy_sdk.services.portal_service import PortalService
 
 
 def _skip_or_fail_internal_api_error(exc: BaseException, *, context: str) -> None:
-    """Skip live API flakes; fail when internal_api was never wired."""
-    if isinstance(exc, ValueError) and str(exc) == INTERNAL_API_CLIENT_NOT_CONFIGURED:
-        pytest.fail(
-            f"{context}: PortalService internal_api client was not wired "
-            "(PortalService must receive an internal_api_client at construction).",
-            pytrace=False,
-        )
-    if isinstance(exc, ValueError):
-        pytest.skip(f"{context} (internal_api): {exc}")
+    """Skip live internal_api flakes (the client is always wired at construction)."""
     pytest.skip(f"{context} (internal_api): {exc}")
 
 

--- a/packages/sdk/tests/services/pipefy/test_portal_service_integration.py
+++ b/packages/sdk/tests/services/pipefy/test_portal_service_integration.py
@@ -32,12 +32,6 @@ from pipefy_sdk.exceptions import PortalPermissionError
 from pipefy_sdk.services.internal_api_client import InternalApiClient
 from pipefy_sdk.services.portal_service import PortalService
 
-
-def _skip_or_fail_internal_api_error(exc: BaseException, *, context: str) -> None:
-    """Skip live internal_api flakes (the client is always wired at construction)."""
-    pytest.skip(f"{context} (internal_api): {exc}")
-
-
 _PORTAL_ORG_SKIP = (
     "Set PIPEFY_PORTAL_ORG_UUID to an org where the token has manage_portals."
 )
@@ -49,11 +43,7 @@ def live_portal_service() -> PortalService:
     require_live_creds()
     settings = live_pipefy_settings()
     auth = live_resolved_auth()
-    internal = InternalApiClient(
-        url=settings.internal_api_url,
-        auth=auth,
-        allow_insecure_urls=settings.allow_insecure_urls,
-    )
+    internal = InternalApiClient(settings, auth=auth)
     return PortalService(
         settings=settings,
         auth=auth,
@@ -347,11 +337,6 @@ async def test_live_publish_sub_portal_cycle(
             pytest.skip(
                 f"publish_sub_portal failed on org {org_uuid} (internal_api): {exc}"
             )
-        except ValueError as exc:
-            _skip_or_fail_internal_api_error(
-                exc,
-                context=f"publish_sub_portal failed on org {org_uuid}",
-            )
 
         after_publish = await live_portal_service.get_portal(portal_uuid)
         published_after_attach = _sub_portal_published(after_publish, sub_portal_uuid)
@@ -366,11 +351,6 @@ async def test_live_publish_sub_portal_cycle(
         except TransportQueryError as exc:
             pytest.skip(
                 f"unpublish_sub_portal failed on org {org_uuid} (internal_api): {exc}"
-            )
-        except ValueError as exc:
-            _skip_or_fail_internal_api_error(
-                exc,
-                context=f"unpublish_sub_portal failed on org {org_uuid}",
             )
 
         after_unpublish = await live_portal_service.get_portal(portal_uuid)

--- a/packages/sdk/tests/services/pipefy/test_relation_service.py
+++ b/packages/sdk/tests/services/pipefy/test_relation_service.py
@@ -1,6 +1,6 @@
 """Unit tests for RelationService (relation reads)."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from gql.transport.exceptions import TransportQueryError
@@ -12,9 +12,14 @@ from pipefy_sdk.queries.relation_queries import (
     DELETE_PIPE_RELATION_MUTATION,
     GET_PIPE_RELATIONS_QUERY,
     GET_TABLE_RELATIONS_QUERY,
+    INTERNAL_DELETE_CARD_RELATION_MUTATION,
     UPDATE_PIPE_RELATION_MUTATION,
 )
-from pipefy_sdk.services.relation_service import RelationService
+from pipefy_sdk.services.internal_api_client import InternalApiClient
+from pipefy_sdk.services.relation_service import (
+    INTERNAL_API_CLIENT_NOT_CONFIGURED,
+    RelationService,
+)
 from pipefy_sdk.settings import PipefySettings
 
 _TEST_AUTH = StaticBearerAuth("test-bearer-token")
@@ -232,3 +237,33 @@ async def test_create_card_relation_transport_error(mock_settings):
     )
     with pytest.raises(TransportQueryError):
         await service.create_card_relation(1, 2, 3)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_delete_card_relation_routes_through_internal_api_client(mock_settings):
+    """delete_card_relation uses the injected InternalApiClient, not the public
+    execute_query, because the mutation only exists on the internal schema."""
+    internal = MagicMock(spec=InternalApiClient)
+    internal.execute_query = AsyncMock(
+        return_value={"deleteCardRelation": {"success": True}}
+    )
+    service = RelationService(
+        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=internal
+    )
+
+    result = await service.delete_card_relation("c1", "p2", "src-3")
+
+    internal.execute_query.assert_awaited_once_with(
+        INTERNAL_DELETE_CARD_RELATION_MUTATION,
+        {"childId": "c1", "parentId": "p2", "sourceId": "src-3"},
+    )
+    assert result == {"deleteCardRelation": {"success": True}}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_delete_card_relation_without_internal_client_raises(mock_settings):
+    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
+    with pytest.raises(ValueError, match=INTERNAL_API_CLIENT_NOT_CONFIGURED):
+        await service.delete_card_relation(1, 2, 3)

--- a/packages/sdk/tests/services/pipefy/test_relation_service.py
+++ b/packages/sdk/tests/services/pipefy/test_relation_service.py
@@ -16,13 +16,13 @@ from pipefy_sdk.queries.relation_queries import (
     UPDATE_PIPE_RELATION_MUTATION,
 )
 from pipefy_sdk.services.internal_api_client import InternalApiClient
-from pipefy_sdk.services.relation_service import (
-    INTERNAL_API_CLIENT_NOT_CONFIGURED,
-    RelationService,
-)
+from pipefy_sdk.services.relation_service import RelationService
 from pipefy_sdk.settings import PipefySettings
 
 _TEST_AUTH = StaticBearerAuth("test-bearer-token")
+# Public-relation tests fake execute_query and never touch the internal client;
+# the constructor requires one, so hand them a stand-in.
+_INTERNAL_API = MagicMock(spec=InternalApiClient)
 
 
 @pytest.fixture
@@ -33,7 +33,9 @@ def mock_settings():
 
 
 def _make_service(mock_settings, return_value: dict):
-    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
+    service = RelationService(
+        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
+    )
     service.execute_query = AsyncMock(return_value=return_value)
     return service
 
@@ -61,7 +63,9 @@ async def test_get_pipe_relations_sends_pipe_id(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_pipe_relations_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
+    service = RelationService(
+        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
+    )
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
     )
@@ -85,7 +89,9 @@ async def test_get_table_relations_sends_ids_list(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_table_relations_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
+    service = RelationService(
+        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
+    )
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "missing"}])
     )
@@ -129,7 +135,9 @@ async def test_create_pipe_relation_merges_attrs(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_pipe_relation_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
+    service = RelationService(
+        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
+    )
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "bad"}])
     )
@@ -168,7 +176,9 @@ async def test_update_pipe_relation_merges_attrs(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_update_pipe_relation_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
+    service = RelationService(
+        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
+    )
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "nope"}])
     )
@@ -192,7 +202,9 @@ async def test_delete_pipe_relation_sends_id(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_delete_pipe_relation_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
+    service = RelationService(
+        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
+    )
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "gone"}])
     )
@@ -231,7 +243,9 @@ async def test_create_card_relation_allows_source_type_override(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_card_relation_transport_error(mock_settings):
-    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
+    service = RelationService(
+        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
+    )
     service.execute_query = AsyncMock(
         side_effect=TransportQueryError("failed", errors=[{"message": "nope"}])
     )
@@ -259,11 +273,3 @@ async def test_delete_card_relation_routes_through_internal_api_client(mock_sett
         {"childId": "c1", "parentId": "p2", "sourceId": "src-3"},
     )
     assert result == {"deleteCardRelation": {"success": True}}
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_delete_card_relation_without_internal_client_raises(mock_settings):
-    service = RelationService(settings=mock_settings, auth=_TEST_AUTH)
-    with pytest.raises(ValueError, match=INTERNAL_API_CLIENT_NOT_CONFIGURED):
-        await service.delete_card_relation(1, 2, 3)

--- a/packages/sdk/tests/services/pipefy/test_relation_service.py
+++ b/packages/sdk/tests/services/pipefy/test_relation_service.py
@@ -1,8 +1,9 @@
 """Unit tests for RelationService (relation reads)."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
+from _shared.mock_clients import mock_internal_api_client
 from gql.transport.exceptions import TransportQueryError
 from pipefy_auth import StaticBearerAuth
 
@@ -15,14 +16,10 @@ from pipefy_sdk.queries.relation_queries import (
     INTERNAL_DELETE_CARD_RELATION_MUTATION,
     UPDATE_PIPE_RELATION_MUTATION,
 )
-from pipefy_sdk.services.internal_api_client import InternalApiClient
 from pipefy_sdk.services.relation_service import RelationService
 from pipefy_sdk.settings import PipefySettings
 
 _TEST_AUTH = StaticBearerAuth("test-bearer-token")
-# Public-relation tests fake execute_query and never touch the internal client;
-# the constructor requires one, so hand them a stand-in.
-_INTERNAL_API = MagicMock(spec=InternalApiClient)
 
 
 @pytest.fixture
@@ -32,11 +29,20 @@ def mock_settings():
     )
 
 
-def _make_service(mock_settings, return_value: dict):
+def _make_service(mock_settings, return_value: dict | None = None, *, side_effect=None):
+    """Build a RelationService whose public execute_query is faked.
+
+    These tests never touch the internal client, so it gets a stand-in; the
+    constructor requires one. Pass ``side_effect`` for the error-path tests.
+    """
     service = RelationService(
-        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
+        settings=mock_settings,
+        auth=_TEST_AUTH,
+        internal_api_client=mock_internal_api_client(),
     )
-    service.execute_query = AsyncMock(return_value=return_value)
+    service.execute_query = AsyncMock(
+        return_value=return_value, side_effect=side_effect
+    )
     return service
 
 
@@ -63,11 +69,9 @@ async def test_get_pipe_relations_sends_pipe_id(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_pipe_relations_transport_error(mock_settings):
-    service = RelationService(
-        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
-    )
-    service.execute_query = AsyncMock(
-        side_effect=TransportQueryError("failed", errors=[{"message": "denied"}])
+    service = _make_service(
+        mock_settings,
+        side_effect=TransportQueryError("failed", errors=[{"message": "denied"}]),
     )
     with pytest.raises(TransportQueryError):
         await service.get_pipe_relations(1)
@@ -89,11 +93,9 @@ async def test_get_table_relations_sends_ids_list(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_table_relations_transport_error(mock_settings):
-    service = RelationService(
-        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
-    )
-    service.execute_query = AsyncMock(
-        side_effect=TransportQueryError("failed", errors=[{"message": "missing"}])
+    service = _make_service(
+        mock_settings,
+        side_effect=TransportQueryError("failed", errors=[{"message": "missing"}]),
     )
     with pytest.raises(TransportQueryError):
         await service.get_table_relations([99])
@@ -135,11 +137,9 @@ async def test_create_pipe_relation_merges_attrs(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_pipe_relation_transport_error(mock_settings):
-    service = RelationService(
-        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
-    )
-    service.execute_query = AsyncMock(
-        side_effect=TransportQueryError("failed", errors=[{"message": "bad"}])
+    service = _make_service(
+        mock_settings,
+        side_effect=TransportQueryError("failed", errors=[{"message": "bad"}]),
     )
     with pytest.raises(TransportQueryError):
         await service.create_pipe_relation(1, 2, "x")
@@ -176,11 +176,9 @@ async def test_update_pipe_relation_merges_attrs(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_update_pipe_relation_transport_error(mock_settings):
-    service = RelationService(
-        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
-    )
-    service.execute_query = AsyncMock(
-        side_effect=TransportQueryError("failed", errors=[{"message": "nope"}])
+    service = _make_service(
+        mock_settings,
+        side_effect=TransportQueryError("failed", errors=[{"message": "nope"}]),
     )
     with pytest.raises(TransportQueryError):
         await service.update_pipe_relation(5, "X")
@@ -202,11 +200,9 @@ async def test_delete_pipe_relation_sends_id(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_delete_pipe_relation_transport_error(mock_settings):
-    service = RelationService(
-        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
-    )
-    service.execute_query = AsyncMock(
-        side_effect=TransportQueryError("failed", errors=[{"message": "gone"}])
+    service = _make_service(
+        mock_settings,
+        side_effect=TransportQueryError("failed", errors=[{"message": "gone"}]),
     )
     with pytest.raises(TransportQueryError):
         await service.delete_pipe_relation(1)
@@ -243,11 +239,9 @@ async def test_create_card_relation_allows_source_type_override(mock_settings):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_card_relation_transport_error(mock_settings):
-    service = RelationService(
-        settings=mock_settings, auth=_TEST_AUTH, internal_api_client=_INTERNAL_API
-    )
-    service.execute_query = AsyncMock(
-        side_effect=TransportQueryError("failed", errors=[{"message": "nope"}])
+    service = _make_service(
+        mock_settings,
+        side_effect=TransportQueryError("failed", errors=[{"message": "nope"}]),
     )
     with pytest.raises(TransportQueryError):
         await service.create_card_relation(1, 2, 3)
@@ -258,10 +252,7 @@ async def test_create_card_relation_transport_error(mock_settings):
 async def test_delete_card_relation_routes_through_internal_api_client(mock_settings):
     """delete_card_relation uses the injected InternalApiClient, not the public
     execute_query, because the mutation only exists on the internal schema."""
-    internal = MagicMock(spec=InternalApiClient)
-    internal.execute_query = AsyncMock(
-        return_value={"deleteCardRelation": {"success": True}}
-    )
+    internal = mock_internal_api_client({"deleteCardRelation": {"success": True}})
     service = RelationService(
         settings=mock_settings, auth=_TEST_AUTH, internal_api_client=internal
     )

--- a/packages/sdk/tests/services/test_card_service.py
+++ b/packages/sdk/tests/services/test_card_service.py
@@ -561,6 +561,6 @@ async def test_get_card_relations_uses_query_and_cardId_variable(mock_settings):
     assert variables == {"cardId": "999"}
     assert result == expected
 
-    # delete_card_relation is routed through InternalApiClient (not CardService)
-    # because the mutation is only available on the internal GraphQL schema.
-    # See tests/services/test_pipefy_facade.py for the facade delegation test.
+    # delete_card_relation lives on RelationService (not CardService) and routes
+    # through InternalApiClient because the mutation is only available on the
+    # internal GraphQL schema. See tests/services/pipefy/test_relation_service.py.

--- a/packages/sdk/tests/services/test_card_service.py
+++ b/packages/sdk/tests/services/test_card_service.py
@@ -560,7 +560,3 @@ async def test_get_card_relations_uses_query_and_cardId_variable(mock_settings):
     assert query_used is GET_CARD_RELATIONS_QUERY
     assert variables == {"cardId": "999"}
     assert result == expected
-
-    # delete_card_relation lives on RelationService (not CardService) and routes
-    # through InternalApiClient because the mutation is only available on the
-    # internal GraphQL schema. See tests/services/pipefy/test_relation_service.py.

--- a/packages/sdk/tests/services/test_internal_api_client.py
+++ b/packages/sdk/tests/services/test_internal_api_client.py
@@ -20,15 +20,10 @@ from pipefy_sdk.settings import PipefySettings
 DEFAULT_INTERNAL_API_URL = "https://app.pipefy.com/internal_api"
 
 
-def _build_client(
-    url: str = DEFAULT_INTERNAL_API_URL,
-    *,
-    allow_insecure_urls: bool = False,
-) -> InternalApiClient:
+def _build_client() -> InternalApiClient:
     return InternalApiClient(
-        url=url,
+        PipefySettings(),
         auth=StaticBearerAuth("test-bearer-token"),
-        allow_insecure_urls=allow_insecure_urls,
     )
 
 
@@ -218,32 +213,3 @@ async def test_execute_query_raises_on_timeout(respx_mock):
 
     with pytest.raises(TransportConnectionFailed, match="timed out"):
         await _build_client().execute_query(gql("query { x }"), {})
-
-
-@pytest.mark.unit
-def test_internal_api_client_rejects_http_url():
-    with pytest.raises(ValueError, match="HTTPS"):
-        _build_client(url="http://app.pipefy.com/internal_api")
-
-
-@pytest.mark.unit
-def test_internal_api_client_rejects_empty_hostname():
-    with pytest.raises(ValueError, match="hostname"):
-        _build_client(url="https://")
-
-
-@pytest.mark.unit
-def test_internal_api_client_rejects_localhost():
-    with pytest.raises(ValueError, match="localhost"):
-        _build_client(url="https://localhost/internal_api")
-
-
-@pytest.mark.unit
-def test_internal_api_client_rejects_private_literal_ip():
-    with pytest.raises(ValueError, match="private|loopback|link-local"):
-        _build_client(url="https://10.0.0.1/internal_api")
-
-
-@pytest.mark.unit
-def test_internal_api_client_allow_insecure_accepts_http():
-    _build_client(url="http://127.0.0.1/internal_api", allow_insecure_urls=True)

--- a/packages/sdk/tests/services/test_pipefy_facade.py
+++ b/packages/sdk/tests/services/test_pipefy_facade.py
@@ -33,6 +33,9 @@ def test_pipefy_client_forwards_caller_provided_auth(mock_settings):
     client = PipefyClient(mock_settings, auth=auth)
     assert client._card_service._auth is auth
     assert client._pipe_service._auth is auth
+    # The internal API client is built in __init__ from the same auth, so GraphQL
+    # auth and the internal API client cannot drift.
+    assert client._internal_api_client._auth is auth
 
 
 @pytest.mark.unit
@@ -743,14 +746,11 @@ async def test_delete_card_relation_delegates_to_internal_api_client(mock_settin
     from pipefy_sdk.queries.card_queries import (
         INTERNAL_DELETE_CARD_RELATION_MUTATION,
     )
-    from pipefy_sdk.services.internal_api_client import InternalApiClient
 
     client = PipefyClient(settings=mock_settings, auth=StaticBearerAuth("t"))
-    internal = MagicMock(spec=InternalApiClient)
-    internal.execute_query = AsyncMock(
+    client._internal_api_client.execute_query = AsyncMock(
         return_value={"deleteCardRelation": {"success": True}}
     )
-    client.set_internal_api_client(internal)
 
     # Pin the snake_case input keys that the internal API expects
     rendered = print_ast(INTERNAL_DELETE_CARD_RELATION_MUTATION.document)
@@ -760,7 +760,7 @@ async def test_delete_card_relation_delegates_to_internal_api_client(mock_settin
 
     result = await client.delete_card_relation("c1", "p2", "src-3")
 
-    internal.execute_query.assert_awaited_once_with(
+    client._internal_api_client.execute_query.assert_awaited_once_with(
         INTERNAL_DELETE_CARD_RELATION_MUTATION,
         {"childId": "c1", "parentId": "p2", "sourceId": "src-3"},
     )
@@ -769,20 +769,17 @@ async def test_delete_card_relation_delegates_to_internal_api_client(mock_settin
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_set_internal_api_client_forwards_to_portal_service(mock_settings):
-    """Sub-portal mutations on PortalService use the same internal_api client as the facade."""
-    from pipefy_sdk.services.internal_api_client import InternalApiClient
-
+async def test_sub_portal_mutation_routes_through_internal_api_client(mock_settings):
+    """A sub-portal mutation reaches the internal_api client the facade builds at
+    construction; PortalService and the facade share that one instance."""
     client = PipefyClient(settings=mock_settings, auth=StaticBearerAuth("t"))
-    internal = MagicMock(spec=InternalApiClient)
-    internal.execute_query = AsyncMock(
+    client._internal_api_client.execute_query = AsyncMock(
         return_value={"updateSubPortalElement": {"success": True}}
     )
-    client.set_internal_api_client(internal)
 
     result = await client.publish_sub_portal("portal-1", "element-2", "sub-3")
 
-    internal.execute_query.assert_awaited()
+    client._internal_api_client.execute_query.assert_awaited()
     assert result == {"updateSubPortalElement": {"success": True}}
 
 

--- a/packages/sdk/tests/services/test_pipefy_facade.py
+++ b/packages/sdk/tests/services/test_pipefy_facade.py
@@ -739,11 +739,11 @@ async def test_pipefy_client_ai_agent_write_methods_delegate_to_ai_agent_service
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_delete_card_relation_delegates_to_internal_api_client(mock_settings):
-    """delete_card_relation uses InternalApiClient (not CardService) because the
-    mutation is only on the internal GraphQL schema."""
+    """delete_card_relation delegates to RelationService, which routes through the
+    InternalApiClient because the mutation is only on the internal GraphQL schema."""
     from graphql import print_ast
 
-    from pipefy_sdk.queries.card_queries import (
+    from pipefy_sdk.queries.relation_queries import (
         INTERNAL_DELETE_CARD_RELATION_MUTATION,
     )
 

--- a/packages/sdk/tests/test_settings.py
+++ b/packages/sdk/tests/test_settings.py
@@ -99,6 +99,25 @@ def test_pipefy_settings_rejects_http_base_url():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("unsafe_base_url", "expected"),
+    [
+        ("https://localhost", "localhost"),
+        ("https://10.0.0.1", "private|loopback|link-local"),
+    ],
+)
+def test_pipefy_settings_rejects_internal_hosts(unsafe_base_url: str, expected: str):
+    """SSRF guard: HTTPS URLs aimed at internal hosts are rejected at construction.
+
+    The derived ``graphql_url`` / ``internal_api_url`` / ``interfaces_graphql_url``
+    inherit this host, so validating ``base_url`` once is the single gate; the
+    endpoint clients trust it rather than re-checking.
+    """
+    with pytest.raises(ValueError, match=expected):
+        PipefySettings(base_url=unsafe_base_url)
+
+
+@pytest.mark.unit
 def test_pipefy_settings_accepts_http_base_url_when_insecure():
     """`allow_insecure_urls=True` opens the door to http:// + localhost."""
     settings = PipefySettings(


### PR DESCRIPTION
## What

Consolidate how the SDK's internal API client is built and owned. The facade now constructs it like every other endpoint client, the services that use it receive it at construction as a required dependency, and the one facade method that did internal-API I/O directly is now pure delegation.

Pipefy has three GraphQL endpoints, each a `BasePipefyClient` differing only by URL (public, Interfaces, internal). The facade built the public and Interfaces clients in place from the shared `(settings, auth)` but threaded the internal one in via `set_internal_api_client`, so every caller (the MCP container, the CLI) repeated the same wiring and tests reached for a setter that existed only for them. `delete_card_relation` was the lone facade method that wasn't pure delegation, because the card/relation services had nowhere to host an internal-API call.

## Changes

- **Construct in `__init__`**: `PipefyClient.__init__` builds the single shared `InternalApiClient` from `(settings, auth)` and injects it into the services that need it. Removed `set_internal_api_client` from `PipefyClient` and `PortalService`. MCP `core/container.py` and CLI `cli/auth.py` collapse to a single `PipefyClient(settings, auth=...)` call.
- **Move `delete_card_relation` onto `RelationService`**: it now lives next to its sibling `create_card_relation`, and `INTERNAL_DELETE_CARD_RELATION_MUTATION` moves from `queries/card_queries.py` to `queries/relation_queries.py`. The facade method becomes one-line delegation, so the facade holds no I/O of its own.
- **Require the internal client**: with the facade always injecting it, the `InternalApiClient | None` parameters and their None guards on `RelationService` and `PortalService` were unreachable in production. The parameter is now non-optional on both, and the dead guards plus the orphaned `INTERNAL_API_CLIENT_NOT_CONFIGURED` constant are gone.
- **Remove `internal_api_available`**: it was already always `True` in production (the internal client was wired unconditionally regardless of auth tier), so its guards in the CLI `relation card delete` command and the MCP `delete_card_relation` tool were reachable only from tests. Removed the property and both guards.
- **Tests**: migrated to the seam the other endpoint clients already use (construct the client, then replace `execute_query` on it), instead of `@patch` and the setter. Added a `RelationService`-level test for `delete_card_relation`; dropped the tests that exercised the now-removed guards.

## Verification

- SDK 958 passed / 17 skipped; MCP 1383 passed / 16 skipped; CLI 320 passed / 13 skipped.
- `rg "internal_api_available|set_internal_api_client|INTERNAL_API_CLIENT_NOT_CONFIGURED"` returns nothing.
- Behavior-preserving: the internal client was always wired before, so neither the removed `internal_api_available` guard nor the removed None guards ever fired in production.

## Notes

- Rebased onto `dev` now that #327 (`feat/mcp-http-transport`) has merged; this PR targets `dev` directly.
- Clears the groundwork #333 (constructor-level DI via an injected `GraphQLExecutor`) was waiting on: every service now owns its operations and is handed the endpoint clients it needs, and the facade is pure delegation, which is the executor refactor's end state for the facade.
