### PR TITLE
feat(mcp): OAuth resource-server profile for the HTTP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **MCP**: opt-in OAuth 2.0 resource-server profile for the `--remote` HTTP transport. Setting `PIPEFY_MCP_RS_RESOURCE_SERVER_URL` activates it (no separate enable flag): the server validates an inbound `Authorization: Bearer` on every request (RS256 against the issuer's JWKS, issuer and expiry, optional audience), serves RFC 9728 protected-resource metadata, and returns `401` with a `WWW-Authenticate` challenge on a missing or invalid token. Token-validation knobs live in `pipefy_auth.JwtValidationSettings` (`PIPEFY_JWT_ISSUER_URL`, which defaults to the login issuer, plus `PIPEFY_JWT_AUDIENCE` / `PIPEFY_JWT_VERIFY_AUDIENCE` / `PIPEFY_JWT_JWKS_URI`); resource identity (`PIPEFY_MCP_RS_RESOURCE_SERVER_URL`, `PIPEFY_MCP_RS_REQUIRED_SCOPES`) stays in `pipefy_mcp.ResourceServerSettings`; `PIPEFY_ALLOW_INSECURE_URLS` covers both. The stdio profile is unchanged. Per-request on-behalf-of identity is not yet wired (#302), so even with a validated bearer every call runs as the single startup identity. Closes #301.
+
 ### Changed
 
 - **SDK**: services now receive GraphQL execution through their constructor instead of inheriting it. A narrow `GraphQLExecutor` protocol is the seam; `HttpxGraphQLExecutor` (formerly `BasePipefyClient`) is the only httpx/gql adapter, and `PipefyClient` builds one executor per endpoint via `build_executors` and injects them. Tests inject a fake executor rather than monkeypatching `execute_query`.

--- a/packages/auth/pyproject.toml
+++ b/packages/auth/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "keyring>=24",
     "keyrings.alt>=5",
     "pipefy-infra",
+    # RS256 validation of inbound bearers (resource-server role); [crypto] pulls cryptography.
+    "pyjwt[crypto]>=2.8",
     "pydantic>=2.13.4,<3",
     "pydantic-settings>=2.8.1",
 ]

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -44,7 +44,7 @@ from pipefy_auth.revoke import (
     RevocationUnsupportedError,
     revoke_session,
 )
-from pipefy_auth.settings import AuthSettings
+from pipefy_auth.settings import AuthSettings, JwtValidationSettings
 from pipefy_auth.storage import (
     SessionDeleteError,
     StoredSession,
@@ -59,6 +59,7 @@ from pipefy_auth.verification import JwtValidator, TokenValidationError
 
 __all__ = [
     "AuthSettings",
+    "JwtValidationSettings",
     "CallableBearerAuth",
     "DEFAULT_AUTH_CLIENT_ID",
     "DiscoveryPolicy",

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -55,12 +55,14 @@ from pipefy_auth.storage import (
     load_session,
     store_session,
 )
+from pipefy_auth.verification import JwtValidator, TokenValidationError
 
 __all__ = [
     "AuthSettings",
     "CallableBearerAuth",
     "DEFAULT_AUTH_CLIENT_ID",
     "DiscoveryPolicy",
+    "JwtValidator",
     "LoginError",
     "LoginResult",
     "OAuthErrorResponse",
@@ -78,6 +80,7 @@ __all__ = [
     "StaticBearerAuth",
     "StoredSession",
     "TokenResponse",
+    "TokenValidationError",
     "__version__",
     "configure_keychain_backend",
     "delete_session",

--- a/packages/auth/src/pipefy_auth/discovery.py
+++ b/packages/auth/src/pipefy_auth/discovery.py
@@ -18,15 +18,19 @@ _DEFAULT_TIMEOUT = 10.0
 class ProviderMetadata:
     """Subset of OIDC provider metadata the login flow needs.
 
-    ``end_session_endpoint`` is optional per OIDC Discovery 1.0 — not every IdP
+    ``end_session_endpoint`` is optional per OIDC Discovery 1.0: not every IdP
     advertises it. ``auth logout`` soft-fails when it's absent (warns + clears
-    the local session only).
+    the local session only). ``jwks_uri`` is the signing-key set the
+    resource-server bearer verifier reads; it's likewise modeled optional so
+    callers that don't validate inbound tokens (the login flow) don't depend on
+    it.
     """
 
     issuer: str
     authorization_endpoint: str
     token_endpoint: str
     end_session_endpoint: str | None = None
+    jwks_uri: str | None = None
 
 
 @dataclass(frozen=True)
@@ -110,6 +114,7 @@ def fetch_provider_metadata(
     authorization_endpoint = str(data["authorization_endpoint"])
     token_endpoint = str(data["token_endpoint"])
     end_session_endpoint = optional_str(data.get("end_session_endpoint"))
+    jwks_uri = optional_str(data.get("jwks_uri"))
 
     endpoints: list[tuple[str, str]] = [
         ("authorization_endpoint", authorization_endpoint),
@@ -117,6 +122,8 @@ def fetch_provider_metadata(
     ]
     if end_session_endpoint is not None:
         endpoints.append(("end_session_endpoint", end_session_endpoint))
+    if jwks_uri is not None:
+        endpoints.append(("jwks_uri", jwks_uri))
     for field, value in endpoints:
         try:
             security.validate_https_url(
@@ -130,6 +137,7 @@ def fetch_provider_metadata(
         authorization_endpoint=authorization_endpoint,
         token_endpoint=token_endpoint,
         end_session_endpoint=end_session_endpoint,
+        jwks_uri=jwks_uri,
     )
 
 

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -375,4 +375,124 @@ class AuthSettings(BaseSettings):
         return self
 
 
-__all__ = ["AuthSettings"]
+class JwtValidationSettings(BaseSettings):
+    """How this process validates an inbound bearer when it acts as a resource server.
+
+    :class:`AuthSettings` configures the *outbound* side: how this process
+    authenticates *to* Pipefy. This is the inbound counterpart that feeds
+    :class:`~pipefy_auth.JwtValidator`. It is a separate model, not fields on
+    :class:`AuthSettings`, because only a transport running the OAuth
+    resource-server profile (today, the MCP ``--remote`` HTTP transport) consumes
+    it: a CLI that only authenticates outbound never carries resource-server knobs.
+
+    ``issuer_url`` is an override. Left unset, the consumer falls back to the
+    issuer this process already logs into (the :class:`OidcClient` issuer): in a
+    single-realm deployment the IdP that signs caller tokens is the same one we
+    authenticate to, so it need not be configured twice. Set it only when inbound
+    and outbound issuers diverge (token exchange, multi-tenant federation).
+
+    ``env_prefix="PIPEFY_JWT_"`` keeps these distinct from ``AuthSettings``'
+    ``PIPEFY_*`` vars; ``allow_insecure_urls`` is the one exception, aliased to the
+    shared ``PIPEFY_ALLOW_INSECURE_URLS`` so the whole auth domain has a single
+    insecure-URL posture rather than a per-model toggle.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="PIPEFY_JWT_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        # Precedence: init_kwargs > env > dotenv > config.toml > file_secret.
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            PipefyTomlConfigSource(settings_cls),
+            file_secret_settings,
+        )
+
+    issuer_url: str | None = Field(
+        default=None,
+        description=(
+            "Override for the inbound OIDC issuer that signs caller tokens "
+            "(env: PIPEFY_JWT_ISSUER_URL). Left unset, the consumer falls back "
+            "to the issuer this process logs into; set it only when inbound and "
+            "outbound issuers diverge. The JWKS endpoint is resolved from the "
+            "issuer's discovery document unless jwks_uri is given."
+        ),
+    )
+
+    audience: str | None = Field(
+        default=None,
+        description=(
+            "Expected token audience (env: PIPEFY_JWT_AUDIENCE). Required when "
+            "verify_audience is true."
+        ),
+    )
+
+    verify_audience: bool = Field(
+        default=False,
+        description=(
+            "When true (env: PIPEFY_JWT_VERIFY_AUDIENCE), reject tokens whose "
+            "aud does not include audience. Defaults false for the same-audience "
+            "interim, which runs before the IdP issues an aud claim."
+        ),
+    )
+
+    jwks_uri: str | None = Field(
+        default=None,
+        description=(
+            "Explicit JWKS endpoint override (env: PIPEFY_JWT_JWKS_URI). When "
+            "unset, resolved from the issuer's discovery document."
+        ),
+    )
+
+    allow_insecure_urls: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("PIPEFY_ALLOW_INSECURE_URLS"),
+        description=(
+            "When true (env: PIPEFY_ALLOW_INSECURE_URLS, shared with the outbound "
+            "side), inbound-validation URLs may use http:// and internal hosts; "
+            "local development only."
+        ),
+    )
+
+    def resolve_issuer_url(self, default: str | None) -> str | None:
+        """The inbound issuer: the explicit override, else ``default`` (the login issuer)."""
+        return self.issuer_url or default
+
+    @model_validator(mode="after")
+    def _validate_configuration(self) -> Self:
+        # issuer_url may carry a realm path (Keycloak-style), so only a query or
+        # fragment that would corrupt the .well-known concatenation is forbidden.
+        # The stripped value is persisted: surrounding whitespace in an env var
+        # would otherwise survive into jwt.decode(issuer=...), which compares the
+        # iss claim exactly and would reject every token.
+        if self.verify_audience and not self.audience:
+            raise ValueError("verify_audience requires audience (PIPEFY_JWT_AUDIENCE).")
+        for label in ("issuer_url", "jwks_uri"):
+            value = getattr(self, label)
+            if value is None:
+                continue
+            stripped = value.strip()
+            setattr(self, label, stripped)
+            security.assert_url_has_no_query_or_fragment(stripped, field_label=label)
+            security.validate_https_url(
+                stripped, label, allow_insecure=self.allow_insecure_urls
+            )
+        return self
+
+
+__all__ = ["AuthSettings", "JwtValidationSettings"]

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -475,13 +475,13 @@ class JwtValidationSettings(BaseSettings):
 
     @model_validator(mode="after")
     def _validate_configuration(self) -> Self:
-        # issuer_url may carry a realm path (Keycloak-style), so only a query or
-        # fragment that would corrupt the .well-known concatenation is forbidden.
-        # The stripped value is persisted: surrounding whitespace in an env var
-        # would otherwise survive into jwt.decode(issuer=...), which compares the
-        # iss claim exactly and would reject every token.
         if self.verify_audience and not self.audience:
             raise ValueError("verify_audience requires audience (PIPEFY_JWT_AUDIENCE).")
+        # Strip and shape-check both URL fields. Env-var whitespace would otherwise
+        # survive into the consumer: issuer_url into jwt.decode(issuer=...), which
+        # compares iss exactly, and jwks_uri into the JWKS fetch. A realm path is
+        # allowed, so only a query or fragment (which would corrupt URL building)
+        # is rejected.
         for label in ("issuer_url", "jwks_uri"):
             value = getattr(self, label)
             if value is None:

--- a/packages/auth/src/pipefy_auth/verification.py
+++ b/packages/auth/src/pipefy_auth/verification.py
@@ -15,6 +15,7 @@ offload :meth:`JwtValidator.validate` to a thread.
 
 from __future__ import annotations
 
+import threading
 from typing import Any
 
 import jwt
@@ -38,9 +39,13 @@ class TokenValidationError(ValueError):
 class JwtValidator:
     """Validate an RS256 access token against an issuer's JWKS.
 
-    The JWKS URL is resolved once from the issuer's OIDC discovery document
-    (``jwks_uri``) unless an explicit ``jwks_uri`` override is supplied. The
-    underlying :class:`~jwt.PyJWKClient` caches signing keys across calls.
+    When an explicit ``jwks_uri`` override is supplied it is validated and the
+    :class:`~jwt.PyJWKClient` is built at construction (no network). Otherwise the
+    JWKS URL is resolved from the issuer's OIDC discovery document lazily, on the
+    first :meth:`validate`, so construction does no network I/O and process boot
+    never blocks on the IdP. A failed discovery is not cached, so the next
+    ``validate`` retries (the validator self-heals once the IdP is reachable). The
+    underlying ``PyJWKClient`` caches signing keys across calls.
 
     ``verify_audience`` is off by default: the same-audience interim runs before
     the IdP issues an ``aud`` claim. Turn it on once the audience mapper is in
@@ -59,18 +64,25 @@ class JwtValidator:
         self._issuer = issuer_url
         self._audience = audience
         self._verify_audience = verify_audience
+        self._allow_insecure_urls = allow_insecure_urls
+        # Guards the one-time lazy discovery in _jwks_client: validate() can run
+        # concurrently, and a cold burst should resolve jwks_uri once rather than
+        # each request firing its own discovery fetch at the IdP.
+        self._lock = threading.Lock()
         if jwks_uri is not None:
+            # Explicit override: validated and built eagerly (no network) so a
+            # misconfigured override fails at startup, not on the first request.
             resolved_jwks_uri = self._validate_jwks_uri(
                 jwks_uri, allow_insecure_urls=allow_insecure_urls
             )
-        else:
-            resolved_jwks_uri = self._discover_jwks_uri(
-                issuer_url, allow_insecure_urls=allow_insecure_urls
+            # cache_keys memoizes get_signing_key(kid), so the steady-state path is
+            # a dict lookup; without it every validate() rebuilds the JWK set and
+            # reconstructs each RSA public key (the network fetch is cached anyway).
+            self._jwks: PyJWKClient | None = PyJWKClient(
+                resolved_jwks_uri, cache_keys=True
             )
-        # cache_keys memoizes get_signing_key(kid), so the steady-state path is a
-        # dict lookup; without it every validate() rebuilds the JWK set and
-        # reconstructs each RSA public key (the network fetch is cached anyway).
-        self._jwks = PyJWKClient(resolved_jwks_uri, cache_keys=True)
+        else:
+            self._jwks = None
 
     @staticmethod
     def _validate_jwks_uri(jwks_uri: str, *, allow_insecure_urls: bool) -> str:
@@ -90,6 +102,24 @@ class JwtValidator:
             stripped, "jwks_uri", allow_insecure=allow_insecure_urls
         )
         return stripped
+
+    def _jwks_client(self) -> PyJWKClient:
+        """Return the JWKS client, resolving it via discovery on first use.
+
+        A discovery failure raises without assigning ``self._jwks``, so the next
+        call retries rather than caching the failure. The pre-lock read is the
+        fast path: once resolved, every call returns without taking the lock.
+        """
+        client = self._jwks
+        if client is not None:
+            return client
+        with self._lock:
+            if self._jwks is None:
+                resolved_jwks_uri = self._discover_jwks_uri(
+                    self._issuer, allow_insecure_urls=self._allow_insecure_urls
+                )
+                self._jwks = PyJWKClient(resolved_jwks_uri, cache_keys=True)
+            return self._jwks
 
     @staticmethod
     def _discover_jwks_uri(issuer_url: str, *, allow_insecure_urls: bool) -> str:
@@ -112,7 +142,7 @@ class JwtValidator:
         :class:`TokenValidationError` so the caller has a single type to catch.
         """
         try:
-            signing_key = self._jwks.get_signing_key_from_jwt(token)
+            signing_key = self._jwks_client().get_signing_key_from_jwt(token)
             return jwt.decode(
                 token,
                 signing_key.key,

--- a/packages/auth/src/pipefy_auth/verification.py
+++ b/packages/auth/src/pipefy_auth/verification.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import jwt
 from jwt import PyJWKClient
+from pipefy_infra import security
 
 from pipefy_auth.discovery import DiscoveryPolicy, fetch_provider_metadata
 
@@ -58,13 +59,37 @@ class JwtValidator:
         self._issuer = issuer_url
         self._audience = audience
         self._verify_audience = verify_audience
-        resolved_jwks_uri = jwks_uri or self._discover_jwks_uri(
-            issuer_url, allow_insecure_urls=allow_insecure_urls
-        )
+        if jwks_uri is not None:
+            resolved_jwks_uri = self._validate_jwks_uri(
+                jwks_uri, allow_insecure_urls=allow_insecure_urls
+            )
+        else:
+            resolved_jwks_uri = self._discover_jwks_uri(
+                issuer_url, allow_insecure_urls=allow_insecure_urls
+            )
         # cache_keys memoizes get_signing_key(kid), so the steady-state path is a
         # dict lookup; without it every validate() rebuilds the JWK set and
         # reconstructs each RSA public key (the network fetch is cached anyway).
         self._jwks = PyJWKClient(resolved_jwks_uri, cache_keys=True)
+
+    @staticmethod
+    def _validate_jwks_uri(jwks_uri: str, *, allow_insecure_urls: bool) -> str:
+        """Apply the https/SSRF gate to an explicit ``jwks_uri`` override.
+
+        The discovery path reaches the IdP through
+        :func:`fetch_provider_metadata`, which enforces this gate on the issuer
+        before trusting its advertised ``jwks_uri``. An explicit override skips
+        discovery, so the primitive enforces the same invariant here rather than
+        handing an unchecked key-fetch URL (``http://`` or an internal host) to
+        :class:`~jwt.PyJWKClient`. A realm path is allowed; only a query or
+        fragment is rejected.
+        """
+        stripped = jwks_uri.strip()
+        security.assert_url_has_no_query_or_fragment(stripped, field_label="jwks_uri")
+        security.validate_https_url(
+            stripped, "jwks_uri", allow_insecure=allow_insecure_urls
+        )
+        return stripped
 
     @staticmethod
     def _discover_jwks_uri(issuer_url: str, *, allow_insecure_urls: bool) -> str:

--- a/packages/auth/src/pipefy_auth/verification.py
+++ b/packages/auth/src/pipefy_auth/verification.py
@@ -66,11 +66,6 @@ class JwtValidator:
         # reconstructs each RSA public key (the network fetch is cached anyway).
         self._jwks = PyJWKClient(resolved_jwks_uri, cache_keys=True)
 
-    @property
-    def audience(self) -> str | None:
-        """The expected token audience (the RFC 8707 resource), checked only when verify_audience is set."""
-        return self._audience
-
     @staticmethod
     def _discover_jwks_uri(issuer_url: str, *, allow_insecure_urls: bool) -> str:
         metadata = fetch_provider_metadata(

--- a/packages/auth/src/pipefy_auth/verification.py
+++ b/packages/auth/src/pipefy_auth/verification.py
@@ -68,7 +68,7 @@ class JwtValidator:
 
     @property
     def audience(self) -> str | None:
-        """The audience the token is validated for (the RFC 8707 resource)."""
+        """The expected token audience (the RFC 8707 resource), checked only when verify_audience is set."""
         return self._audience
 
     @staticmethod

--- a/packages/auth/src/pipefy_auth/verification.py
+++ b/packages/auth/src/pipefy_auth/verification.py
@@ -1,0 +1,102 @@
+"""Inbound bearer validation: verify an RS256 access token against issuer JWKS.
+
+The outbound side of this package (``bearer.py``) attaches a bearer to requests
+this process makes. This is the inbound counterpart: when the process acts as an
+OAuth 2.0 resource server, it must validate the access token a caller presents
+before trusting it. :class:`JwtValidator` checks the token's signature against
+the issuer's JWKS and its issuer, expiry, and (optionally) audience, returning
+the decoded claims.
+
+The validator is transport-agnostic and returns raw claims; mapping those claims
+onto a consumer's identity type (e.g. an MCP ``AccessToken``) is the consumer's
+job. It is synchronous (PyJWT and ``PyJWKClient`` are); an async consumer should
+offload :meth:`JwtValidator.validate` to a thread.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jwt
+from jwt import PyJWKClient
+
+from pipefy_auth.discovery import DiscoveryPolicy, fetch_provider_metadata
+
+_ALGORITHMS = ["RS256"]
+
+
+class TokenValidationError(ValueError):
+    """An inbound bearer failed validation (bad signature, issuer, expiry, aud).
+
+    Subclasses :class:`ValueError` so a consumer that rejects on validation
+    failure can catch the broad type without importing PyJWT's exception
+    hierarchy. The underlying cause is chained for diagnostics.
+    """
+
+
+class JwtValidator:
+    """Validate an RS256 access token against an issuer's JWKS.
+
+    The JWKS URL is resolved once from the issuer's OIDC discovery document
+    (``jwks_uri``) unless an explicit ``jwks_uri`` override is supplied. The
+    underlying :class:`~jwt.PyJWKClient` caches signing keys across calls.
+
+    ``verify_audience`` is off by default: the same-audience interim runs before
+    the IdP issues an ``aud`` claim. Turn it on once the audience mapper is in
+    place; ``audience`` is then required by the caller.
+    """
+
+    def __init__(
+        self,
+        *,
+        issuer_url: str,
+        audience: str | None,
+        verify_audience: bool,
+        allow_insecure_urls: bool = False,
+        jwks_uri: str | None = None,
+    ) -> None:
+        self._issuer = issuer_url
+        self._audience = audience
+        self._verify_audience = verify_audience
+        resolved_jwks_uri = jwks_uri or self._discover_jwks_uri(
+            issuer_url, allow_insecure_urls=allow_insecure_urls
+        )
+        self._jwks = PyJWKClient(resolved_jwks_uri)
+
+    @property
+    def audience(self) -> str | None:
+        """The audience the token is validated for (the RFC 8707 resource)."""
+        return self._audience
+
+    @staticmethod
+    def _discover_jwks_uri(issuer_url: str, *, allow_insecure_urls: bool) -> str:
+        metadata = fetch_provider_metadata(
+            issuer_url,
+            policy=DiscoveryPolicy(allow_insecure_urls=allow_insecure_urls),
+        )
+        if metadata.jwks_uri is None:
+            raise ValueError(
+                f"OIDC discovery for {issuer_url!r} advertised no jwks_uri; supply "
+                f"the signing-key endpoint explicitly."
+            )
+        return metadata.jwks_uri
+
+    def validate(self, token: str) -> dict[str, Any]:
+        """Return the token's claims, or raise :class:`TokenValidationError`.
+
+        Every failure mode (bad signature, wrong issuer, expired, wrong
+        audience, or an unreachable JWKS) is folded into
+        :class:`TokenValidationError` so the caller has a single type to catch.
+        """
+        try:
+            signing_key = self._jwks.get_signing_key_from_jwt(token)
+            return jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=_ALGORITHMS,
+                issuer=self._issuer,
+                audience=self._audience if self._verify_audience else None,
+                options={"verify_aud": self._verify_audience},
+            )
+        except Exception as exc:
+            raise TokenValidationError(str(exc)) from exc

--- a/packages/auth/src/pipefy_auth/verification.py
+++ b/packages/auth/src/pipefy_auth/verification.py
@@ -61,7 +61,10 @@ class JwtValidator:
         resolved_jwks_uri = jwks_uri or self._discover_jwks_uri(
             issuer_url, allow_insecure_urls=allow_insecure_urls
         )
-        self._jwks = PyJWKClient(resolved_jwks_uri)
+        # cache_keys memoizes get_signing_key(kid), so the steady-state path is a
+        # dict lookup; without it every validate() rebuilds the JWK set and
+        # reconstructs each RSA public key (the network fetch is cached anyway).
+        self._jwks = PyJWKClient(resolved_jwks_uri, cache_keys=True)
 
     @property
     def audience(self) -> str | None:
@@ -96,7 +99,9 @@ class JwtValidator:
                 algorithms=_ALGORITHMS,
                 issuer=self._issuer,
                 audience=self._audience if self._verify_audience else None,
-                options={"verify_aud": self._verify_audience},
+                # require exp so a token that simply omits it is rejected rather
+                # than treated as never-expiring (PyJWT only checks exp when present).
+                options={"verify_aud": self._verify_audience, "require": ["exp"]},
             )
         except Exception as exc:
             raise TokenValidationError(str(exc)) from exc

--- a/packages/auth/tests/test_discovery.py
+++ b/packages/auth/tests/test_discovery.py
@@ -1,0 +1,63 @@
+"""Unit tests for ``pipefy_auth.discovery`` — OIDC ``.well-known`` parsing."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from pipefy_auth.discovery import DiscoveryPolicy, fetch_provider_metadata
+
+_ISSUER = "https://signin.example.com/realms/pipefy"
+
+
+def _discovery_payload(issuer: str = _ISSUER, **extra: str) -> dict[str, str]:
+    payload = {
+        "issuer": issuer,
+        "authorization_endpoint": f"{issuer}/protocol/openid-connect/auth",
+        "token_endpoint": f"{issuer}/protocol/openid-connect/token",
+    }
+    payload.update(extra)
+    return payload
+
+
+def _client(payload: dict[str, str]) -> httpx.Client:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/.well-known/openid-configuration")
+        return httpx.Response(200, json=payload)
+
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.unit
+def test_jwks_uri_is_parsed_when_advertised() -> None:
+    jwks = f"{_ISSUER}/protocol/openid-connect/certs"
+    with _client(_discovery_payload(jwks_uri=jwks)) as client:
+        metadata = fetch_provider_metadata(_ISSUER, client=client)
+    assert metadata.jwks_uri == jwks
+
+
+@pytest.mark.unit
+def test_jwks_uri_is_none_when_absent() -> None:
+    # The login flow does not read jwks_uri, so its absence must not break parsing.
+    with _client(_discovery_payload()) as client:
+        metadata = fetch_provider_metadata(_ISSUER, client=client)
+    assert metadata.jwks_uri is None
+
+
+@pytest.mark.unit
+def test_insecure_jwks_uri_is_rejected() -> None:
+    with _client(_discovery_payload(jwks_uri="http://internal/certs")) as client:
+        with pytest.raises(ValueError, match="jwks_uri"):
+            fetch_provider_metadata(_ISSUER, client=client)
+
+
+@pytest.mark.unit
+def test_insecure_jwks_uri_allowed_under_policy() -> None:
+    jwks = "http://127.0.0.1:8080/certs"
+    with _client(_discovery_payload(jwks_uri=jwks)) as client:
+        metadata = fetch_provider_metadata(
+            _ISSUER,
+            policy=DiscoveryPolicy(allow_insecure_urls=True),
+            client=client,
+        )
+    assert metadata.jwks_uri == jwks

--- a/packages/auth/tests/test_discovery.py
+++ b/packages/auth/tests/test_discovery.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``pipefy_auth.discovery`` — OIDC ``.well-known`` parsing."""
+"""Unit tests for ``pipefy_auth.discovery``: OIDC ``.well-known`` parsing."""
 
 from __future__ import annotations
 

--- a/packages/auth/tests/test_jwt_validation_settings.py
+++ b/packages/auth/tests/test_jwt_validation_settings.py
@@ -1,0 +1,90 @@
+"""Unit tests for ``pipefy_auth.JwtValidationSettings``: inbound-validation config."""
+
+from __future__ import annotations
+
+import pytest
+
+from pipefy_auth import JwtValidationSettings
+
+_ISSUER = "https://idp.example.com/realms/x"
+
+
+@pytest.fixture(autouse=True)
+def _clear_inbound_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate from the ambient environment so defaults are exercised."""
+    for key in (
+        "PIPEFY_JWT_ISSUER_URL",
+        "PIPEFY_JWT_AUDIENCE",
+        "PIPEFY_JWT_VERIFY_AUDIENCE",
+        "PIPEFY_JWT_JWKS_URI",
+        "PIPEFY_ALLOW_INSECURE_URLS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.mark.unit
+def test_defaults_are_inactive_and_safe():
+    """Unset is a valid, empty config: no issuer override, audience off."""
+    settings = JwtValidationSettings()
+    assert settings.issuer_url is None
+    assert settings.audience is None
+    assert settings.verify_audience is False
+    assert settings.jwks_uri is None
+    assert settings.allow_insecure_urls is False
+
+
+@pytest.mark.unit
+def test_resolve_issuer_url_prefers_override():
+    """An explicit issuer wins over the supplied login-issuer default."""
+    settings = JwtValidationSettings(issuer_url=_ISSUER, jwks_uri=None)
+    assert settings.resolve_issuer_url("https://login.example.com/realms/y") == _ISSUER
+
+
+@pytest.mark.unit
+def test_resolve_issuer_url_falls_back_to_default():
+    """With no override, the inbound issuer is the login issuer."""
+    settings = JwtValidationSettings()
+    assert settings.resolve_issuer_url(_ISSUER) == _ISSUER
+
+
+@pytest.mark.unit
+def test_resolve_issuer_url_is_none_when_neither_set():
+    """No override and no login issuer leaves the inbound issuer unresolved."""
+    assert JwtValidationSettings().resolve_issuer_url(None) is None
+
+
+@pytest.mark.unit
+def test_verify_audience_requires_audience():
+    """Turning on audience checks without an audience is a misconfiguration."""
+    with pytest.raises(ValueError, match="verify_audience requires audience"):
+        JwtValidationSettings(verify_audience=True)
+
+
+@pytest.mark.unit
+def test_issuer_url_is_stripped():
+    """Surrounding whitespace is stripped so it cannot survive into jwt.decode."""
+    settings = JwtValidationSettings(issuer_url=f"  {_ISSUER}  ")
+    assert settings.issuer_url == _ISSUER
+
+
+@pytest.mark.unit
+def test_issuer_url_rejects_query_or_fragment():
+    """A query/fragment would corrupt the .well-known concatenation."""
+    with pytest.raises(ValueError):
+        JwtValidationSettings(issuer_url=f"{_ISSUER}?foo=bar")
+
+
+@pytest.mark.unit
+def test_insecure_issuer_rejected_without_allow_flag():
+    """http:// issuers are rejected unless the shared insecure flag is set."""
+    with pytest.raises(ValueError):
+        JwtValidationSettings(issuer_url="http://idp.internal/realms/x")
+
+
+@pytest.mark.unit
+def test_insecure_issuer_allowed_with_shared_env_flag(monkeypatch: pytest.MonkeyPatch):
+    """allow_insecure_urls reads the shared PIPEFY_ALLOW_INSECURE_URLS var."""
+    monkeypatch.setenv("PIPEFY_ALLOW_INSECURE_URLS", "true")
+    settings = JwtValidationSettings(issuer_url="http://127.0.0.1:8080/realms/x")
+    assert settings.allow_insecure_urls is True
+    assert settings.issuer_url == "http://127.0.0.1:8080/realms/x"

--- a/packages/auth/tests/test_verification.py
+++ b/packages/auth/tests/test_verification.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``pipefy_auth.verification`` — inbound RS256 bearer validation."""
+"""Unit tests for ``pipefy_auth.verification``: inbound RS256 bearer validation."""
 
 from __future__ import annotations
 

--- a/packages/auth/tests/test_verification.py
+++ b/packages/auth/tests/test_verification.py
@@ -145,3 +145,52 @@ def test_discovery_without_jwks_uri_raises(monkeypatch: pytest.MonkeyPatch) -> N
     )
     with pytest.raises(ValueError, match="jwks_uri"):
         JwtValidator(issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False)
+
+
+@pytest.mark.unit
+def test_explicit_http_jwks_uri_is_rejected() -> None:
+    # An explicit jwks_uri skips discovery; the primitive still enforces the
+    # https/SSRF gate rather than handing an unchecked URL to PyJWKClient.
+    with pytest.raises(ValueError, match="jwks_uri"):
+        JwtValidator(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            verify_audience=False,
+            jwks_uri="http://idp.example.com/protocol/openid-connect/certs",
+        )
+
+
+@pytest.mark.unit
+def test_explicit_internal_host_jwks_uri_is_rejected() -> None:
+    with pytest.raises(ValueError, match="jwks_uri"):
+        JwtValidator(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            verify_audience=False,
+            jwks_uri="https://127.0.0.1/certs",
+        )
+
+
+@pytest.mark.unit
+def test_explicit_jwks_uri_with_query_is_rejected() -> None:
+    with pytest.raises(ValueError, match="jwks_uri"):
+        JwtValidator(
+            issuer_url=_ISSUER,
+            audience=_AUDIENCE,
+            verify_audience=False,
+            jwks_uri=f"{_JWKS_URI}?rotate=1",
+        )
+
+
+@pytest.mark.unit
+def test_explicit_insecure_jwks_uri_allowed_when_opted_in() -> None:
+    # allow_insecure_urls relaxes both the scheme and the internal-host gate,
+    # mirroring the discovery path's policy.
+    validator = JwtValidator(
+        issuer_url=_ISSUER,
+        audience=_AUDIENCE,
+        verify_audience=False,
+        allow_insecure_urls=True,
+        jwks_uri="http://127.0.0.1/certs",
+    )
+    assert validator._jwks.uri == "http://127.0.0.1/certs"

--- a/packages/auth/tests/test_verification.py
+++ b/packages/auth/tests/test_verification.py
@@ -1,0 +1,147 @@
+"""Unit tests for ``pipefy_auth.verification`` — inbound RS256 bearer validation."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from pipefy_auth.verification import JwtValidator, TokenValidationError
+
+_ISSUER = "https://idp.example.com/realms/pipefy"
+_AUDIENCE = "https://mcp.example.com/mcp"
+_JWKS_URI = "https://idp.example.com/protocol/openid-connect/certs"
+
+_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_OTHER_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _sign(claims: dict[str, Any], *, key: rsa.RSAPrivateKey = _PRIVATE_KEY) -> str:
+    return jwt.encode(claims, key, algorithm="RS256", headers={"kid": "test-key"})
+
+
+def _claims(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "iss": _ISSUER,
+        "sub": "user-123",
+        "azp": "client-abc",
+        "scope": "read write",
+        "exp": int(time.time()) + 3600,
+        "aud": _AUDIENCE,
+    }
+    base.update(overrides)
+    return base
+
+
+def _validator(monkeypatch: pytest.MonkeyPatch, **kwargs: Any) -> JwtValidator:
+    """Build a validator whose JWKS lookup returns the in-test public key.
+
+    The explicit ``jwks_uri`` skips discovery (no network at construction); the
+    monkeypatch returns the signing key without an HTTP fetch.
+    """
+    defaults = {
+        "issuer_url": _ISSUER,
+        "audience": _AUDIENCE,
+        "verify_audience": False,
+        "jwks_uri": _JWKS_URI,
+    }
+    defaults.update(kwargs)
+    validator = JwtValidator(**defaults)
+    monkeypatch.setattr(
+        validator._jwks,
+        "get_signing_key_from_jwt",
+        lambda token: SimpleNamespace(key=_PRIVATE_KEY.public_key()),
+    )
+    return validator
+
+
+@pytest.mark.unit
+def test_valid_token_returns_claims(monkeypatch: pytest.MonkeyPatch) -> None:
+    validator = _validator(monkeypatch)
+    claims = validator.validate(_sign(_claims()))
+    assert claims["sub"] == "user-123"
+    assert claims["azp"] == "client-abc"
+    assert claims["scope"] == "read write"
+
+
+@pytest.mark.unit
+def test_tampered_signature_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    validator = _validator(monkeypatch)
+    token = _sign(_claims())
+    header, payload, signature = token.split(".")
+    tampered = f"{header}.{payload}.{signature[:-4]}AAAA"
+    with pytest.raises(TokenValidationError):
+        validator.validate(tampered)
+
+
+@pytest.mark.unit
+def test_token_signed_by_unknown_key_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    validator = _validator(monkeypatch)
+    # Signed by a key whose public half is not what the JWKS returns.
+    with pytest.raises(TokenValidationError):
+        validator.validate(_sign(_claims(), key=_OTHER_KEY))
+
+
+@pytest.mark.unit
+def test_expired_token_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    validator = _validator(monkeypatch)
+    with pytest.raises(TokenValidationError):
+        validator.validate(_sign(_claims(exp=int(time.time()) - 3600)))
+
+
+@pytest.mark.unit
+def test_wrong_issuer_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    validator = _validator(monkeypatch)
+    with pytest.raises(TokenValidationError):
+        validator.validate(_sign(_claims(iss="https://evil.example.com/realms/x")))
+
+
+@pytest.mark.unit
+def test_wrong_audience_is_rejected_when_verifying(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    validator = _validator(monkeypatch, verify_audience=True)
+    with pytest.raises(TokenValidationError):
+        validator.validate(_sign(_claims(aud="https://other.example.com")))
+
+
+@pytest.mark.unit
+def test_wrong_audience_passes_when_not_verifying(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The toggle: the same wrong-aud token the previous test rejects is accepted
+    # when verify_audience is off (the same-audience interim).
+    validator = _validator(monkeypatch, verify_audience=False)
+    claims = validator.validate(_sign(_claims(aud="https://other.example.com")))
+    assert claims["aud"] == "https://other.example.com"
+
+
+@pytest.mark.unit
+def test_jwks_uri_resolved_from_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    # With no explicit jwks_uri, the validator reads it from the issuer's
+    # discovery document.
+    metadata = SimpleNamespace(jwks_uri=_JWKS_URI)
+    monkeypatch.setattr(
+        "pipefy_auth.verification.fetch_provider_metadata",
+        lambda issuer_url, policy: metadata,
+    )
+    validator = JwtValidator(
+        issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False
+    )
+    assert validator._jwks.uri == _JWKS_URI
+
+
+@pytest.mark.unit
+def test_discovery_without_jwks_uri_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "pipefy_auth.verification.fetch_provider_metadata",
+        lambda issuer_url, policy: SimpleNamespace(jwks_uri=None),
+    )
+    with pytest.raises(ValueError, match="jwks_uri"):
+        JwtValidator(issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False)

--- a/packages/auth/tests/test_verification.py
+++ b/packages/auth/tests/test_verification.py
@@ -125,7 +125,7 @@ def test_wrong_audience_passes_when_not_verifying(
 @pytest.mark.unit
 def test_jwks_uri_resolved_from_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
     # With no explicit jwks_uri, the validator reads it from the issuer's
-    # discovery document.
+    # discovery document, lazily on first use rather than at construction.
     metadata = SimpleNamespace(jwks_uri=_JWKS_URI)
     monkeypatch.setattr(
         "pipefy_auth.verification.fetch_provider_metadata",
@@ -134,17 +134,72 @@ def test_jwks_uri_resolved_from_discovery(monkeypatch: pytest.MonkeyPatch) -> No
     validator = JwtValidator(
         issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False
     )
-    assert validator._jwks.uri == _JWKS_URI
+    assert validator._jwks is None  # deferred, not resolved at construction
+    assert validator._jwks_client().uri == _JWKS_URI
+
+
+@pytest.mark.unit
+def test_discovery_path_does_no_network_at_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Construction must not touch the IdP, so process boot never blocks on it.
+    # A discovery that would raise leaves construction untouched; the failure
+    # only surfaces on validate().
+    def _fail(issuer_url: str, policy: Any) -> SimpleNamespace:
+        raise AssertionError("discovery must not run at construction")
+
+    monkeypatch.setattr("pipefy_auth.verification.fetch_provider_metadata", _fail)
+    validator = JwtValidator(
+        issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False
+    )
+    assert validator._jwks is None
 
 
 @pytest.mark.unit
 def test_discovery_without_jwks_uri_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The discovery failure now surfaces on validate() (lazy), folded into
+    # TokenValidationError, not at construction.
     monkeypatch.setattr(
         "pipefy_auth.verification.fetch_provider_metadata",
         lambda issuer_url, policy: SimpleNamespace(jwks_uri=None),
     )
-    with pytest.raises(ValueError, match="jwks_uri"):
-        JwtValidator(issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False)
+    validator = JwtValidator(
+        issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False
+    )
+    with pytest.raises(TokenValidationError, match="jwks_uri"):
+        validator.validate(_sign(_claims()))
+
+
+@pytest.mark.unit
+def test_discovery_failure_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A transient discovery failure must not be cached: the next validate()
+    # retries, so the validator self-heals once the IdP is reachable again.
+    calls = {"n": 0}
+
+    def _flaky(issuer_url: str, policy: Any) -> SimpleNamespace:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ValueError("transient discovery outage")
+        return SimpleNamespace(jwks_uri=_JWKS_URI)
+
+    monkeypatch.setattr("pipefy_auth.verification.fetch_provider_metadata", _flaky)
+    validator = JwtValidator(
+        issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False
+    )
+
+    with pytest.raises(TokenValidationError, match="transient discovery outage"):
+        validator.validate(_sign(_claims()))
+    assert validator._jwks is None  # failure not cached
+
+    # Second attempt: discovery succeeds and the resolved client is reused.
+    monkeypatch.setattr(
+        validator._jwks_client(),
+        "get_signing_key_from_jwt",
+        lambda token: SimpleNamespace(key=_PRIVATE_KEY.public_key()),
+    )
+    assert calls["n"] == 2
+    claims = validator.validate(_sign(_claims()))
+    assert claims["sub"] == "user-123"
 
 
 @pytest.mark.unit

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -34,26 +34,35 @@ Two ways to launch `pipefy-mcp-server`:
   `127.0.0.1:8000`), overridable with `--host` / `--port`.
 
 The HTTP transport (issue #300) optionally runs as an OAuth 2.0 resource server
-(issue #301): with the resource-server profile enabled it validates an inbound
+(issue #301): with the resource-server profile configured it validates an inbound
 bearer on every request. It does not yet carry per-request on-behalf-of identity
 (#302), so even with a validated bearer every call still runs as the single
 identity resolved at startup; treat `--remote` as local/validation until #302
 lands.
 
-**Resource-server profile.** Enabled with `PIPEFY_MCP_RS_ENABLED=1` and configured
-via the `PIPEFY_MCP_RS_*` env vars (`ResourceServerSettings`, settings namespace
-`settings.rs`): `ISSUER_URL` (inbound issuer that signs caller tokens),
-`RESOURCE_SERVER_URL` (this server's public canonical URL, e.g.
-`https://host/mcp`), and optional `AUDIENCE` / `VERIFY_AUDIENCE` (off by default,
-the same-audience interim), `REQUIRED_SCOPES`, `JWKS_URI`, `ALLOW_INSECURE_URLS`.
+**Resource-server profile.** Config is split by domain. *Token validation* is an
+auth concern and lives in `pipefy_auth.JwtValidationSettings` (`settings.jwt`,
+env `PIPEFY_JWT_*`): `ISSUER_URL` (an override; absent it, the inbound issuer
+defaults to the one this process logs into, the `OidcClient` issuer, since in a
+single-realm deployment they are the same IdP), optional `AUDIENCE` /
+`VERIFY_AUDIENCE` (off by default, the same-audience interim), and `JWKS_URI`.
+*Resource identity* is MCP-specific and stays in `pipefy_mcp.ResourceServerSettings`
+(`settings.rs`, env `PIPEFY_MCP_RS_*`): `RESOURCE_SERVER_URL` (this server's public
+canonical URL, e.g. `https://host/mcp`) and `REQUIRED_SCOPES`. The shared
+`PIPEFY_ALLOW_INSECURE_URLS` covers both. The profile activates when
+`RESOURCE_SERVER_URL` is set (the one value that cannot default); there is no
+separate enable flag, just `--remote` plus this URL. Set `RESOURCE_SERVER_URL`
+with the stored-session login disabled and no `ISSUER_URL` override and startup
+fails (no issuer to validate against).
+
 The JWKS/RS256 validation lives in `pipefy_auth` (`JwtValidator`); the MCP adapter
 `auth/resource_server.py` (`JwtTokenVerifier`) maps validated claims onto the
 SDK's `AccessToken`. FastMCP serves the RFC 9728 protected-resource metadata and
-the `401` + `WWW-Authenticate` challenge; `_build_resource_server_auth` wires the
-verifier and `AuthSettings` into the app.
+the `401` + `WWW-Authenticate` challenge; `_build_resource_server_auth` resolves
+the inbound issuer and wires the verifier and `AuthSettings` into the app.
 
 **Loopback bind.** `_assert_loopback_http_bind` allows a non-loopback bind only
-when the resource-server profile is enabled (every request then carries a
+when the resource-server profile is configured (every request then carries a
 validated bearer). Without it, the HTTP transport is unauthenticated, every call
 runs as the single startup identity, and a network-reachable port would hand that
 identity to anyone who can reach it, so the bind is restricted to loopback. The

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -61,7 +61,7 @@ SDK's `AccessToken`. FastMCP serves the RFC 9728 protected-resource metadata and
 the `401` + `WWW-Authenticate` challenge; `_build_resource_server_auth` resolves
 the inbound issuer and wires the verifier and `AuthSettings` into the app.
 
-**Loopback bind.** `_assert_loopback_http_bind` allows a non-loopback bind only
+**Loopback bind.** `_assert_safe_http_bind` allows a non-loopback bind only
 when the resource-server profile is configured (every request then carries a
 validated bearer). Without it, the HTTP transport is unauthenticated, every call
 runs as the single startup identity, and a network-reachable port would hand that

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -62,14 +62,17 @@ the `401` + `WWW-Authenticate` challenge; `build_resource_server_auth` (same
 module, the composition root) resolves the inbound issuer and pairs the verifier
 with `AuthSettings`, which `server.py` wires into the app.
 
-**Loopback bind.** `_assert_safe_http_bind` allows a non-loopback bind only
-when the resource-server profile is configured (every request then carries a
-validated bearer). Without it, the HTTP transport is unauthenticated, every call
-runs as the single startup identity, and a network-reachable port would hand that
-identity to anyone who can reach it, so the bind is restricted to loopback. The
-configurable host / Origin allowlist for a proxied deployment (DNS-rebinding
-protection) is #303; the attachment tools' local `file_path` inputs still assume a
-loopback peer that shares the client's disk (remote-safe file inputs are #305).
+**Loopback bind.** `_assert_safe_http_bind` restricts the HTTP transport to a
+loopback bind, unconditionally for now. Even with the resource-server profile
+validating an inbound bearer, there is no per-request on-behalf-of identity yet
+(#302), so every call runs as the single startup identity; a network-reachable
+port would hand that identity to anyone who can reach it. Off-loopback binding
+stays off until the hosted on-behalf-of profile lands (see
+`experiments/hosted-obo/RFC-OUTLINE.md`), which brings per-request identity and
+the configurable host / Origin allowlist for a proxied deployment (DNS-rebinding
+protection, #303). The attachment tools' local `file_path` inputs also still
+assume a loopback peer that shares the client's disk (remote-safe file inputs are
+#305).
 
 ## Tool registration
 

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -33,21 +33,33 @@ Two ways to launch `pipefy-mcp-server`:
   surface. Bind host/port come from `PIPEFY_MCP_HOST` / `PIPEFY_MCP_PORT` (defaults
   `127.0.0.1:8000`), overridable with `--host` / `--port`.
 
-The HTTP profile is foundation work behind the flag (issue #300). It does **not**
-yet validate inbound bearers (resource-server role, #301) or carry per-request
-on-behalf-of identity (#302); until those land it is unauthenticated and uses the
-single identity resolved at startup. Treat `--remote` as local/validation only, not
-a production hosted endpoint.
+The HTTP transport (issue #300) optionally runs as an OAuth 2.0 resource server
+(issue #301): with the resource-server profile enabled it validates an inbound
+bearer on every request. It does not yet carry per-request on-behalf-of identity
+(#302), so even with a validated bearer every call still runs as the single
+identity resolved at startup; treat `--remote` as local/validation until #302
+lands.
 
-**Loopback-only bind.** While the HTTP transport is unauthenticated, the HTTP path
-of `run_server` refuses any non-loopback bind (`_assert_loopback_http_bind`): every
-call would run as the single startup identity, so a network-reachable port would
-hand that identity to anyone who can reach it. This is independent of the tool
-profile, the remote-safe subset is no safer over an unauthenticated network bind.
-It also keeps the filesystem tools coherent: the attachment uploads read a local
-`file_path`, which only resolves when the server shares the client's disk, i.e. on
-loopback (remote-safe file inputs are tracked in #305). When inbound auth lands
-(#301), revisit allowing a network bind.
+**Resource-server profile.** Enabled with `PIPEFY_MCP_RS_ENABLED=1` and configured
+via the `PIPEFY_MCP_RS_*` env vars (`ResourceServerSettings`, settings namespace
+`settings.rs`): `ISSUER_URL` (inbound issuer that signs caller tokens),
+`RESOURCE_SERVER_URL` (this server's public canonical URL, e.g.
+`https://host/mcp`), and optional `AUDIENCE` / `VERIFY_AUDIENCE` (off by default,
+the same-audience interim), `REQUIRED_SCOPES`, `JWKS_URI`, `ALLOW_INSECURE_URLS`.
+The JWKS/RS256 validation lives in `pipefy_auth` (`JwtValidator`); the MCP adapter
+`auth/resource_server.py` (`JwtTokenVerifier`) maps validated claims onto the
+SDK's `AccessToken`. FastMCP serves the RFC 9728 protected-resource metadata and
+the `401` + `WWW-Authenticate` challenge; `_build_resource_server_auth` wires the
+verifier and `AuthSettings` into the app.
+
+**Loopback bind.** `_assert_loopback_http_bind` allows a non-loopback bind only
+when the resource-server profile is enabled (every request then carries a
+validated bearer). Without it, the HTTP transport is unauthenticated, every call
+runs as the single startup identity, and a network-reachable port would hand that
+identity to anyone who can reach it, so the bind is restricted to loopback. The
+configurable host / Origin allowlist for a proxied deployment (DNS-rebinding
+protection) is #303; the attachment tools' local `file_path` inputs still assume a
+loopback peer that shares the client's disk (remote-safe file inputs are #305).
 
 ## Tool registration
 

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -58,8 +58,9 @@ fails (no issuer to validate against).
 The JWKS/RS256 validation lives in `pipefy_auth` (`JwtValidator`); the MCP adapter
 `auth/resource_server.py` (`JwtTokenVerifier`) maps validated claims onto the
 SDK's `AccessToken`. FastMCP serves the RFC 9728 protected-resource metadata and
-the `401` + `WWW-Authenticate` challenge; `_build_resource_server_auth` resolves
-the inbound issuer and wires the verifier and `AuthSettings` into the app.
+the `401` + `WWW-Authenticate` challenge; `build_resource_server_auth` (same
+module, the composition root) resolves the inbound issuer and pairs the verifier
+with `AuthSettings`, which `server.py` wires into the app.
 
 **Loopback bind.** `_assert_safe_http_bind` allows a non-loopback bind only
 when the resource-server profile is configured (every request then carries a

--- a/packages/mcp/src/pipefy_mcp/auth/__init__.py
+++ b/packages/mcp/src/pipefy_mcp/auth/__init__.py
@@ -1,5 +1,9 @@
 """Resource-server auth for the HTTP transport: inbound bearer validation."""
 
-from pipefy_mcp.auth.resource_server import JwtTokenVerifier
+from pipefy_mcp.auth.resource_server import (
+    JwtTokenVerifier,
+    ResourceServerAuth,
+    build_resource_server_auth,
+)
 
-__all__ = ["JwtTokenVerifier"]
+__all__ = ["JwtTokenVerifier", "ResourceServerAuth", "build_resource_server_auth"]

--- a/packages/mcp/src/pipefy_mcp/auth/__init__.py
+++ b/packages/mcp/src/pipefy_mcp/auth/__init__.py
@@ -1,0 +1,5 @@
+"""Resource-server auth for the HTTP transport: inbound bearer validation."""
+
+from pipefy_mcp.auth.resource_server import JwtTokenVerifier
+
+__all__ = ["JwtTokenVerifier"]

--- a/packages/mcp/src/pipefy_mcp/auth/resource_server.py
+++ b/packages/mcp/src/pipefy_mcp/auth/resource_server.py
@@ -11,8 +11,6 @@ This is a thin adapter: the JWKS resolution and RS256 decoding live in
 ``pipefy_auth`` (:class:`~pipefy_auth.JwtValidator`, a transport-agnostic auth
 primitive). This class maps the validated claims onto the SDK's ``AccessToken``
 and turns a validation failure into the ``None`` the protocol reads as "reject".
-The validated token then lands in the MCP auth context for the per-request
-on-behalf-of work tracked separately.
 """
 
 from __future__ import annotations

--- a/packages/mcp/src/pipefy_mcp/auth/resource_server.py
+++ b/packages/mcp/src/pipefy_mcp/auth/resource_server.py
@@ -74,17 +74,28 @@ class JwtTokenVerifier(TokenVerifier):
             return None
 
     def _to_access_token(self, token: str, claims: dict[str, Any]) -> AccessToken:
+        # OAuth/OIDC precedence: azp (authorized party) over client_id over sub,
+        # so a token minted via exchange reports the acting client. A token
+        # carrying none of the three has no usable identity; reject it rather
+        # than stamp an anonymous "" client_id that AccessToken would accept.
+        client_id = claims.get("azp") or claims.get("client_id") or claims.get("sub")
+        if not client_id:
+            raise ValueError("token carries no azp, client_id, or sub claim")
+
+        # The validator requires exp, so a missing one cannot reach here through
+        # the real path; reject defensively rather than emit a never-expiring
+        # token (the bearer middleware reads a falsy expires_at as "no expiry")
+        # if that invariant ever changes.
         exp = claims.get("exp")
+        if exp is None:
+            raise ValueError("token has no exp claim")
+
         return AccessToken(
             token=token,
-            # OAuth/OIDC precedence: azp (authorized party) over client_id over
-            # sub, so a token minted via exchange reports the acting client.
-            client_id=(
-                claims.get("azp") or claims.get("client_id") or claims.get("sub", "")
-            ),
+            client_id=client_id,
             scopes=_parse_scopes(claims.get("scope")),
             # exp is an RFC 7519 NumericDate (may be fractional); AccessToken
-            # wants an int. The validator requires exp, so it is present here.
-            expires_at=int(exp) if exp is not None else None,
+            # wants an int.
+            expires_at=int(exp),
             resource=self._resource,
         )

--- a/packages/mcp/src/pipefy_mcp/auth/resource_server.py
+++ b/packages/mcp/src/pipefy_mcp/auth/resource_server.py
@@ -19,11 +19,26 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from pipefy_auth import JwtValidator
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_scopes(scope: Any) -> list[str]:
+    """Normalize the ``scope`` claim to a list of strings.
+
+    RFC 9068 specifies a space-delimited string, but some IdPs emit a JSON
+    array. Accept both and treat anything else as no scopes, so a non-string
+    ``scope`` can't raise out of the claims mapping.
+    """
+    if isinstance(scope, str):
+        return scope.split()
+    if isinstance(scope, list):
+        return [str(item) for item in scope]
+    return []
 
 
 class JwtTokenVerifier(TokenVerifier):
@@ -35,9 +50,11 @@ class JwtTokenVerifier(TokenVerifier):
     async def verify_token(self, token: str) -> AccessToken | None:
         """Return the validated token, or ``None`` to reject it (FastMCP -> 401).
 
-        The validator is synchronous, so it runs off the event loop. A
-        ``ValueError`` (the base of ``TokenValidationError``) is a rejection, not
-        a raise: the SDK turns ``None`` into the ``401`` challenge.
+        The validator is synchronous, so it runs off the event loop. Both a
+        failed signature/claim check (``ValueError``, the base of
+        ``TokenValidationError``) and an unmappable claim set are rejections, not
+        raises: the SDK turns ``None`` into the ``401`` challenge, so a malformed
+        token must never escape as a 500.
         """
         try:
             claims = await asyncio.to_thread(self._validator.validate, token)
@@ -45,6 +62,17 @@ class JwtTokenVerifier(TokenVerifier):
             logger.warning("Inbound bearer rejected: %s", exc)
             return None
 
+        try:
+            return self._to_access_token(token, claims)
+        except (ValueError, TypeError) as exc:
+            # A validly-signed token can still carry claims we can't map onto an
+            # AccessToken (e.g. an exp outside int range). Reject rather than let
+            # the mapping error escape verify_token as a 500.
+            logger.warning("Inbound bearer rejected (unmappable claims): %s", exc)
+            return None
+
+    def _to_access_token(self, token: str, claims: dict[str, Any]) -> AccessToken:
+        exp = claims.get("exp")
         return AccessToken(
             token=token,
             # OAuth/OIDC precedence: azp (authorized party) over client_id over
@@ -52,7 +80,9 @@ class JwtTokenVerifier(TokenVerifier):
             client_id=(
                 claims.get("azp") or claims.get("client_id") or claims.get("sub", "")
             ),
-            scopes=(claims.get("scope") or "").split(),
-            expires_at=claims.get("exp"),
+            scopes=_parse_scopes(claims.get("scope")),
+            # exp is an RFC 7519 NumericDate (may be fractional); AccessToken
+            # wants an int. The validator requires exp, so it is present here.
+            expires_at=int(exp) if exp is not None else None,
             resource=self._validator.audience,
         )

--- a/packages/mcp/src/pipefy_mcp/auth/resource_server.py
+++ b/packages/mcp/src/pipefy_mcp/auth/resource_server.py
@@ -1,0 +1,58 @@
+"""Inbound bearer validation for the OAuth 2.0 resource-server profile.
+
+The HTTP transport acts as an OAuth resource server (RFC 6749 §1.1): it accepts
+an ``Authorization: Bearer`` on every request and validates the access token
+before any tool runs. :class:`JwtTokenVerifier` implements FastMCP's
+``TokenVerifier`` protocol so the SDK's bearer middleware drives it; FastMCP
+emits the ``401`` + ``WWW-Authenticate`` challenge and serves the RFC 9728
+protected-resource metadata around it.
+
+This is a thin adapter: the JWKS resolution and RS256 decoding live in
+``pipefy_auth`` (:class:`~pipefy_auth.JwtValidator`, a transport-agnostic auth
+primitive). This class maps the validated claims onto the SDK's ``AccessToken``
+and turns a validation failure into the ``None`` the protocol reads as "reject".
+The validated token then lands in the MCP auth context for the per-request
+on-behalf-of work tracked separately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+from pipefy_auth import JwtValidator
+
+logger = logging.getLogger(__name__)
+
+
+class JwtTokenVerifier(TokenVerifier):
+    """Adapt :class:`~pipefy_auth.JwtValidator` to FastMCP's ``TokenVerifier``."""
+
+    def __init__(self, validator: JwtValidator) -> None:
+        self._validator = validator
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Return the validated token, or ``None`` to reject it (FastMCP -> 401).
+
+        The validator is synchronous, so it runs off the event loop. A
+        ``ValueError`` (the base of ``TokenValidationError``) is a rejection, not
+        a raise: the SDK turns ``None`` into the ``401`` challenge.
+        """
+        try:
+            claims = await asyncio.to_thread(self._validator.validate, token)
+        except ValueError as exc:
+            logger.warning("Inbound bearer rejected: %s", exc)
+            return None
+
+        return AccessToken(
+            token=token,
+            # OAuth/OIDC precedence: azp (authorized party) over client_id over
+            # sub, so a token minted via exchange reports the acting client.
+            client_id=(
+                claims.get("azp") or claims.get("client_id") or claims.get("sub", "")
+            ),
+            scopes=(claims.get("scope") or "").split(),
+            expires_at=claims.get("exp"),
+            resource=self._validator.audience,
+        )

--- a/packages/mcp/src/pipefy_mcp/auth/resource_server.py
+++ b/packages/mcp/src/pipefy_mcp/auth/resource_server.py
@@ -7,10 +7,15 @@ before any tool runs. :class:`JwtTokenVerifier` implements FastMCP's
 emits the ``401`` + ``WWW-Authenticate`` challenge and serves the RFC 9728
 protected-resource metadata around it.
 
-This is a thin adapter: the JWKS resolution and RS256 decoding live in
-``pipefy_auth`` (:class:`~pipefy_auth.JwtValidator`, a transport-agnostic auth
-primitive). This class maps the validated claims onto the SDK's ``AccessToken``
-and turns a validation failure into the ``None`` the protocol reads as "reject".
+:class:`JwtTokenVerifier` is a thin adapter: the JWKS resolution and RS256
+decoding live in ``pipefy_auth`` (:class:`~pipefy_auth.JwtValidator`, a
+transport-agnostic auth primitive). This class maps the validated claims onto
+the SDK's ``AccessToken`` and turns a validation failure into the ``None`` the
+protocol reads as "reject".
+
+:func:`build_resource_server_auth` is the composition root for this profile: it
+resolves the inbound issuer, constructs the verifier over a ``JwtValidator``,
+and pairs it with FastMCP's ``AuthSettings`` for the server to wire in.
 """
 
 from __future__ import annotations
@@ -20,7 +25,10 @@ import logging
 from typing import Any
 
 from mcp.server.auth.provider import AccessToken, TokenVerifier
-from pipefy_auth import JwtValidator
+from mcp.server.auth.settings import AuthSettings as FastMcpAuthSettings
+from pipefy_auth import JwtValidationSettings, JwtValidator
+
+from pipefy_mcp.settings import ResourceServerSettings
 
 logger = logging.getLogger(__name__)
 
@@ -99,3 +107,56 @@ class JwtTokenVerifier(TokenVerifier):
             expires_at=int(exp),
             resource=self._resource,
         )
+
+
+# The (verifier, auth) pair the server threads into FastMCP for the
+# resource-server profile: the inbound bearer verifier and FastMCP's matching
+# AuthSettings (RFC 9728 metadata + the 401 challenge).
+ResourceServerAuth = tuple[JwtTokenVerifier, FastMcpAuthSettings]
+
+
+def build_resource_server_auth(
+    rs: ResourceServerSettings,
+    jwt_validation: JwtValidationSettings,
+    *,
+    default_issuer_url: str | None,
+) -> ResourceServerAuth | None:
+    """Build the inbound bearer verifier and FastMCP auth config, or ``None``.
+
+    The resource-server profile has no enable flag: it is active when this
+    server's ``resource_server_url`` is configured. Absent it, this returns
+    ``None`` and the unauthenticated foundation profile constructs ``FastMCP``
+    exactly as before.
+
+    The inbound issuer is ``jwt_validation.issuer_url`` if set, else
+    ``default_issuer_url`` (see :class:`JwtValidationSettings` for why the login
+    issuer is the fallback). With ``resource_server_url`` set but no issuer
+    resolvable (the stored-session login is disabled and no override is given),
+    validation is impossible, so this raises rather than serve an open endpoint.
+    """
+    if rs.resource_server_url is None:
+        return None
+    issuer_url = jwt_validation.resolve_issuer_url(default_issuer_url)
+    if issuer_url is None:
+        raise RuntimeError(
+            "The resource-server profile is active "
+            "(PIPEFY_MCP_RS_RESOURCE_SERVER_URL is set) but no inbound issuer is "
+            "resolvable: set PIPEFY_JWT_ISSUER_URL, or leave the stored-session "
+            "login enabled so its issuer can be reused."
+        )
+    verifier = JwtTokenVerifier(
+        JwtValidator(
+            issuer_url=issuer_url,
+            audience=jwt_validation.audience,
+            verify_audience=jwt_validation.verify_audience,
+            allow_insecure_urls=jwt_validation.allow_insecure_urls,
+            jwks_uri=jwt_validation.jwks_uri,
+        ),
+        resource=rs.resource_server_url,
+    )
+    auth = FastMcpAuthSettings(
+        issuer_url=issuer_url,
+        resource_server_url=rs.resource_server_url,
+        required_scopes=rs.required_scopes,
+    )
+    return verifier, auth

--- a/packages/mcp/src/pipefy_mcp/auth/resource_server.py
+++ b/packages/mcp/src/pipefy_mcp/auth/resource_server.py
@@ -44,8 +44,12 @@ def _parse_scopes(scope: Any) -> list[str]:
 class JwtTokenVerifier(TokenVerifier):
     """Adapt :class:`~pipefy_auth.JwtValidator` to FastMCP's ``TokenVerifier``."""
 
-    def __init__(self, validator: JwtValidator) -> None:
+    def __init__(self, validator: JwtValidator, *, resource: str | None = None) -> None:
         self._validator = validator
+        # The RFC 8707 resource this token targets, stamped onto every AccessToken.
+        # Injected by the wiring layer that owns the resource-server identity,
+        # rather than read back out of the validator's config.
+        self._resource = resource
 
     async def verify_token(self, token: str) -> AccessToken | None:
         """Return the validated token, or ``None`` to reject it (FastMCP -> 401).
@@ -84,5 +88,5 @@ class JwtTokenVerifier(TokenVerifier):
             # exp is an RFC 7519 NumericDate (may be fractional); AccessToken
             # wants an int. The validator requires exp, so it is present here.
             expires_at=int(exp) if exp is not None else None,
-            resource=self._validator.audience,
+            resource=self._resource,
         )

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -5,10 +5,13 @@ import textwrap
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+from mcp.server.auth.settings import AuthSettings as FastMcpAuthSettings
 from mcp.server.fastmcp import FastMCP
+from pipefy_auth import JwtValidator
 
+from pipefy_mcp.auth import JwtTokenVerifier
 from pipefy_mcp.core.container import ServicesContainer
-from pipefy_mcp.settings import settings
+from pipefy_mcp.settings import ResourceServerSettings, settings
 from pipefy_mcp.tools.registry import ToolRegistry
 from pipefy_mcp.tools.validation_envelope import install_pipefy_validation_envelope
 
@@ -94,11 +97,51 @@ def _resolve_bind(host: str | None, port: int | None) -> tuple[str, int]:
     )
 
 
+def _build_resource_server_auth(
+    rs: ResourceServerSettings,
+) -> tuple[JwtTokenVerifier, FastMcpAuthSettings] | None:
+    """Build the inbound bearer verifier and FastMCP auth config, or ``None``.
+
+    Returns ``None`` unless the resource-server profile is enabled, so the
+    unauthenticated foundation profile constructs ``FastMCP`` exactly as before.
+    When enabled, the settings validator guarantees ``issuer_url`` and
+    ``resource_server_url`` are set (asserted here to satisfy the type narrowing).
+    The verifier consumes ``audience``/``verify_audience``/``allow_insecure_urls``;
+    FastMCP's ``AuthSettings`` consumes the issuer, resource, and required scopes
+    to serve RFC 9728 metadata and the ``401`` challenge.
+    """
+    if not rs.enabled:
+        return None
+    if rs.issuer_url is None or rs.resource_server_url is None:
+        # Unreachable: the settings validator requires both when enabled. Guard
+        # the invariant explicitly (and narrow the types) rather than assert.
+        raise RuntimeError(
+            "resource-server profile enabled without issuer_url/resource_server_url "
+            "(settings invariant broken)."
+        )
+    verifier = JwtTokenVerifier(
+        JwtValidator(
+            issuer_url=rs.issuer_url,
+            audience=rs.audience,
+            verify_audience=rs.verify_audience,
+            allow_insecure_urls=rs.allow_insecure_urls,
+            jwks_uri=rs.jwks_uri,
+        )
+    )
+    auth = FastMcpAuthSettings(
+        issuer_url=rs.issuer_url,
+        resource_server_url=rs.resource_server_url,
+        required_scopes=rs.required_scopes,
+    )
+    return verifier, auth
+
+
 def build_pipefy_mcp_server(
     *,
     remote_mode: bool | None = None,
     host: str | None = None,
     port: int | None = None,
+    resource_server: tuple[JwtTokenVerifier, FastMcpAuthSettings] | None = None,
 ) -> FastMCP:
     """Build the FastMCP app with its tools registered once, before serving.
 
@@ -107,37 +150,50 @@ def build_pipefy_mcp_server(
     ``PIPEFY_MCP_REMOTE_MODE``; pass an explicit value to override (used by
     tests). ``host``/``port`` default to ``PIPEFY_MCP_HOST`` / ``PIPEFY_MCP_PORT``
     and matter only for the HTTP transport; stdio ignores them.
+
+    ``resource_server`` is the ``(verifier, auth)`` pair from
+    :func:`_build_resource_server_auth`. When present, FastMCP validates the
+    inbound bearer per request and serves the resource-server metadata; when
+    ``None`` (stdio, or the disabled HTTP profile) the app has no inbound auth.
     """
     resolved = settings.mcp.remote_mode if remote_mode is None else remote_mode
     resolved_host, resolved_port = _resolve_bind(host, port)
+    verifier, auth = resource_server or (None, None)
     app = FastMCP(
         "pipefy",
         instructions=PIPEFY_INSTRUCTIONS,
         lifespan=lifespan,
         host=resolved_host,
         port=resolved_port,
+        token_verifier=verifier,
+        auth=auth,
     )
     _register_pipefy_tools(app, remote_mode=resolved)
     return app
 
 
-def _assert_loopback_http_bind(*, host: str) -> None:
-    """Refuse to bind the HTTP transport to a non-loopback host.
+def _assert_loopback_http_bind(*, host: str, resource_server_enabled: bool) -> None:
+    """Refuse to bind the HTTP transport to a non-loopback host while unauthenticated.
 
-    The HTTP profile is unauthenticated: it validates no inbound bearer and
-    carries no per-request identity, so every call runs as the single identity
-    resolved at startup. A network-reachable bind would hand that identity to
-    anyone who can reach the port, so HTTP is restricted to loopback. Relax this
-    guard when inbound auth lands (#301). (The filesystem tools, e.g. the
-    attachment uploads, also only make sense on loopback, where the server shares
-    the client's disk.)
+    Without the resource-server profile the HTTP transport validates no inbound
+    bearer and carries no per-request identity, so every call runs as the single
+    identity resolved at startup. A network-reachable bind would hand that
+    identity to anyone who can reach the port, so it is restricted to loopback.
+    (The filesystem tools, e.g. the attachment uploads, also only make sense on
+    loopback, where the server shares the client's disk.)
+
+    Once the resource-server profile is enabled (#301), every request carries a
+    validated bearer, so a non-loopback bind is allowed. The configurable host /
+    Origin allowlist for a proxied deployment is #303.
     """
-    if host in _LOOPBACK_HOSTS:
+    if host in _LOOPBACK_HOSTS or resource_server_enabled:
         return
     raise RuntimeError(
         f"Refusing to serve over HTTP on a non-loopback host ({host}). The HTTP "
         f"transport is unauthenticated and is restricted to loopback "
-        f"(127.0.0.1/localhost/::1) until inbound auth lands."
+        f"(127.0.0.1/localhost/::1). Enable the resource-server profile "
+        f"(PIPEFY_MCP_RS_ENABLED=1) to validate inbound bearers and bind "
+        f"off-loopback."
     )
 
 
@@ -176,15 +232,22 @@ def run_server(
 
     resolved_remote = settings.mcp.remote_mode if remote_mode is None else remote_mode
     resolved_host, resolved_port = _resolve_bind(host, port)
+    resource_server = _build_resource_server_auth(settings.rs)
     logger.info(
-        "Starting Pipefy MCP server over HTTP on %s:%d (remote_mode=%s)",
+        "Starting Pipefy MCP server over HTTP on %s:%d (remote_mode=%s, resource_server=%s)",
         resolved_host,
         resolved_port,
         "enabled" if resolved_remote else "disabled",
+        "enabled" if resource_server is not None else "disabled",
     )
-    _assert_loopback_http_bind(host=resolved_host)
+    _assert_loopback_http_bind(
+        host=resolved_host, resource_server_enabled=resource_server is not None
+    )
 
     app = build_pipefy_mcp_server(
-        remote_mode=resolved_remote, host=resolved_host, port=resolved_port
+        remote_mode=resolved_remote,
+        host=resolved_host,
+        port=resolved_port,
+        resource_server=resource_server,
     )
     app.run("streamable-http")

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -183,7 +183,7 @@ def build_pipefy_mcp_server(
     return app
 
 
-def _assert_loopback_http_bind(*, host: str, resource_server_configured: bool) -> None:
+def _assert_safe_http_bind(*, host: str, resource_server_configured: bool) -> None:
     """Refuse to bind the HTTP transport to a non-loopback host while unauthenticated.
 
     Without the resource-server profile the HTTP transport validates no inbound
@@ -221,7 +221,7 @@ def run_server(
     stdio. With ``http=True`` it serves over Streamable HTTP on ``host``/``port``,
     defaulting to the configured ``PIPEFY_MCP_HOST`` / ``PIPEFY_MCP_PORT``. HTTP
     is restricted to a loopback bind while it is unauthenticated foundation work
-    (see :func:`_assert_loopback_http_bind`).
+    (see :func:`_assert_safe_http_bind`).
 
     ``remote_mode`` selects the default-deny remote tool surface and defaults to
     the configured ``PIPEFY_MCP_REMOTE_MODE``. It is orthogonal to the transport:
@@ -256,7 +256,7 @@ def run_server(
         "enabled" if resolved_remote else "disabled",
         "active" if resource_server is not None else "inactive",
     )
-    _assert_loopback_http_bind(
+    _assert_safe_http_bind(
         host=resolved_host, resource_server_configured=resource_server is not None
     )
 

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -5,13 +5,11 @@ import textwrap
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from mcp.server.auth.settings import AuthSettings as FastMcpAuthSettings
 from mcp.server.fastmcp import FastMCP
-from pipefy_auth import JwtValidationSettings, JwtValidator
 
-from pipefy_mcp.auth import JwtTokenVerifier
+from pipefy_mcp.auth import ResourceServerAuth, build_resource_server_auth
 from pipefy_mcp.core.container import ServicesContainer
-from pipefy_mcp.settings import ResourceServerSettings, settings
+from pipefy_mcp.settings import settings
 from pipefy_mcp.tools.registry import ToolRegistry
 from pipefy_mcp.tools.validation_envelope import install_pipefy_validation_envelope
 
@@ -97,59 +95,12 @@ def _resolve_bind(host: str | None, port: int | None) -> tuple[str, int]:
     )
 
 
-def _build_resource_server_auth(
-    rs: ResourceServerSettings,
-    jwt_validation: JwtValidationSettings,
-    *,
-    default_issuer_url: str | None,
-) -> tuple[JwtTokenVerifier, FastMcpAuthSettings] | None:
-    """Build the inbound bearer verifier and FastMCP auth config, or ``None``.
-
-    The resource-server profile has no enable flag: it is active when this
-    server's ``resource_server_url`` is configured. Absent it, this returns
-    ``None`` and the unauthenticated foundation profile constructs ``FastMCP``
-    exactly as before.
-
-    The inbound issuer is ``jwt_validation.issuer_url`` if set, else
-    ``default_issuer_url`` (see :class:`JwtValidationSettings` for why the login
-    issuer is the fallback). With ``resource_server_url`` set but no issuer
-    resolvable (the stored-session login is disabled and no override is given),
-    validation is impossible, so this raises rather than serve an open endpoint.
-    """
-    if rs.resource_server_url is None:
-        return None
-    issuer_url = jwt_validation.resolve_issuer_url(default_issuer_url)
-    if issuer_url is None:
-        raise RuntimeError(
-            "The resource-server profile is active "
-            "(PIPEFY_MCP_RS_RESOURCE_SERVER_URL is set) but no inbound issuer is "
-            "resolvable: set PIPEFY_JWT_ISSUER_URL, or leave the stored-session "
-            "login enabled so its issuer can be reused."
-        )
-    verifier = JwtTokenVerifier(
-        JwtValidator(
-            issuer_url=issuer_url,
-            audience=jwt_validation.audience,
-            verify_audience=jwt_validation.verify_audience,
-            allow_insecure_urls=jwt_validation.allow_insecure_urls,
-            jwks_uri=jwt_validation.jwks_uri,
-        ),
-        resource=rs.resource_server_url,
-    )
-    auth = FastMcpAuthSettings(
-        issuer_url=issuer_url,
-        resource_server_url=rs.resource_server_url,
-        required_scopes=rs.required_scopes,
-    )
-    return verifier, auth
-
-
 def build_pipefy_mcp_server(
     *,
     remote_mode: bool | None = None,
     host: str | None = None,
     port: int | None = None,
-    resource_server: tuple[JwtTokenVerifier, FastMcpAuthSettings] | None = None,
+    resource_server: ResourceServerAuth | None = None,
 ) -> FastMCP:
     """Build the FastMCP app with its tools registered once, before serving.
 
@@ -160,9 +111,10 @@ def build_pipefy_mcp_server(
     and matter only for the HTTP transport; stdio ignores them.
 
     ``resource_server`` is the ``(verifier, auth)`` pair from
-    :func:`_build_resource_server_auth`. When present, FastMCP validates the
-    inbound bearer per request and serves the resource-server metadata; when
-    ``None`` (stdio, or the disabled HTTP profile) the app has no inbound auth.
+    :func:`pipefy_mcp.auth.build_resource_server_auth`. When present, FastMCP
+    validates the inbound bearer per request and serves the resource-server
+    metadata; when ``None`` (stdio, or the disabled HTTP profile) the app has no
+    inbound auth.
     """
     resolved = settings.mcp.remote_mode if remote_mode is None else remote_mode
     resolved_host, resolved_port = _resolve_bind(host, port)
@@ -242,7 +194,7 @@ def run_server(
     resolved_remote = settings.mcp.remote_mode if remote_mode is None else remote_mode
     resolved_host, resolved_port = _resolve_bind(host, port)
     oidc_client = settings.auth.to_oidc_client()
-    resource_server = _build_resource_server_auth(
+    resource_server = build_resource_server_auth(
         settings.rs,
         settings.jwt,
         default_issuer_url=oidc_client.issuer_url if oidc_client else None,

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -137,7 +137,8 @@ def _build_resource_server_auth(
             verify_audience=jwt_validation.verify_audience,
             allow_insecure_urls=jwt_validation.allow_insecure_urls,
             jwks_uri=jwt_validation.jwks_uri,
-        )
+        ),
+        resource=jwt_validation.audience,
     )
     auth = FastMcpAuthSettings(
         issuer_url=issuer_url,

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -134,7 +134,7 @@ def _build_resource_server_auth(
             allow_insecure_urls=jwt_validation.allow_insecure_urls,
             jwks_uri=jwt_validation.jwks_uri,
         ),
-        resource=jwt_validation.audience,
+        resource=rs.resource_server_url,
     )
     auth = FastMcpAuthSettings(
         issuer_url=issuer_url,
@@ -191,8 +191,9 @@ def _assert_safe_http_bind(*, host: str, resource_server_configured: bool) -> No
     loopback, where the server shares the client's disk.)
 
     Once the resource-server profile is configured, every request carries a
-    validated bearer, so a non-loopback bind is allowed. The configurable host /
-    Origin allowlist for a proxied deployment is #303.
+    validated bearer, so a non-loopback bind is allowed. A configurable host /
+    Origin allowlist for a proxied deployment (DNS-rebinding protection) is
+    still to come.
     """
     if host in _LOOPBACK_HOSTS or resource_server_configured:
         return

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -110,12 +110,11 @@ def _build_resource_server_auth(
     ``None`` and the unauthenticated foundation profile constructs ``FastMCP``
     exactly as before.
 
-    The inbound issuer is ``jwt_validation.issuer_url`` if set, else ``default_issuer_url``
-    (the issuer this process logs into): in a single-realm deployment the IdP that
-    signs caller tokens is the one we authenticate to, so it need not be configured
-    twice. With ``resource_server_url`` set but no issuer resolvable (the
-    stored-session login is disabled and no override is given), validation is
-    impossible, so this raises rather than serve an open endpoint.
+    The inbound issuer is ``jwt_validation.issuer_url`` if set, else
+    ``default_issuer_url`` (see :class:`JwtValidationSettings` for why the login
+    issuer is the fallback). With ``resource_server_url`` set but no issuer
+    resolvable (the stored-session login is disabled and no override is given),
+    validation is impossible, so this raises rather than serve an open endpoint.
 
     The verifier consumes the inbound validation knobs (audience, verify_audience,
     jwks_uri); FastMCP's ``AuthSettings`` consumes the issuer, resource, and

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -115,10 +115,6 @@ def _build_resource_server_auth(
     issuer is the fallback). With ``resource_server_url`` set but no issuer
     resolvable (the stored-session login is disabled and no override is given),
     validation is impossible, so this raises rather than serve an open endpoint.
-
-    The verifier consumes the inbound validation knobs (audience, verify_audience,
-    jwks_uri); FastMCP's ``AuthSettings`` consumes the issuer, resource, and
-    required scopes to serve RFC 9728 metadata and the ``401`` challenge.
     """
     if rs.resource_server_url is None:
         return None

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 
 from mcp.server.auth.settings import AuthSettings as FastMcpAuthSettings
 from mcp.server.fastmcp import FastMCP
-from pipefy_auth import JwtValidator
+from pipefy_auth import JwtValidationSettings, JwtValidator
 
 from pipefy_mcp.auth import JwtTokenVerifier
 from pipefy_mcp.core.container import ServicesContainer
@@ -99,37 +99,49 @@ def _resolve_bind(host: str | None, port: int | None) -> tuple[str, int]:
 
 def _build_resource_server_auth(
     rs: ResourceServerSettings,
+    jwt_validation: JwtValidationSettings,
+    *,
+    default_issuer_url: str | None,
 ) -> tuple[JwtTokenVerifier, FastMcpAuthSettings] | None:
     """Build the inbound bearer verifier and FastMCP auth config, or ``None``.
 
-    Returns ``None`` unless the resource-server profile is enabled, so the
-    unauthenticated foundation profile constructs ``FastMCP`` exactly as before.
-    When enabled, the settings validator guarantees ``issuer_url`` and
-    ``resource_server_url`` are set (asserted here to satisfy the type narrowing).
-    The verifier consumes ``audience``/``verify_audience``/``allow_insecure_urls``;
-    FastMCP's ``AuthSettings`` consumes the issuer, resource, and required scopes
-    to serve RFC 9728 metadata and the ``401`` challenge.
+    The resource-server profile has no enable flag: it is active when this
+    server's ``resource_server_url`` is configured. Absent it, this returns
+    ``None`` and the unauthenticated foundation profile constructs ``FastMCP``
+    exactly as before.
+
+    The inbound issuer is ``jwt_validation.issuer_url`` if set, else ``default_issuer_url``
+    (the issuer this process logs into): in a single-realm deployment the IdP that
+    signs caller tokens is the one we authenticate to, so it need not be configured
+    twice. With ``resource_server_url`` set but no issuer resolvable (the
+    stored-session login is disabled and no override is given), validation is
+    impossible, so this raises rather than serve an open endpoint.
+
+    The verifier consumes the inbound validation knobs (audience, verify_audience,
+    jwks_uri); FastMCP's ``AuthSettings`` consumes the issuer, resource, and
+    required scopes to serve RFC 9728 metadata and the ``401`` challenge.
     """
-    if not rs.enabled:
+    if rs.resource_server_url is None:
         return None
-    if rs.issuer_url is None or rs.resource_server_url is None:
-        # Unreachable: the settings validator requires both when enabled. Guard
-        # the invariant explicitly (and narrow the types) rather than assert.
+    issuer_url = jwt_validation.resolve_issuer_url(default_issuer_url)
+    if issuer_url is None:
         raise RuntimeError(
-            "resource-server profile enabled without issuer_url/resource_server_url "
-            "(settings invariant broken)."
+            "The resource-server profile is active "
+            "(PIPEFY_MCP_RS_RESOURCE_SERVER_URL is set) but no inbound issuer is "
+            "resolvable: set PIPEFY_JWT_ISSUER_URL, or leave the stored-session "
+            "login enabled so its issuer can be reused."
         )
     verifier = JwtTokenVerifier(
         JwtValidator(
-            issuer_url=rs.issuer_url,
-            audience=rs.audience,
-            verify_audience=rs.verify_audience,
-            allow_insecure_urls=rs.allow_insecure_urls,
-            jwks_uri=rs.jwks_uri,
+            issuer_url=issuer_url,
+            audience=jwt_validation.audience,
+            verify_audience=jwt_validation.verify_audience,
+            allow_insecure_urls=jwt_validation.allow_insecure_urls,
+            jwks_uri=jwt_validation.jwks_uri,
         )
     )
     auth = FastMcpAuthSettings(
-        issuer_url=rs.issuer_url,
+        issuer_url=issuer_url,
         resource_server_url=rs.resource_server_url,
         required_scopes=rs.required_scopes,
     )
@@ -172,7 +184,7 @@ def build_pipefy_mcp_server(
     return app
 
 
-def _assert_loopback_http_bind(*, host: str, resource_server_enabled: bool) -> None:
+def _assert_loopback_http_bind(*, host: str, resource_server_configured: bool) -> None:
     """Refuse to bind the HTTP transport to a non-loopback host while unauthenticated.
 
     Without the resource-server profile the HTTP transport validates no inbound
@@ -182,18 +194,18 @@ def _assert_loopback_http_bind(*, host: str, resource_server_enabled: bool) -> N
     (The filesystem tools, e.g. the attachment uploads, also only make sense on
     loopback, where the server shares the client's disk.)
 
-    Once the resource-server profile is enabled (#301), every request carries a
+    Once the resource-server profile is configured, every request carries a
     validated bearer, so a non-loopback bind is allowed. The configurable host /
     Origin allowlist for a proxied deployment is #303.
     """
-    if host in _LOOPBACK_HOSTS or resource_server_enabled:
+    if host in _LOOPBACK_HOSTS or resource_server_configured:
         return
     raise RuntimeError(
         f"Refusing to serve over HTTP on a non-loopback host ({host}). The HTTP "
         f"transport is unauthenticated and is restricted to loopback "
-        f"(127.0.0.1/localhost/::1). Enable the resource-server profile "
-        f"(PIPEFY_MCP_RS_ENABLED=1) to validate inbound bearers and bind "
-        f"off-loopback."
+        f"(127.0.0.1/localhost/::1). Set PIPEFY_MCP_RS_RESOURCE_SERVER_URL to "
+        f"activate the resource-server profile, which validates inbound bearers "
+        f"and may bind off-loopback."
     )
 
 
@@ -232,16 +244,21 @@ def run_server(
 
     resolved_remote = settings.mcp.remote_mode if remote_mode is None else remote_mode
     resolved_host, resolved_port = _resolve_bind(host, port)
-    resource_server = _build_resource_server_auth(settings.rs)
+    oidc_client = settings.auth.to_oidc_client()
+    resource_server = _build_resource_server_auth(
+        settings.rs,
+        settings.jwt,
+        default_issuer_url=oidc_client.issuer_url if oidc_client else None,
+    )
     logger.info(
         "Starting Pipefy MCP server over HTTP on %s:%d (remote_mode=%s, resource_server=%s)",
         resolved_host,
         resolved_port,
         "enabled" if resolved_remote else "disabled",
-        "enabled" if resource_server is not None else "disabled",
+        "active" if resource_server is not None else "inactive",
     )
     _assert_loopback_http_bind(
-        host=resolved_host, resource_server_enabled=resource_server is not None
+        host=resolved_host, resource_server_configured=resource_server is not None
     )
 
     app = build_pipefy_mcp_server(

--- a/packages/mcp/src/pipefy_mcp/server.py
+++ b/packages/mcp/src/pipefy_mcp/server.py
@@ -132,29 +132,27 @@ def build_pipefy_mcp_server(
     return app
 
 
-def _assert_safe_http_bind(*, host: str, resource_server_configured: bool) -> None:
-    """Refuse to bind the HTTP transport to a non-loopback host while unauthenticated.
+def _assert_safe_http_bind(*, host: str) -> None:
+    """Refuse to bind the HTTP transport to a non-loopback host.
 
-    Without the resource-server profile the HTTP transport validates no inbound
-    bearer and carries no per-request identity, so every call runs as the single
-    identity resolved at startup. A network-reachable bind would hand that
-    identity to anyone who can reach the port, so it is restricted to loopback.
-    (The filesystem tools, e.g. the attachment uploads, also only make sense on
-    loopback, where the server shares the client's disk.)
+    The HTTP transport is restricted to loopback for now. Even with the
+    resource-server profile validating an inbound bearer, there is no
+    per-request on-behalf-of identity yet, so every call still runs as the
+    single identity resolved at startup. A network-reachable bind would hand
+    that identity to anyone who can reach the port. (The filesystem tools, e.g.
+    the attachment uploads, also only make sense on loopback, where the server
+    shares the client's disk.)
 
-    Once the resource-server profile is configured, every request carries a
-    validated bearer, so a non-loopback bind is allowed. A configurable host /
-    Origin allowlist for a proxied deployment (DNS-rebinding protection) is
-    still to come.
+    Off-loopback binding stays off until the hosted on-behalf-of profile lands
+    (per-request identity and the DNS-rebinding host/Origin allowlist); see
+    experiments/hosted-obo/RFC-OUTLINE.md.
     """
-    if host in _LOOPBACK_HOSTS or resource_server_configured:
+    if host in _LOOPBACK_HOSTS:
         return
     raise RuntimeError(
         f"Refusing to serve over HTTP on a non-loopback host ({host}). The HTTP "
-        f"transport is unauthenticated and is restricted to loopback "
-        f"(127.0.0.1/localhost/::1). Set PIPEFY_MCP_RS_RESOURCE_SERVER_URL to "
-        f"activate the resource-server profile, which validates inbound bearers "
-        f"and may bind off-loopback."
+        f"transport is restricted to loopback (127.0.0.1/localhost/::1) until "
+        f"the hosted on-behalf-of profile lands."
     )
 
 
@@ -170,7 +168,7 @@ def run_server(
     With ``http=False`` (the default, local profile) the process speaks MCP over
     stdio. With ``http=True`` it serves over Streamable HTTP on ``host``/``port``,
     defaulting to the configured ``PIPEFY_MCP_HOST`` / ``PIPEFY_MCP_PORT``. HTTP
-    is restricted to a loopback bind while it is unauthenticated foundation work
+    is restricted to a loopback bind until the hosted on-behalf-of profile lands
     (see :func:`_assert_safe_http_bind`).
 
     ``remote_mode`` selects the default-deny remote tool surface and defaults to
@@ -206,9 +204,7 @@ def run_server(
         "enabled" if resolved_remote else "disabled",
         "active" if resource_server is not None else "inactive",
     )
-    _assert_safe_http_bind(
-        host=resolved_host, resource_server_configured=resource_server is not None
-    )
+    _assert_safe_http_bind(host=resolved_host)
 
     app = build_pipefy_mcp_server(
         remote_mode=resolved_remote,

--- a/packages/mcp/src/pipefy_mcp/settings.py
+++ b/packages/mcp/src/pipefy_mcp/settings.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import Self
 
-from pipefy_auth import AuthSettings
+from pipefy_auth import AuthSettings, JwtValidationSettings
 from pipefy_infra import security
 from pipefy_infra.config import PipefyTomlConfigSource
 from pipefy_sdk import PipefySettings
-from pydantic import Field, model_validator
+from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -92,18 +92,23 @@ class McpSettings(BaseSettings):
 
 
 class ResourceServerSettings(BaseSettings):
-    """OAuth resource-server knobs for inbound bearer validation (HTTP profile).
+    """This MCP server's identity as an OAuth protected resource (HTTP profile).
 
-    Off by default: only the ``--remote`` HTTP transport consults these, and
-    only when ``enabled`` so the unauthenticated foundation profile is
-    unaffected. Kept separate from :class:`McpSettings` (transport knobs) and the
-    repo ``AuthSettings`` (outbound: how this process authenticates *to* Pipefy):
-    ``issuer_url`` here is the *inbound* issuer that signs caller tokens, which
-    can differ from the issuer this process logs into.
+    The resource-server profile activates when ``resource_server_url`` is set: the
+    ``--remote`` transport then validates inbound bearers and serves RFC 9728
+    metadata, and the unauthenticated foundation profile is left untouched. There
+    is no separate enable flag, just ``--remote`` plus this URL.
+
+    Token *validation* knobs (issuer, audience, JWKS) are an auth concern and live
+    in :class:`pipefy_auth.JwtValidationSettings`, alongside the validator they
+    feed. This model carries only what is specific to *this* server's resource
+    identity: its public URL and the scopes it requires.
 
     ``env_prefix="PIPEFY_MCP_RS_"`` does not collide with ``McpSettings``'
     ``PIPEFY_MCP_``: that model has no ``rs_*`` fields, so ``PIPEFY_MCP_RS_*``
-    vars fall through its ``extra="ignore"`` gate.
+    vars fall through its ``extra="ignore"`` gate. ``allow_insecure_urls`` is
+    aliased to the shared ``PIPEFY_ALLOW_INSECURE_URLS`` so the whole deployment
+    has a single insecure-URL posture.
     """
 
     model_config = SettingsConfigDict(
@@ -132,39 +137,15 @@ class ResourceServerSettings(BaseSettings):
             file_secret_settings,
         )
 
-    enabled: bool = Field(
-        default=False,
-        description=(
-            "Master switch (env: PIPEFY_MCP_RS_ENABLED). When true, the HTTP "
-            "transport validates an inbound bearer on every request and may bind "
-            "off-loopback. When false (default), the HTTP profile stays "
-            "unauthenticated and loopback-only."
-        ),
-    )
-
-    issuer_url: str | None = Field(
+    resource_server_url: str | None = Field(
         default=None,
         description=(
-            "Inbound OIDC issuer that signs caller tokens (env: "
-            "PIPEFY_MCP_RS_ISSUER_URL). The JWKS endpoint is resolved from its "
-            "discovery document. Required when enabled."
-        ),
-    )
-
-    audience: str | None = Field(
-        default=None,
-        description=(
-            "Expected token audience (env: PIPEFY_MCP_RS_AUDIENCE). Required when "
-            "verify_audience is true."
-        ),
-    )
-
-    verify_audience: bool = Field(
-        default=False,
-        description=(
-            "When true (env: PIPEFY_MCP_RS_VERIFY_AUDIENCE), reject tokens whose "
-            "aud does not include audience. Defaults false for the same-audience "
-            "interim, which runs before the IdP issues an aud claim."
+            "Public canonical URL of this MCP server as an OAuth protected "
+            "resource (env: PIPEFY_MCP_RS_RESOURCE_SERVER_URL). Decoupled from the "
+            "bind host, so behind a proxy it is the public origin, not host/port. "
+            "Include the /mcp endpoint path, e.g. https://mcp.pipefy.com/mcp: it "
+            "becomes the RFC 9728 resource identifier and the base for the "
+            "protected-resource metadata route. Setting it activates the profile."
         ),
     )
 
@@ -176,64 +157,31 @@ class ResourceServerSettings(BaseSettings):
         ),
     )
 
-    resource_server_url: str | None = Field(
-        default=None,
-        description=(
-            "Public canonical URL of this MCP server as an OAuth protected "
-            "resource (env: PIPEFY_MCP_RS_RESOURCE_SERVER_URL). Decoupled from the "
-            "bind host, so behind a proxy it is the public origin, not host/port. "
-            "Include the /mcp endpoint path, e.g. https://mcp.pipefy.com/mcp: it "
-            "becomes the RFC 9728 resource identifier and the base for the "
-            "protected-resource metadata route. Required when enabled."
-        ),
-    )
-
     allow_insecure_urls: bool = Field(
         default=False,
+        validation_alias=AliasChoices("PIPEFY_ALLOW_INSECURE_URLS"),
         description=(
-            "When true (env: PIPEFY_MCP_RS_ALLOW_INSECURE_URLS), resource-server "
-            "URLs may use http:// and internal hosts; local development only."
-        ),
-    )
-
-    jwks_uri: str | None = Field(
-        default=None,
-        description=(
-            "Explicit JWKS endpoint override (env: PIPEFY_MCP_RS_JWKS_URI). When "
-            "unset, resolved from the issuer's discovery document."
+            "When true (env: PIPEFY_ALLOW_INSECURE_URLS, shared across the "
+            "deployment), resource_server_url may use http:// and internal hosts; "
+            "local development only."
         ),
     )
 
     @model_validator(mode="after")
-    def _validate_when_enabled(self) -> Self:
-        # Inert unless enabled, so the default (disabled) profile never trips on
-        # absent URLs. ``issuer_url`` and ``resource_server_url`` may carry a path
-        # (a Keycloak realm; the /mcp endpoint), so they only forbid a query or
-        # fragment that would corrupt downstream concatenation, not any path.
-        if not self.enabled:
+    def _validate_configuration(self) -> Self:
+        if self.resource_server_url is None:
             return self
-        if not self.issuer_url or not self.resource_server_url:
-            raise ValueError(
-                "resource-server profile requires issuer_url and "
-                "resource_server_url when enabled "
-                "(PIPEFY_MCP_RS_ISSUER_URL / PIPEFY_MCP_RS_RESOURCE_SERVER_URL)."
-            )
-        if self.verify_audience and not self.audience:
-            raise ValueError(
-                "verify_audience requires audience (PIPEFY_MCP_RS_AUDIENCE)."
-            )
-        for value, label in (
-            (self.issuer_url, "issuer_url"),
-            (self.resource_server_url, "resource_server_url"),
-            (self.jwks_uri, "jwks_uri"),
-        ):
-            if value is None:
-                continue
-            stripped = value.strip()
-            security.assert_url_has_no_query_or_fragment(stripped, field_label=label)
-            security.validate_https_url(
-                stripped, label, allow_insecure=self.allow_insecure_urls
-            )
+        # Persist the stripped value: surrounding whitespace in an env var would
+        # otherwise survive into the RFC 9728 resource identifier. The /mcp
+        # endpoint path is expected, so only a query or fragment is forbidden.
+        stripped = self.resource_server_url.strip()
+        self.resource_server_url = stripped
+        security.assert_url_has_no_query_or_fragment(
+            stripped, field_label="resource_server_url"
+        )
+        security.validate_https_url(
+            stripped, "resource_server_url", allow_insecure=self.allow_insecure_urls
+        )
         return self
 
 
@@ -253,6 +201,7 @@ class Settings(BaseSettings):
     pipefy: PipefySettings = Field(default_factory=PipefySettings)
     auth: AuthSettings = Field(default_factory=AuthSettings)
     mcp: McpSettings = Field(default_factory=McpSettings)
+    jwt: JwtValidationSettings = Field(default_factory=JwtValidationSettings)
     rs: ResourceServerSettings = Field(default_factory=ResourceServerSettings)
 
 
@@ -260,6 +209,7 @@ settings = Settings()
 
 __all__ = [
     "AuthSettings",
+    "JwtValidationSettings",
     "McpSettings",
     "PipefySettings",
     "ResourceServerSettings",

--- a/packages/mcp/src/pipefy_mcp/settings.py
+++ b/packages/mcp/src/pipefy_mcp/settings.py
@@ -96,8 +96,7 @@ class ResourceServerSettings(BaseSettings):
 
     The resource-server profile activates when ``resource_server_url`` is set: the
     ``--remote`` transport then validates inbound bearers and serves RFC 9728
-    metadata, and the unauthenticated foundation profile is left untouched. There
-    is no separate enable flag, just ``--remote`` plus this URL.
+    metadata, and the unauthenticated foundation profile is left untouched.
 
     Token *validation* knobs (issuer, audience, JWKS) are an auth concern and live
     in :class:`pipefy_auth.JwtValidationSettings`, alongside the validator they

--- a/packages/mcp/src/pipefy_mcp/settings.py
+++ b/packages/mcp/src/pipefy_mcp/settings.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import Self
+
 from pipefy_auth import AuthSettings
+from pipefy_infra import security
 from pipefy_infra.config import PipefyTomlConfigSource
 from pipefy_sdk import PipefySettings
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -88,6 +91,152 @@ class McpSettings(BaseSettings):
     )
 
 
+class ResourceServerSettings(BaseSettings):
+    """OAuth resource-server knobs for inbound bearer validation (HTTP profile).
+
+    Off by default: only the ``--remote`` HTTP transport consults these, and
+    only when ``enabled`` so the unauthenticated foundation profile is
+    unaffected. Kept separate from :class:`McpSettings` (transport knobs) and the
+    repo ``AuthSettings`` (outbound: how this process authenticates *to* Pipefy):
+    ``issuer_url`` here is the *inbound* issuer that signs caller tokens, which
+    can differ from the issuer this process logs into.
+
+    ``env_prefix="PIPEFY_MCP_RS_"`` does not collide with ``McpSettings``'
+    ``PIPEFY_MCP_``: that model has no ``rs_*`` fields, so ``PIPEFY_MCP_RS_*``
+    vars fall through its ``extra="ignore"`` gate.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="PIPEFY_MCP_RS_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        # Precedence: init_kwargs > env > dotenv > config.toml > file_secret.
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            PipefyTomlConfigSource(settings_cls),
+            file_secret_settings,
+        )
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Master switch (env: PIPEFY_MCP_RS_ENABLED). When true, the HTTP "
+            "transport validates an inbound bearer on every request and may bind "
+            "off-loopback. When false (default), the HTTP profile stays "
+            "unauthenticated and loopback-only."
+        ),
+    )
+
+    issuer_url: str | None = Field(
+        default=None,
+        description=(
+            "Inbound OIDC issuer that signs caller tokens (env: "
+            "PIPEFY_MCP_RS_ISSUER_URL). The JWKS endpoint is resolved from its "
+            "discovery document. Required when enabled."
+        ),
+    )
+
+    audience: str | None = Field(
+        default=None,
+        description=(
+            "Expected token audience (env: PIPEFY_MCP_RS_AUDIENCE). Required when "
+            "verify_audience is true."
+        ),
+    )
+
+    verify_audience: bool = Field(
+        default=False,
+        description=(
+            "When true (env: PIPEFY_MCP_RS_VERIFY_AUDIENCE), reject tokens whose "
+            "aud does not include audience. Defaults false for the same-audience "
+            "interim, which runs before the IdP issues an aud claim."
+        ),
+    )
+
+    required_scopes: list[str] | None = Field(
+        default=None,
+        description=(
+            "Scopes a token must carry (env: PIPEFY_MCP_RS_REQUIRED_SCOPES as "
+            "JSON). FastMCP returns 403 when any is missing."
+        ),
+    )
+
+    resource_server_url: str | None = Field(
+        default=None,
+        description=(
+            "Public canonical URL of this MCP server as an OAuth protected "
+            "resource (env: PIPEFY_MCP_RS_RESOURCE_SERVER_URL). Decoupled from the "
+            "bind host, so behind a proxy it is the public origin, not host/port. "
+            "Include the /mcp endpoint path, e.g. https://mcp.pipefy.com/mcp: it "
+            "becomes the RFC 9728 resource identifier and the base for the "
+            "protected-resource metadata route. Required when enabled."
+        ),
+    )
+
+    allow_insecure_urls: bool = Field(
+        default=False,
+        description=(
+            "When true (env: PIPEFY_MCP_RS_ALLOW_INSECURE_URLS), resource-server "
+            "URLs may use http:// and internal hosts; local development only."
+        ),
+    )
+
+    jwks_uri: str | None = Field(
+        default=None,
+        description=(
+            "Explicit JWKS endpoint override (env: PIPEFY_MCP_RS_JWKS_URI). When "
+            "unset, resolved from the issuer's discovery document."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_when_enabled(self) -> Self:
+        # Inert unless enabled, so the default (disabled) profile never trips on
+        # absent URLs. ``issuer_url`` and ``resource_server_url`` may carry a path
+        # (a Keycloak realm; the /mcp endpoint), so they only forbid a query or
+        # fragment that would corrupt downstream concatenation, not any path.
+        if not self.enabled:
+            return self
+        if not self.issuer_url or not self.resource_server_url:
+            raise ValueError(
+                "resource-server profile requires issuer_url and "
+                "resource_server_url when enabled "
+                "(PIPEFY_MCP_RS_ISSUER_URL / PIPEFY_MCP_RS_RESOURCE_SERVER_URL)."
+            )
+        if self.verify_audience and not self.audience:
+            raise ValueError(
+                "verify_audience requires audience (PIPEFY_MCP_RS_AUDIENCE)."
+            )
+        for value, label in (
+            (self.issuer_url, "issuer_url"),
+            (self.resource_server_url, "resource_server_url"),
+            (self.jwks_uri, "jwks_uri"),
+        ):
+            if value is None:
+                continue
+            stripped = value.strip()
+            security.assert_url_has_no_query_or_fragment(stripped, field_label=label)
+            security.validate_https_url(
+                stripped, label, allow_insecure=self.allow_insecure_urls
+            )
+        return self
+
+
 class Settings(BaseSettings):
     """Application configuration via pydantic-settings.
 
@@ -104,8 +253,16 @@ class Settings(BaseSettings):
     pipefy: PipefySettings = Field(default_factory=PipefySettings)
     auth: AuthSettings = Field(default_factory=AuthSettings)
     mcp: McpSettings = Field(default_factory=McpSettings)
+    rs: ResourceServerSettings = Field(default_factory=ResourceServerSettings)
 
 
 settings = Settings()
 
-__all__ = ["AuthSettings", "McpSettings", "PipefySettings", "Settings", "settings"]
+__all__ = [
+    "AuthSettings",
+    "McpSettings",
+    "PipefySettings",
+    "ResourceServerSettings",
+    "Settings",
+    "settings",
+]

--- a/packages/mcp/tests/auth/test_resource_server.py
+++ b/packages/mcp/tests/auth/test_resource_server.py
@@ -15,7 +15,8 @@ from pipefy_auth import TokenValidationError
 
 from pipefy_mcp.auth import JwtTokenVerifier
 
-_AUDIENCE = "https://mcp.example.com/mcp"
+_RESOURCE = "https://mcp.example.com/mcp"
+_EXP = 1893456000
 
 
 class _StubValidator:
@@ -36,37 +37,67 @@ async def test_maps_claims_to_access_token() -> None:
             "azp": "client-abc",
             "sub": "user-123",
             "scope": "read write",
-            "exp": 1893456000,
+            "exp": _EXP,
         }
     )
-    token = await JwtTokenVerifier(validator, resource=_AUDIENCE).verify_token(
+    token = await JwtTokenVerifier(validator, resource=_RESOURCE).verify_token(
         "the-token"
     )
     assert token is not None
     assert token.token == "the-token"
     assert token.client_id == "client-abc"
     assert token.scopes == ["read", "write"]
-    assert token.expires_at == 1893456000
-    assert token.resource == _AUDIENCE
+    assert token.expires_at == _EXP
+    assert token.resource == _RESOURCE
 
 
 @pytest.mark.unit
 async def test_client_id_falls_back_to_client_id_then_sub() -> None:
     by_client_id = await JwtTokenVerifier(
-        _StubValidator(claims={"client_id": "cid", "sub": "user-123"})
+        _StubValidator(claims={"client_id": "cid", "sub": "user-123", "exp": _EXP})
     ).verify_token("t")
     assert by_client_id is not None and by_client_id.client_id == "cid"
 
     by_sub = await JwtTokenVerifier(
-        _StubValidator(claims={"sub": "user-123"})
+        _StubValidator(claims={"sub": "user-123", "exp": _EXP})
     ).verify_token("t")
     assert by_sub is not None and by_sub.client_id == "user-123"
 
 
 @pytest.mark.unit
-async def test_missing_scope_claim_yields_empty_scopes() -> None:
+async def test_empty_azp_falls_through_to_next_identity() -> None:
+    # Some IdPs emit an empty azp for direct grants; it must not short-circuit
+    # the chain to an empty client_id.
+    token = await JwtTokenVerifier(
+        _StubValidator(claims={"azp": "", "client_id": "cid", "exp": _EXP})
+    ).verify_token("t")
+    assert token is not None and token.client_id == "cid"
+
+
+@pytest.mark.unit
+async def test_no_client_identity_returns_none() -> None:
+    # A token with no azp/client_id/sub carries no usable identity; reject it
+    # rather than stamp an anonymous "" client_id.
+    token = await JwtTokenVerifier(
+        _StubValidator(claims={"scope": "read", "exp": _EXP})
+    ).verify_token("t")
+    assert token is None
+
+
+@pytest.mark.unit
+async def test_missing_exp_returns_none() -> None:
+    # The validator requires exp; if one ever reaches the mapping without it,
+    # reject rather than emit a never-expiring token.
     token = await JwtTokenVerifier(
         _StubValidator(claims={"sub": "user-123"})
+    ).verify_token("t")
+    assert token is None
+
+
+@pytest.mark.unit
+async def test_missing_scope_claim_yields_empty_scopes() -> None:
+    token = await JwtTokenVerifier(
+        _StubValidator(claims={"sub": "user-123", "exp": _EXP})
     ).verify_token("t")
     assert token is not None and token.scopes == []
 
@@ -76,7 +107,9 @@ async def test_scope_claim_as_list_maps_to_scopes() -> None:
     # RFC 9068 specifies a space-delimited string, but some IdPs emit an array;
     # it must map rather than crash (a list has no .split()).
     token = await JwtTokenVerifier(
-        _StubValidator(claims={"sub": "user-123", "scope": ["read", "write"]})
+        _StubValidator(
+            claims={"sub": "user-123", "scope": ["read", "write"], "exp": _EXP}
+        )
     ).verify_token("t")
     assert token is not None and token.scopes == ["read", "write"]
 

--- a/packages/mcp/tests/auth/test_resource_server.py
+++ b/packages/mcp/tests/auth/test_resource_server.py
@@ -71,6 +71,36 @@ async def test_missing_scope_claim_yields_empty_scopes() -> None:
 
 
 @pytest.mark.unit
+async def test_scope_claim_as_list_maps_to_scopes() -> None:
+    # RFC 9068 specifies a space-delimited string, but some IdPs emit an array;
+    # it must map rather than crash (a list has no .split()).
+    token = await JwtTokenVerifier(
+        _StubValidator(claims={"sub": "user-123", "scope": ["read", "write"]})
+    ).verify_token("t")
+    assert token is not None and token.scopes == ["read", "write"]
+
+
+@pytest.mark.unit
+async def test_fractional_exp_is_coerced_to_int() -> None:
+    # exp is an RFC 7519 NumericDate and may be fractional; AccessToken wants an
+    # int, so it is truncated rather than crashing the mapping.
+    token = await JwtTokenVerifier(
+        _StubValidator(claims={"sub": "user-123", "exp": 1893456000.5})
+    ).verify_token("t")
+    assert token is not None and token.expires_at == 1893456000
+
+
+@pytest.mark.unit
+async def test_unmappable_claims_return_none() -> None:
+    # A validly-signed token whose claims can't map onto an AccessToken is a
+    # rejection (None -> 401), never an escaping exception (500).
+    token = await JwtTokenVerifier(
+        _StubValidator(claims={"sub": "user-123", "exp": "not-a-number"})
+    ).verify_token("t")
+    assert token is None
+
+
+@pytest.mark.unit
 async def test_validation_failure_returns_none() -> None:
     token = await JwtTokenVerifier(_StubValidator(raises=True)).verify_token("t")
     assert token is None

--- a/packages/mcp/tests/auth/test_resource_server.py
+++ b/packages/mcp/tests/auth/test_resource_server.py
@@ -1,9 +1,11 @@
-"""Unit tests for the resource-server adapter: claims -> AccessToken, reject -> None.
+"""Unit tests for the resource-server adapter and its composition root.
 
-The JWT/JWKS validation itself is covered in ``pipefy_auth``'s
-``test_verification.py``. These tests use a stub validator to pin the adapter's
-two jobs: mapping validated claims onto the SDK ``AccessToken`` and turning a
-validation failure into ``None`` (which FastMCP renders as a 401).
+The adapter tests (claims -> AccessToken, reject -> None) use a stub validator to
+pin :class:`JwtTokenVerifier`'s two jobs: mapping validated claims onto the SDK
+``AccessToken`` and turning a validation failure into ``None`` (which FastMCP
+renders as a 401). The JWT/JWKS validation itself is covered in ``pipefy_auth``'s
+``test_verification.py``. The builder tests pin
+:func:`build_resource_server_auth`'s issuer resolution and active/inactive gating.
 """
 
 from __future__ import annotations
@@ -11,11 +13,13 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from pipefy_auth import TokenValidationError
+from pipefy_auth import JwtValidationSettings, TokenValidationError
 
-from pipefy_mcp.auth import JwtTokenVerifier
+from pipefy_mcp.auth import JwtTokenVerifier, build_resource_server_auth
+from pipefy_mcp.settings import ResourceServerSettings
 
 _RESOURCE = "https://mcp.example.com/mcp"
+_ISSUER = "https://idp.example.com/realms/x"
 _EXP = 1893456000
 
 
@@ -138,3 +142,75 @@ async def test_unmappable_claims_return_none() -> None:
 async def test_validation_failure_returns_none() -> None:
     token = await JwtTokenVerifier(_StubValidator(raises=True)).verify_token("t")
     assert token is None
+
+
+# --- build_resource_server_auth: the composition root ---
+
+
+@pytest.mark.unit
+def test_build_stamps_resource_server_url_not_audience() -> None:
+    """The verifier stamps this server's resource_server_url onto AccessToken.
+
+    The RFC 9728 metadata advertises resource_server_url as the resource, so the
+    token's stamped resource must match it, not the (often unset) audience.
+    """
+    verifier, _ = build_resource_server_auth(
+        ResourceServerSettings(resource_server_url=_RESOURCE),
+        # audience set and distinct from resource_server_url: the stamped resource
+        # must follow resource_server_url, not audience.
+        JwtValidationSettings(
+            audience="urn:some-other-audience",
+            jwks_uri="https://idp.example.com/jwks",
+        ),
+        default_issuer_url=_ISSUER,
+    )
+    assert verifier._resource == _RESOURCE
+
+
+@pytest.mark.unit
+def test_build_inactive_when_unconfigured() -> None:
+    """No resource_server_url means no auth: the profile is off, not an error."""
+    assert (
+        build_resource_server_auth(
+            ResourceServerSettings(),
+            JwtValidationSettings(),
+            default_issuer_url=_ISSUER,
+        )
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_build_issuer_defaults_to_login_issuer() -> None:
+    """With no inbound override, the inbound issuer is the login issuer."""
+    _, auth = build_resource_server_auth(
+        ResourceServerSettings(resource_server_url=_RESOURCE),
+        JwtValidationSettings(jwks_uri="https://idp.example.com/jwks"),
+        default_issuer_url=_ISSUER,
+    )
+    assert str(auth.issuer_url).rstrip("/") == _ISSUER
+
+
+@pytest.mark.unit
+def test_build_inbound_issuer_overrides_login_issuer() -> None:
+    """An explicit inbound issuer wins over the login issuer."""
+    override = "https://other-idp.example.com/realms/y"
+    _, auth = build_resource_server_auth(
+        ResourceServerSettings(resource_server_url=_RESOURCE),
+        JwtValidationSettings(
+            issuer_url=override, jwks_uri="https://other-idp.example.com/jwks"
+        ),
+        default_issuer_url=_ISSUER,
+    )
+    assert str(auth.issuer_url).rstrip("/") == override
+
+
+@pytest.mark.unit
+def test_build_without_resolvable_issuer_raises() -> None:
+    """resource_server_url set but no issuer (override or login) is a misconfiguration."""
+    with pytest.raises(RuntimeError, match="no inbound issuer"):
+        build_resource_server_auth(
+            ResourceServerSettings(resource_server_url=_RESOURCE),
+            JwtValidationSettings(),
+            default_issuer_url=None,
+        )

--- a/packages/mcp/tests/auth/test_resource_server.py
+++ b/packages/mcp/tests/auth/test_resource_server.py
@@ -22,7 +22,6 @@ class _StubValidator:
     def __init__(self, *, claims: dict[str, Any] | None = None, raises: bool = False):
         self._claims = claims or {}
         self._raises = raises
-        self.audience = _AUDIENCE
 
     def validate(self, token: str) -> dict[str, Any]:
         if self._raises:
@@ -40,7 +39,9 @@ async def test_maps_claims_to_access_token() -> None:
             "exp": 1893456000,
         }
     )
-    token = await JwtTokenVerifier(validator).verify_token("the-token")
+    token = await JwtTokenVerifier(validator, resource=_AUDIENCE).verify_token(
+        "the-token"
+    )
     assert token is not None
     assert token.token == "the-token"
     assert token.client_id == "client-abc"

--- a/packages/mcp/tests/auth/test_resource_server.py
+++ b/packages/mcp/tests/auth/test_resource_server.py
@@ -1,0 +1,76 @@
+"""Unit tests for the resource-server adapter: claims -> AccessToken, reject -> None.
+
+The JWT/JWKS validation itself is covered in ``pipefy_auth``'s
+``test_verification.py``. These tests use a stub validator to pin the adapter's
+two jobs: mapping validated claims onto the SDK ``AccessToken`` and turning a
+validation failure into ``None`` (which FastMCP renders as a 401).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pipefy_auth import TokenValidationError
+
+from pipefy_mcp.auth import JwtTokenVerifier
+
+_AUDIENCE = "https://mcp.example.com/mcp"
+
+
+class _StubValidator:
+    def __init__(self, *, claims: dict[str, Any] | None = None, raises: bool = False):
+        self._claims = claims or {}
+        self._raises = raises
+        self.audience = _AUDIENCE
+
+    def validate(self, token: str) -> dict[str, Any]:
+        if self._raises:
+            raise TokenValidationError("bad token")
+        return self._claims
+
+
+@pytest.mark.unit
+async def test_maps_claims_to_access_token() -> None:
+    validator = _StubValidator(
+        claims={
+            "azp": "client-abc",
+            "sub": "user-123",
+            "scope": "read write",
+            "exp": 1893456000,
+        }
+    )
+    token = await JwtTokenVerifier(validator).verify_token("the-token")
+    assert token is not None
+    assert token.token == "the-token"
+    assert token.client_id == "client-abc"
+    assert token.scopes == ["read", "write"]
+    assert token.expires_at == 1893456000
+    assert token.resource == _AUDIENCE
+
+
+@pytest.mark.unit
+async def test_client_id_falls_back_to_client_id_then_sub() -> None:
+    by_client_id = await JwtTokenVerifier(
+        _StubValidator(claims={"client_id": "cid", "sub": "user-123"})
+    ).verify_token("t")
+    assert by_client_id is not None and by_client_id.client_id == "cid"
+
+    by_sub = await JwtTokenVerifier(
+        _StubValidator(claims={"sub": "user-123"})
+    ).verify_token("t")
+    assert by_sub is not None and by_sub.client_id == "user-123"
+
+
+@pytest.mark.unit
+async def test_missing_scope_claim_yields_empty_scopes() -> None:
+    token = await JwtTokenVerifier(
+        _StubValidator(claims={"sub": "user-123"})
+    ).verify_token("t")
+    assert token is not None and token.scopes == []
+
+
+@pytest.mark.unit
+async def test_validation_failure_returns_none() -> None:
+    token = await JwtTokenVerifier(_StubValidator(raises=True)).verify_token("t")
+    assert token is None

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -7,7 +7,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_client_session,
 )
-from pipefy_auth import AuthSettings
+from pipefy_auth import AuthSettings, JwtValidationSettings
 from pipefy_sdk import PipefySettings
 
 from pipefy_mcp.server import (
@@ -26,18 +26,18 @@ _RS_RESOURCE = "https://mcp.example.com/mcp"
 
 
 def _resource_server_pair():
-    """An enabled resource-server (verifier, auth) pair with no network at build.
+    """A configured resource-server (verifier, auth) pair with no network at build.
 
     The explicit ``jwks_uri`` skips OIDC discovery; the unauthenticated-request
-    and metadata tests never decode a token, so the JWKS is never fetched.
+    and metadata tests never decode a token, so the JWKS is never fetched. The
+    inbound issuer comes from ``default_issuer_url`` (the login issuer) to exercise
+    the same-realm default rather than an explicit override.
     """
-    rs = ResourceServerSettings(
-        enabled=True,
-        issuer_url=_RS_ISSUER,
-        resource_server_url=_RS_RESOURCE,
-        jwks_uri="https://idp.example.com/jwks",
+    return _build_resource_server_auth(
+        ResourceServerSettings(resource_server_url=_RS_RESOURCE),
+        JwtValidationSettings(jwks_uri="https://idp.example.com/jwks"),
+        default_issuer_url=_RS_ISSUER,
     )
-    return _build_resource_server_auth(rs)
 
 
 _MINIMAL_PIPEFY_SETTINGS = Settings(
@@ -213,7 +213,7 @@ async def test_lifespan_logs_error_when_initialization_raises():
 @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
 def test_loopback_http_bind_allows_loopback_hosts(host):
     # Does not raise, regardless of the resource-server profile.
-    _assert_loopback_http_bind(host=host, resource_server_enabled=False)
+    _assert_loopback_http_bind(host=host, resource_server_configured=False)
 
 
 @pytest.mark.unit
@@ -221,14 +221,14 @@ def test_loopback_http_bind_allows_loopback_hosts(host):
 def test_loopback_http_bind_refuses_non_loopback_hosts(host):
     """A non-loopback bind is refused while the transport is unauthenticated."""
     with pytest.raises(RuntimeError, match="non-loopback host"):
-        _assert_loopback_http_bind(host=host, resource_server_enabled=False)
+        _assert_loopback_http_bind(host=host, resource_server_configured=False)
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize("host", ["0.0.0.0", "203.0.113.5"])
-def test_loopback_http_bind_allows_non_loopback_when_resource_server_enabled(host):
-    """With inbound bearer validation on, a non-loopback bind is allowed (#301)."""
-    _assert_loopback_http_bind(host=host, resource_server_enabled=True)
+def test_loopback_http_bind_allows_non_loopback_when_resource_server_configured(host):
+    """With inbound bearer validation on, a non-loopback bind is allowed."""
+    _assert_loopback_http_bind(host=host, resource_server_configured=True)
 
 
 @pytest.mark.unit
@@ -295,7 +295,7 @@ def test_run_server_http_refuses_non_loopback_before_building():
     mock_build.assert_not_called()
 
 
-# --- Resource-server role (OAuth 2.0 inbound bearer validation, #301) --------
+# --- Resource-server role (OAuth 2.0 inbound bearer validation) --------------
 
 
 @pytest.mark.unit
@@ -313,6 +313,55 @@ def test_build_with_resource_server_wires_inbound_auth(mocked_container):
     )
     assert app.settings.auth is not None
     assert str(app.settings.auth.resource_server_url).rstrip("/") == _RS_RESOURCE
+
+
+@pytest.mark.unit
+def test_resource_server_inactive_when_unconfigured():
+    """No resource_server_url means no auth: the profile is off, not an error."""
+    assert (
+        _build_resource_server_auth(
+            ResourceServerSettings(),
+            JwtValidationSettings(),
+            default_issuer_url=_RS_ISSUER,
+        )
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_resource_server_issuer_defaults_to_login_issuer():
+    """With no inbound override, the inbound issuer is the login issuer."""
+    _, auth = _build_resource_server_auth(
+        ResourceServerSettings(resource_server_url=_RS_RESOURCE),
+        JwtValidationSettings(jwks_uri="https://idp.example.com/jwks"),
+        default_issuer_url=_RS_ISSUER,
+    )
+    assert str(auth.issuer_url).rstrip("/") == _RS_ISSUER
+
+
+@pytest.mark.unit
+def test_resource_server_inbound_issuer_overrides_login_issuer():
+    """An explicit inbound issuer wins over the login issuer."""
+    override = "https://other-idp.example.com/realms/y"
+    _, auth = _build_resource_server_auth(
+        ResourceServerSettings(resource_server_url=_RS_RESOURCE),
+        JwtValidationSettings(
+            issuer_url=override, jwks_uri="https://other-idp.example.com/jwks"
+        ),
+        default_issuer_url=_RS_ISSUER,
+    )
+    assert str(auth.issuer_url).rstrip("/") == override
+
+
+@pytest.mark.unit
+def test_resource_server_without_resolvable_issuer_raises():
+    """resource_server_url set but no issuer (override or login) is a misconfiguration."""
+    with pytest.raises(RuntimeError, match="no inbound issuer"):
+        _build_resource_server_auth(
+            ResourceServerSettings(resource_server_url=_RS_RESOURCE),
+            JwtValidationSettings(),
+            default_issuer_url=None,
+        )
 
 
 def _asgi_client(app):

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from mcp.server.fastmcp import FastMCP
 from mcp.shared.memory import (
@@ -11,13 +12,33 @@ from pipefy_sdk import PipefySettings
 
 from pipefy_mcp.server import (
     _assert_loopback_http_bind,
+    _build_resource_server_auth,
     _register_pipefy_tools,
     build_pipefy_mcp_server,
     lifespan,
     run_server,
 )
-from pipefy_mcp.settings import Settings
+from pipefy_mcp.settings import ResourceServerSettings, Settings
 from pipefy_mcp.tools.registry import PIPEFY_TOOL_NAMES
+
+_RS_ISSUER = "https://idp.example.com/realms/x"
+_RS_RESOURCE = "https://mcp.example.com/mcp"
+
+
+def _resource_server_pair():
+    """An enabled resource-server (verifier, auth) pair with no network at build.
+
+    The explicit ``jwks_uri`` skips OIDC discovery; the unauthenticated-request
+    and metadata tests never decode a token, so the JWKS is never fetched.
+    """
+    rs = ResourceServerSettings(
+        enabled=True,
+        issuer_url=_RS_ISSUER,
+        resource_server_url=_RS_RESOURCE,
+        jwks_uri="https://idp.example.com/jwks",
+    )
+    return _build_resource_server_auth(rs)
+
 
 _MINIMAL_PIPEFY_SETTINGS = Settings(
     pipefy=PipefySettings(base_url="https://api.pipefy.com"),
@@ -191,16 +212,23 @@ async def test_lifespan_logs_error_when_initialization_raises():
 @pytest.mark.unit
 @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
 def test_loopback_http_bind_allows_loopback_hosts(host):
-    # Does not raise.
-    _assert_loopback_http_bind(host=host)
+    # Does not raise, regardless of the resource-server profile.
+    _assert_loopback_http_bind(host=host, resource_server_enabled=False)
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize("host", ["0.0.0.0", "203.0.113.5"])
 def test_loopback_http_bind_refuses_non_loopback_hosts(host):
-    """A non-loopback bind is refused outright; the tool profile cannot exempt it."""
+    """A non-loopback bind is refused while the transport is unauthenticated."""
     with pytest.raises(RuntimeError, match="non-loopback host"):
-        _assert_loopback_http_bind(host=host)
+        _assert_loopback_http_bind(host=host, resource_server_enabled=False)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("host", ["0.0.0.0", "203.0.113.5"])
+def test_loopback_http_bind_allows_non_loopback_when_resource_server_enabled(host):
+    """With inbound bearer validation on, a non-loopback bind is allowed (#301)."""
+    _assert_loopback_http_bind(host=host, resource_server_enabled=True)
 
 
 @pytest.mark.unit
@@ -215,7 +243,9 @@ def test_run_server_http_builds_the_app_and_serves_over_streamable_http():
     ):
         run_server(http=True, host="127.0.0.1", port=9123, remote_mode=True)
 
-    mock_build.assert_called_once_with(remote_mode=True, host="127.0.0.1", port=9123)
+    mock_build.assert_called_once_with(
+        remote_mode=True, host="127.0.0.1", port=9123, resource_server=None
+    )
     fake_app.run.assert_called_once_with("streamable-http")
 
 
@@ -263,3 +293,61 @@ def test_run_server_http_refuses_non_loopback_before_building():
             run_server(http=True, host="0.0.0.0", port=9123, remote_mode=True)
 
     mock_build.assert_not_called()
+
+
+# --- Resource-server role (OAuth 2.0 inbound bearer validation, #301) --------
+
+
+@pytest.mark.unit
+def test_stdio_build_has_no_inbound_auth(mocked_container):
+    """The stdio profile builds with no inbound auth wired into FastMCP."""
+    app = build_pipefy_mcp_server(remote_mode=False)
+    assert app.settings.auth is None
+
+
+@pytest.mark.unit
+def test_build_with_resource_server_wires_inbound_auth(mocked_container):
+    """An enabled resource-server pair wires FastMCP's auth + token verifier."""
+    app = build_pipefy_mcp_server(
+        remote_mode=True, resource_server=_resource_server_pair()
+    )
+    assert app.settings.auth is not None
+    assert str(app.settings.auth.resource_server_url).rstrip("/") == _RS_RESOURCE
+
+
+def _asgi_client(app):
+    transport = httpx.ASGITransport(app=app.streamable_http_app())
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.mark.unit
+async def test_http_unauthenticated_request_gets_401_challenge(mocked_container):
+    """A request with no bearer is rejected with a 401 + WWW-Authenticate challenge.
+
+    The auth middleware runs before the MCP handler, so no session (and no
+    network) is needed: the challenge points at the protected-resource metadata.
+    """
+    app = build_pipefy_mcp_server(
+        remote_mode=True, resource_server=_resource_server_pair()
+    )
+    async with _asgi_client(app) as client:
+        resp = await client.post(
+            "/mcp", json={"jsonrpc": "2.0", "method": "ping", "id": 1}
+        )
+    assert resp.status_code == 401
+    assert "resource_metadata=" in resp.headers["www-authenticate"]
+
+
+@pytest.mark.unit
+async def test_http_serves_protected_resource_metadata(mocked_container):
+    """The RFC 9728 metadata route is served at the resource's well-known path."""
+    app = build_pipefy_mcp_server(
+        remote_mode=True, resource_server=_resource_server_pair()
+    )
+    async with _asgi_client(app) as client:
+        resp = await client.get("/.well-known/oauth-protected-resource/mcp")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["resource"].rstrip("/") == _RS_RESOURCE
+    advertised = [s.rstrip("/") for s in body["authorization_servers"]]
+    assert _RS_ISSUER in advertised

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -10,9 +10,9 @@ from mcp.shared.memory import (
 from pipefy_auth import AuthSettings, JwtValidationSettings
 from pipefy_sdk import PipefySettings
 
+from pipefy_mcp.auth import build_resource_server_auth
 from pipefy_mcp.server import (
     _assert_safe_http_bind,
-    _build_resource_server_auth,
     _register_pipefy_tools,
     build_pipefy_mcp_server,
     lifespan,
@@ -33,7 +33,7 @@ def _resource_server_pair():
     inbound issuer comes from ``default_issuer_url`` (the login issuer) to exercise
     the same-realm default rather than an explicit override.
     """
-    return _build_resource_server_auth(
+    return build_resource_server_auth(
         ResourceServerSettings(resource_server_url=_RS_RESOURCE),
         JwtValidationSettings(jwks_uri="https://idp.example.com/jwks"),
         default_issuer_url=_RS_ISSUER,
@@ -313,75 +313,6 @@ def test_build_with_resource_server_wires_inbound_auth(mocked_container):
     )
     assert app.settings.auth is not None
     assert str(app.settings.auth.resource_server_url).rstrip("/") == _RS_RESOURCE
-
-
-@pytest.mark.unit
-def test_resource_server_stamps_resource_server_url_not_audience():
-    """The verifier stamps this server's resource_server_url onto AccessToken.
-
-    The RFC 9728 metadata advertises resource_server_url as the resource, so the
-    token's stamped resource must match it, not the (often unset) audience.
-    """
-    verifier, _ = _build_resource_server_auth(
-        ResourceServerSettings(resource_server_url=_RS_RESOURCE),
-        # audience set and distinct from resource_server_url: the stamped resource
-        # must follow resource_server_url, not audience.
-        JwtValidationSettings(
-            audience="urn:some-other-audience",
-            jwks_uri="https://idp.example.com/jwks",
-        ),
-        default_issuer_url=_RS_ISSUER,
-    )
-    assert verifier._resource == _RS_RESOURCE
-
-
-@pytest.mark.unit
-def test_resource_server_inactive_when_unconfigured():
-    """No resource_server_url means no auth: the profile is off, not an error."""
-    assert (
-        _build_resource_server_auth(
-            ResourceServerSettings(),
-            JwtValidationSettings(),
-            default_issuer_url=_RS_ISSUER,
-        )
-        is None
-    )
-
-
-@pytest.mark.unit
-def test_resource_server_issuer_defaults_to_login_issuer():
-    """With no inbound override, the inbound issuer is the login issuer."""
-    _, auth = _build_resource_server_auth(
-        ResourceServerSettings(resource_server_url=_RS_RESOURCE),
-        JwtValidationSettings(jwks_uri="https://idp.example.com/jwks"),
-        default_issuer_url=_RS_ISSUER,
-    )
-    assert str(auth.issuer_url).rstrip("/") == _RS_ISSUER
-
-
-@pytest.mark.unit
-def test_resource_server_inbound_issuer_overrides_login_issuer():
-    """An explicit inbound issuer wins over the login issuer."""
-    override = "https://other-idp.example.com/realms/y"
-    _, auth = _build_resource_server_auth(
-        ResourceServerSettings(resource_server_url=_RS_RESOURCE),
-        JwtValidationSettings(
-            issuer_url=override, jwks_uri="https://other-idp.example.com/jwks"
-        ),
-        default_issuer_url=_RS_ISSUER,
-    )
-    assert str(auth.issuer_url).rstrip("/") == override
-
-
-@pytest.mark.unit
-def test_resource_server_without_resolvable_issuer_raises():
-    """resource_server_url set but no issuer (override or login) is a misconfiguration."""
-    with pytest.raises(RuntimeError, match="no inbound issuer"):
-        _build_resource_server_auth(
-            ResourceServerSettings(resource_server_url=_RS_RESOURCE),
-            JwtValidationSettings(),
-            default_issuer_url=None,
-        )
 
 
 def _asgi_client(app):

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -316,6 +316,26 @@ def test_build_with_resource_server_wires_inbound_auth(mocked_container):
 
 
 @pytest.mark.unit
+def test_resource_server_stamps_resource_server_url_not_audience():
+    """The verifier stamps this server's resource_server_url onto AccessToken.
+
+    The RFC 9728 metadata advertises resource_server_url as the resource, so the
+    token's stamped resource must match it, not the (often unset) audience.
+    """
+    verifier, _ = _build_resource_server_auth(
+        ResourceServerSettings(resource_server_url=_RS_RESOURCE),
+        # audience set and distinct from resource_server_url: the stamped resource
+        # must follow resource_server_url, not audience.
+        JwtValidationSettings(
+            audience="urn:some-other-audience",
+            jwks_uri="https://idp.example.com/jwks",
+        ),
+        default_issuer_url=_RS_ISSUER,
+    )
+    assert verifier._resource == _RS_RESOURCE
+
+
+@pytest.mark.unit
 def test_resource_server_inactive_when_unconfigured():
     """No resource_server_url means no auth: the profile is off, not an error."""
     assert (

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -212,23 +212,15 @@ async def test_lifespan_logs_error_when_initialization_raises():
 @pytest.mark.unit
 @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
 def test_loopback_http_bind_allows_loopback_hosts(host):
-    # Does not raise, regardless of the resource-server profile.
-    _assert_safe_http_bind(host=host, resource_server_configured=False)
+    _assert_safe_http_bind(host=host)
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize("host", ["0.0.0.0", "203.0.113.5"])
 def test_loopback_http_bind_refuses_non_loopback_hosts(host):
-    """A non-loopback bind is refused while the transport is unauthenticated."""
+    """A non-loopback bind is refused until the hosted on-behalf-of profile lands."""
     with pytest.raises(RuntimeError, match="non-loopback host"):
-        _assert_safe_http_bind(host=host, resource_server_configured=False)
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize("host", ["0.0.0.0", "203.0.113.5"])
-def test_loopback_http_bind_allows_non_loopback_when_resource_server_configured(host):
-    """With inbound bearer validation on, a non-loopback bind is allowed."""
-    _assert_safe_http_bind(host=host, resource_server_configured=True)
+        _assert_safe_http_bind(host=host)
 
 
 @pytest.mark.unit

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -11,7 +11,7 @@ from pipefy_auth import AuthSettings, JwtValidationSettings
 from pipefy_sdk import PipefySettings
 
 from pipefy_mcp.server import (
-    _assert_loopback_http_bind,
+    _assert_safe_http_bind,
     _build_resource_server_auth,
     _register_pipefy_tools,
     build_pipefy_mcp_server,
@@ -213,7 +213,7 @@ async def test_lifespan_logs_error_when_initialization_raises():
 @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
 def test_loopback_http_bind_allows_loopback_hosts(host):
     # Does not raise, regardless of the resource-server profile.
-    _assert_loopback_http_bind(host=host, resource_server_configured=False)
+    _assert_safe_http_bind(host=host, resource_server_configured=False)
 
 
 @pytest.mark.unit
@@ -221,14 +221,14 @@ def test_loopback_http_bind_allows_loopback_hosts(host):
 def test_loopback_http_bind_refuses_non_loopback_hosts(host):
     """A non-loopback bind is refused while the transport is unauthenticated."""
     with pytest.raises(RuntimeError, match="non-loopback host"):
-        _assert_loopback_http_bind(host=host, resource_server_configured=False)
+        _assert_safe_http_bind(host=host, resource_server_configured=False)
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize("host", ["0.0.0.0", "203.0.113.5"])
 def test_loopback_http_bind_allows_non_loopback_when_resource_server_configured(host):
     """With inbound bearer validation on, a non-loopback bind is allowed."""
-    _assert_loopback_http_bind(host=host, resource_server_configured=True)
+    _assert_safe_http_bind(host=host, resource_server_configured=True)
 
 
 @pytest.mark.unit

--- a/uv.lock
+++ b/uv.lock
@@ -836,6 +836,7 @@ dependencies = [
     { name = "pipefy-infra" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
 ]
 
 [package.dev-dependencies]
@@ -854,6 +855,7 @@ requires-dist = [
     { name = "pipefy-infra", editable = "packages/infra" },
     { name = "pydantic", specifier = ">=2.13.4,<3" },
     { name = "pydantic-settings", specifier = ">=2.8.1" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Closes #301.

Makes the MCP HTTP transport (#300) optionally act as an OAuth 2.0 resource server. With the profile enabled it validates the inbound bearer on every request (RS256 via JWKS, issuer, expiry, and optional audience), serves the RFC 9728 protected-resource metadata, and returns `401` + `WWW-Authenticate` on a missing or invalid token. A malformed token is rejected (401), never surfaced as a 500. The server never resolves a global service identity for inbound validation.

This unblocks #302 (request-scoped identity, which consumes the validated token from the MCP auth context) and #307 (rate limiting keyed on the subject).

## In scope

- Per-request inbound bearer validation: signature against the issuer JWKS, issuer match, and a required `exp`; audience is checked when enabled.
- RFC 9728 protected-resource metadata and the `401` / `WWW-Authenticate` challenge, both served by FastMCP.
- Relaxing the loopback bind guard once the profile is enabled, since every request then carries a validated bearer.

## Out of scope

- Request-scoped on-behalf-of identity (#302). Even with a validated bearer, every call still runs as the single identity resolved at startup. The design does not preclude it: FastMCP auto-installs `AuthContextMiddleware`, so the validated token lands in `get_access_token()`.
- The configurable host / Origin allowlist for a proxied deployment (#303). Until it lands, an off-loopback bind has no DNS-rebinding protection, so treat off-loopback as a trusted-network deployment.

## Design

The validation core and the transport adapter are split across packages so the `mcp -> auth` dependency arrow stays one-way and no mcp-SDK type enters auth:

- `packages/auth` owns `JwtValidator`, a transport-agnostic primitive: it resolves the JWKS URL (explicit override or via OIDC discovery), builds a caching `PyJWKClient` once, decodes RS256 tokens, and returns raw claims or raises `TokenValidationError`. OIDC discovery now also exposes `jwks_uri`. Adds the `pyjwt[crypto]` dependency.
- `packages/mcp` owns `JwtTokenVerifier`, a thin adapter over `JwtValidator` that implements FastMCP's `TokenVerifier` protocol and maps validated claims onto the SDK's `AccessToken`. `ResourceServerSettings` (`settings.rs`, env prefix `PIPEFY_MCP_RS_`) carries the inbound issuer, audience, scopes, and public `resource_server_url`. `_build_resource_server_auth` wires the verifier and FastMCP's `AuthSettings` into the app.

`verify_audience` defaults `False` for the same-audience interim, which runs before the IdP issues an `aud` claim (open question #312). Production flips it on once the IdP maps `aud`; tests cover both directions.

## Configuration

Enable with `PIPEFY_MCP_RS_ENABLED=1`. Required when enabled: `PIPEFY_MCP_RS_ISSUER_URL` (inbound issuer that signs caller tokens) and `PIPEFY_MCP_RS_RESOURCE_SERVER_URL` (this server's public canonical URL, e.g. `https://mcp.pipefy.com/mcp`). Optional: `AUDIENCE`, `VERIFY_AUDIENCE`, `REQUIRED_SCOPES`, `JWKS_URI`, `ALLOW_INSECURE_URLS`.

## Tests

- auth: `jwks_uri` discovery parsing (present, absent, insecure rejected and allowed); `JwtValidator` over an in-test RSA keypair (valid, tampered, unknown key, expired, wrong issuer, wrong audience both directions, discovery-resolved `jwks_uri`).
- mcp: `JwtTokenVerifier` claim mapping (client_id fallback, list and string scopes, fractional `exp`, unmappable claims and validation failure return `None`); resource-server integration over `httpx.ASGITransport` (401 + `WWW-Authenticate`, metadata route 200, stdio has no auth, build wires auth); loopback guard relaxes when enabled.

All suites green; lint and format clean.
