### PR TITLE
refactor(auth,cli): parse auth methods into ResolvedAuth

### DIFF
--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -29,9 +29,6 @@ from pipefy_auth.refresh import (
     refresh_access_token,
 )
 from pipefy_auth.resolver import (
-    SERVICE_ACCOUNT_TIER,
-    STATIC_TOKEN_TIER,
-    STORED_SESSION_TIER,
     ResolvedAuth,
     ServiceAccount,
     ServiceAccountAuth,
@@ -78,9 +75,6 @@ __all__ = [
     "RevocationError",
     "RevocationUnsupportedError",
     "ResolvedAuth",
-    "SERVICE_ACCOUNT_TIER",
-    "STATIC_TOKEN_TIER",
-    "STORED_SESSION_TIER",
     "ServiceAccount",
     "ServiceAccountAuth",
     "SessionDeleteError",

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -35,7 +35,7 @@ from pipefy_auth.resolver import (
     StaticTokenAuth,
     StoredSessionAuth,
     build_httpx_auth,
-    detect_pipefy_tiers,
+    detect_pipefy_auth_methods,
     missing_auth_message,
     resolve_pipefy_auth,
 )
@@ -88,7 +88,7 @@ __all__ = [
     "build_httpx_auth",
     "configure_keychain_backend",
     "delete_session",
-    "detect_pipefy_tiers",
+    "detect_pipefy_auth_methods",
     "ensure_fresh_session",
     "fetch_provider_metadata",
     "keychain_backend_name",

--- a/packages/auth/src/pipefy_auth/identity.py
+++ b/packages/auth/src/pipefy_auth/identity.py
@@ -13,7 +13,7 @@ DEFAULT_AUTH_CLIENT_ID = "pipefy-cli"
 class OidcClient:
     """OIDC client identity: issuer URL + the public client id registered there.
 
-    Presence of an :class:`OidcClient` is what gates the stored-session tier
+    Presence of an :class:`OidcClient` is what gates the stored-session method
     of the credential precedence chain.
     """
 

--- a/packages/auth/src/pipefy_auth/resolver.py
+++ b/packages/auth/src/pipefy_auth/resolver.py
@@ -8,7 +8,7 @@ The chain is a fixed three-slot tuple — consumers do not extend it:
 3. ``stored-session`` — keychain session populated by ``pipefy auth login``.
 
 The flag-vs-env distinction the CLI surfaces in ``pipefy auth status`` is a
-display concern handled in CLI code, not a tier here.
+display concern handled in CLI code, not an auth method here.
 """
 
 from __future__ import annotations
@@ -30,7 +30,7 @@ from pipefy_auth.storage import load_session
 
 @dataclass(frozen=True)
 class ServiceAccount:
-    """OAuth2 client-credentials inputs for the service-account tier."""
+    """OAuth2 client-credentials inputs for the service-account auth method."""
 
     token_url: str
     client_id: str
@@ -39,21 +39,21 @@ class ServiceAccount:
 
 @dataclass(frozen=True)
 class StaticTokenAuth:
-    """Resolved static-token tier: a pre-issued bearer, stripped and non-blank."""
+    """Resolved static-token method: a pre-issued bearer, stripped and non-blank."""
 
     token: str = field(repr=False)
 
 
 @dataclass(frozen=True)
 class ServiceAccountAuth:
-    """Resolved service-account tier: the OAuth2 client-credentials inputs."""
+    """Resolved service-account method: the OAuth2 client-credentials inputs."""
 
     credentials: ServiceAccount
 
 
 @dataclass(frozen=True)
 class StoredSessionAuth:
-    """Resolved stored-session tier: the OIDC client whose keychain session was found.
+    """Resolved stored-session method: the OIDC client whose keychain session was found.
 
     ``oidc_client`` is non-None by construction: :func:`resolve_pipefy_auth` only
     builds this variant once a keychain session is present, so consumers reach it
@@ -63,7 +63,7 @@ class StoredSessionAuth:
     oidc_client: OidcClient
 
 
-# The credential precedence chain, parsed into the tier that won:
+# The credential precedence chain, parsed into the auth method that won:
 # :func:`resolve_pipefy_auth` produces it, :func:`build_httpx_auth` consumes it.
 ResolvedAuth = StaticTokenAuth | ServiceAccountAuth | StoredSessionAuth
 
@@ -106,22 +106,22 @@ def resolve_pipefy_auth(
     service_account: ServiceAccount | None = None,
     oidc_client: OidcClient | None = None,
 ) -> ResolvedAuth | None:
-    """Parse the available credentials into the highest-precedence tier that resolves.
+    """Parse the available credentials into the highest-precedence auth method.
 
-    Short-circuits at the first tier that resolves; lower tiers are never
-    inspected. The returned :data:`ResolvedAuth` variant carries the tier
-    identity in its type; pass it to :func:`build_httpx_auth` to obtain the
-    transport's ``httpx.Auth``.
+    Short-circuits at the first method that resolves; lower-precedence methods
+    are never inspected. The returned :data:`ResolvedAuth` variant carries the
+    method's identity in its type; pass it to :func:`build_httpx_auth` to obtain
+    the transport's ``httpx.Auth``.
 
-    For an enumeration of every detected tier (e.g. for diagnostics), call
-    :func:`detect_pipefy_tiers` instead.
+    For an enumeration of every detected auth method (e.g. for diagnostics),
+    call :func:`detect_pipefy_auth_methods` instead.
 
     Args:
-        static_token: Pre-resolved bearer for the static-token tier. Consumers
+        static_token: Pre-resolved bearer for the static-token method. Consumers
             collapse their own per-source precedence (e.g. CLI ``--token`` flag
             vs ``PIPEFY_TOKEN`` env var) into one value before calling.
         service_account: Service-account client-credentials inputs.
-        oidc_client: OIDC client identity for the stored-session tier; the
+        oidc_client: OIDC client identity for the stored-session method; the
             session is loaded from the keychain at detection time.
     """
     if static_token and static_token.strip():
@@ -134,11 +134,11 @@ def resolve_pipefy_auth(
 
 
 def build_httpx_auth(resolved: ResolvedAuth) -> Auth:
-    """Construct the ``httpx.Auth`` for an already-resolved tier.
+    """Construct the ``httpx.Auth`` for an already-resolved auth method.
 
     Total over :data:`ResolvedAuth`: the "no credentials" case is decided once,
     in :func:`resolve_pipefy_auth`, so this function has no ``None`` branch. The
-    stored-session tier fetches a fresh access token per request via
+    stored-session method fetches a fresh access token per request via
     :class:`pipefy_auth.bearer.RefreshableBearerAuth`, which also forces a
     refresh + retry on a 401 response.
     """
@@ -157,28 +157,28 @@ def build_httpx_auth(resolved: ResolvedAuth) -> Auth:
             assert_never(resolved)
 
 
-def detect_pipefy_tiers(
+def detect_pipefy_auth_methods(
     *,
     static_token: str | None = None,
     service_account: ServiceAccount | None = None,
     oidc_client: OidcClient | None = None,
 ) -> list[ResolvedAuth]:
-    """Return every tier with credentials available, highest-precedence first.
+    """Return every auth method with credentials available, precedence-first.
 
     The non-short-circuiting sibling of :func:`resolve_pipefy_auth`: it parses
-    each configured tier into the same :data:`ResolvedAuth` variant rather than
-    stopping at the winner, so ``pipefy auth status`` can surface masked sources
-    alongside the active one. Runs every tier's detection, including the
-    keychain read for the stored-session tier.
+    each configured method into the same :data:`ResolvedAuth` variant rather
+    than stopping at the winner, so ``pipefy auth status`` can surface masked
+    methods alongside the active one. Runs every method's detection, including
+    the keychain read for the stored-session method.
     """
-    detected: list[ResolvedAuth] = []
+    methods: list[ResolvedAuth] = []
     if static_token and static_token.strip():
-        detected.append(StaticTokenAuth(static_token.strip()))
+        methods.append(StaticTokenAuth(static_token.strip()))
     if service_account is not None:
-        detected.append(ServiceAccountAuth(service_account))
+        methods.append(ServiceAccountAuth(service_account))
     if oidc_client is not None and _has_stored_session(oidc_client):
-        detected.append(StoredSessionAuth(oidc_client))
-    return detected
+        methods.append(StoredSessionAuth(oidc_client))
+    return methods
 
 
 def missing_auth_message(*, login_command: str = "pipefy auth login") -> str:
@@ -196,7 +196,7 @@ __all__ = [
     "StaticTokenAuth",
     "StoredSessionAuth",
     "build_httpx_auth",
-    "detect_pipefy_tiers",
+    "detect_pipefy_auth_methods",
     "missing_auth_message",
     "resolve_pipefy_auth",
 ]

--- a/packages/auth/src/pipefy_auth/resolver.py
+++ b/packages/auth/src/pipefy_auth/resolver.py
@@ -13,6 +13,7 @@ display concern handled in CLI code, not an auth method here.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import assert_never
 
@@ -100,6 +101,29 @@ def _has_stored_session(oidc_client: OidcClient) -> bool:
     )
 
 
+def _detected_methods(
+    *,
+    static_token: str | None,
+    service_account: ServiceAccount | None,
+    oidc_client: OidcClient | None,
+) -> Iterator[ResolvedAuth]:
+    """Yield each configured auth method, highest precedence first.
+
+    The single source of both precedence order and per-method gate logic:
+    :func:`resolve_pipefy_auth` takes the first item, :func:`detect_pipefy_auth_methods`
+    takes them all. Lazy by design, so ``resolve``'s short-circuit falls out of
+    generator suspension: pulling only the first item stops the body at that
+    ``yield``, leaving lower gates (including the stored-session keychain read)
+    unevaluated.
+    """
+    if static_token and static_token.strip():
+        yield StaticTokenAuth(static_token.strip())
+    if service_account is not None:
+        yield ServiceAccountAuth(service_account)
+    if oidc_client is not None and _has_stored_session(oidc_client):
+        yield StoredSessionAuth(oidc_client)
+
+
 def resolve_pipefy_auth(
     *,
     static_token: str | None = None,
@@ -114,7 +138,8 @@ def resolve_pipefy_auth(
     the transport's ``httpx.Auth``.
 
     For an enumeration of every detected auth method (e.g. for diagnostics),
-    call :func:`detect_pipefy_auth_methods` instead.
+    call :func:`detect_pipefy_auth_methods` instead. The two share
+    :func:`_detected_methods`, so this always equals that function's first entry.
 
     Args:
         static_token: Pre-resolved bearer for the static-token method. Consumers
@@ -124,13 +149,14 @@ def resolve_pipefy_auth(
         oidc_client: OIDC client identity for the stored-session method; the
             session is loaded from the keychain at detection time.
     """
-    if static_token and static_token.strip():
-        return StaticTokenAuth(static_token.strip())
-    if service_account is not None:
-        return ServiceAccountAuth(service_account)
-    if oidc_client is not None and _has_stored_session(oidc_client):
-        return StoredSessionAuth(oidc_client)
-    return None
+    return next(
+        _detected_methods(
+            static_token=static_token,
+            service_account=service_account,
+            oidc_client=oidc_client,
+        ),
+        None,
+    )
 
 
 def build_httpx_auth(resolved: ResolvedAuth) -> Auth:
@@ -169,16 +195,17 @@ def detect_pipefy_auth_methods(
     each configured method into the same :data:`ResolvedAuth` variant rather
     than stopping at the winner, so ``pipefy auth status`` can surface masked
     methods alongside the active one. Runs every method's detection, including
-    the keychain read for the stored-session method.
+    the keychain read for the stored-session method. The first entry is always
+    the method :func:`resolve_pipefy_auth` returns; both draw from
+    :func:`_detected_methods`.
     """
-    methods: list[ResolvedAuth] = []
-    if static_token and static_token.strip():
-        methods.append(StaticTokenAuth(static_token.strip()))
-    if service_account is not None:
-        methods.append(ServiceAccountAuth(service_account))
-    if oidc_client is not None and _has_stored_session(oidc_client):
-        methods.append(StoredSessionAuth(oidc_client))
-    return methods
+    return list(
+        _detected_methods(
+            static_token=static_token,
+            service_account=service_account,
+            oidc_client=oidc_client,
+        )
+    )
 
 
 def missing_auth_message(*, login_command: str = "pipefy auth login") -> str:

--- a/packages/auth/src/pipefy_auth/resolver.py
+++ b/packages/auth/src/pipefy_auth/resolver.py
@@ -166,20 +166,22 @@ def detect_pipefy_tiers(
     static_token: str | None = None,
     service_account: ServiceAccount | None = None,
     oidc_client: OidcClient | None = None,
-) -> list[str]:
+) -> list[ResolvedAuth]:
     """Return every tier with credentials available, highest-precedence first.
 
-    Used by ``pipefy auth status`` to surface masked sources alongside the
-    winner. Does not short-circuit — every tier's detection runs (including
-    the keychain read for the stored-session tier).
+    The non-short-circuiting sibling of :func:`resolve_pipefy_auth`: it parses
+    each configured tier into the same :data:`ResolvedAuth` variant rather than
+    stopping at the winner, so ``pipefy auth status`` can surface masked sources
+    alongside the active one. Runs every tier's detection, including the
+    keychain read for the stored-session tier.
     """
-    detected: list[str] = []
+    detected: list[ResolvedAuth] = []
     if static_token and static_token.strip():
-        detected.append(STATIC_TOKEN_TIER)
+        detected.append(StaticTokenAuth(static_token.strip()))
     if service_account is not None:
-        detected.append(SERVICE_ACCOUNT_TIER)
+        detected.append(ServiceAccountAuth(service_account))
     if oidc_client is not None and _has_stored_session(oidc_client):
-        detected.append(STORED_SESSION_TIER)
+        detected.append(StoredSessionAuth(oidc_client))
     return detected
 
 

--- a/packages/auth/src/pipefy_auth/resolver.py
+++ b/packages/auth/src/pipefy_auth/resolver.py
@@ -27,10 +27,6 @@ from pipefy_auth.identity import OidcClient
 from pipefy_auth.refresh import RefreshError, ensure_fresh_session
 from pipefy_auth.storage import load_session
 
-STATIC_TOKEN_TIER = "static-token"
-SERVICE_ACCOUNT_TIER = "service-account"
-STORED_SESSION_TIER = "stored-session"
-
 
 @dataclass(frozen=True)
 class ServiceAccount:
@@ -194,9 +190,6 @@ def missing_auth_message(*, login_command: str = "pipefy auth login") -> str:
 
 
 __all__ = [
-    "SERVICE_ACCOUNT_TIER",
-    "STATIC_TOKEN_TIER",
-    "STORED_SESSION_TIER",
     "ResolvedAuth",
     "ServiceAccount",
     "ServiceAccountAuth",

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -5,7 +5,7 @@ Owns every value that describes *how* to authenticate against Pipefy:
 * ``PIPEFY_SERVICE_ACCOUNT_CLIENT_ID`` / ``PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET``
   — OAuth2 client-credentials grant inputs (legacy ``PIPEFY_OAUTH_CLIENT`` /
   ``_SECRET`` names still honoured via :class:`AliasChoices`).
-* ``PIPEFY_AUTH_URL`` — full OIDC issuer URL for the stored-session method
+* ``PIPEFY_AUTH_URL``: full OIDC issuer URL for the stored-session method
   (default ``https://signin.pipefy.com/realms/pipefy``).
 * ``PIPEFY_AUTH_CLIENT_ID`` — OIDC public client id (defaults to
   :data:`pipefy_auth.identity.DEFAULT_AUTH_CLIENT_ID`).

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -5,7 +5,7 @@ Owns every value that describes *how* to authenticate against Pipefy:
 * ``PIPEFY_SERVICE_ACCOUNT_CLIENT_ID`` / ``PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET``
   — OAuth2 client-credentials grant inputs (legacy ``PIPEFY_OAUTH_CLIENT`` /
   ``_SECRET`` names still honoured via :class:`AliasChoices`).
-* ``PIPEFY_AUTH_URL`` — full OIDC issuer URL for the stored-session tier
+* ``PIPEFY_AUTH_URL`` — full OIDC issuer URL for the stored-session method
   (default ``https://signin.pipefy.com/realms/pipefy``).
 * ``PIPEFY_AUTH_CLIENT_ID`` — OIDC public client id (defaults to
   :data:`pipefy_auth.identity.DEFAULT_AUTH_CLIENT_ID`).
@@ -212,7 +212,7 @@ class AuthSettings(BaseSettings):
         pattern=_OPAQUE_CREDENTIAL_PATTERN,
         validation_alias=AliasChoices("PIPEFY_TOKEN"),
         description=(
-            "Pre-issued bearer for the static-token tier (env: PIPEFY_TOKEN). "
+            "Pre-issued bearer for the static-token method (env: PIPEFY_TOKEN). "
             "When set, outranks both the service-account triple and any stored session."
         ),
     )
@@ -247,7 +247,7 @@ class AuthSettings(BaseSettings):
         default=DEFAULT_AUTH_URL,
         pattern=security.URL_SHAPE_PATTERN,
         description=(
-            "OIDC issuer URL for the stored-session tier "
+            "OIDC issuer URL for the stored-session method "
             "(env: PIPEFY_AUTH_URL). Defaults to "
             f"'{DEFAULT_AUTH_URL}' (canonical Pipefy production IdP). Set to "
             "the full issuer URL for a non-prod IdP."
@@ -294,7 +294,7 @@ class AuthSettings(BaseSettings):
         default=False,
         description=(
             "When true (env: PIPEFY_DISABLE_STORED_SESSION), the stored-session "
-            "tier is never probed: ``to_oidc_client()`` returns None, tier "
+            "method is never probed: ``to_oidc_client()`` returns None, method "
             "resolution skips the keychain, and ``pipefy auth login`` refuses. "
             "Use to avoid the keychain backend-discovery cost on cold start "
             "(headless Linux, CI) or to opt out of OS-keychain storage entirely."
@@ -316,7 +316,7 @@ class AuthSettings(BaseSettings):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def service_account_url(self) -> str:
-        """OAuth 2.0 token endpoint for the service-account tier."""
+        """OAuth 2.0 token endpoint for the service-account method."""
         return f"{self.base_url.rstrip('/')}/oauth/token"
 
     def to_service_account(self) -> ServiceAccount | None:
@@ -337,7 +337,7 @@ class AuthSettings(BaseSettings):
         """Project the OIDC fields into an :class:`OidcClient`.
 
         Returns ``None`` when :attr:`disable_stored_session` is set: callers
-        treat that as "the stored-session tier is off" without inspecting any
+        treat that as "the stored-session method is off" without inspecting any
         OIDC field. Otherwise returns a real client because ``auth_url`` has
         a non-empty default.
         """

--- a/packages/auth/tests/test_resolver.py
+++ b/packages/auth/tests/test_resolver.py
@@ -201,6 +201,31 @@ def test_detect_skips_tiers_without_credentials(monkeypatch):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "static_token": "T",
+            "service_account": _service_account(),
+            "oidc_client": _oidc(),
+        },
+        {"service_account": _service_account(), "oidc_client": _oidc()},
+        {"oidc_client": _oidc()},
+        {},
+    ],
+)
+def test_detect_head_is_the_resolved_method(monkeypatch, kwargs):
+    """``auth status`` treats ``detect(...)[0]`` as active; both draw from the
+    same generator, so its head equals ``resolve(...)`` (and empty ⟺ ``None``)."""
+    monkeypatch.setattr(
+        "pipefy_auth.resolver.load_session", lambda **_: _stored_session()
+    )
+    methods = detect_pipefy_auth_methods(**kwargs)
+    resolved = resolve_pipefy_auth(**kwargs)
+    assert (methods[0] if methods else None) == resolved
+
+
+@pytest.mark.unit
 def test_missing_auth_message_mentions_all_tiers():
     msg = missing_auth_message()
     assert "PIPEFY_TOKEN" in msg

--- a/packages/auth/tests/test_resolver.py
+++ b/packages/auth/tests/test_resolver.py
@@ -14,9 +14,6 @@ from pipefy_auth.bearer import (
 from pipefy_auth.identity import OidcClient
 from pipefy_auth.refresh import RefreshError
 from pipefy_auth.resolver import (
-    SERVICE_ACCOUNT_TIER,
-    STATIC_TOKEN_TIER,
-    STORED_SESSION_TIER,
     ServiceAccount,
     ServiceAccountAuth,
     StaticTokenAuth,
@@ -151,7 +148,7 @@ def test_detect_omits_stored_session_when_oidc_client_is_none(monkeypatch):
         service_account=_service_account(),
         oidc_client=None,
     )
-    assert tiers == [STATIC_TOKEN_TIER, SERVICE_ACCOUNT_TIER]
+    assert [type(tier) for tier in tiers] == [StaticTokenAuth, ServiceAccountAuth]
 
 
 @pytest.mark.unit
@@ -187,10 +184,10 @@ def test_detect_lists_every_configured_tier_in_precedence_order(monkeypatch):
         service_account=_service_account(),
         oidc_client=_oidc(),
     )
-    assert tiers == [
-        STATIC_TOKEN_TIER,
-        SERVICE_ACCOUNT_TIER,
-        STORED_SESSION_TIER,
+    assert [type(tier) for tier in tiers] == [
+        StaticTokenAuth,
+        ServiceAccountAuth,
+        StoredSessionAuth,
     ]
 
 
@@ -198,7 +195,7 @@ def test_detect_lists_every_configured_tier_in_precedence_order(monkeypatch):
 def test_detect_skips_tiers_without_credentials(monkeypatch):
     monkeypatch.setattr("pipefy_auth.resolver.load_session", lambda **_: None)
     tiers = detect_pipefy_tiers(static_token="T", service_account=_service_account())
-    assert tiers == [STATIC_TOKEN_TIER, SERVICE_ACCOUNT_TIER]
+    assert [type(tier) for tier in tiers] == [StaticTokenAuth, ServiceAccountAuth]
 
 
 @pytest.mark.unit

--- a/packages/auth/tests/test_resolver.py
+++ b/packages/auth/tests/test_resolver.py
@@ -19,7 +19,7 @@ from pipefy_auth.resolver import (
     StaticTokenAuth,
     StoredSessionAuth,
     build_httpx_auth,
-    detect_pipefy_tiers,
+    detect_pipefy_auth_methods,
     missing_auth_message,
     resolve_pipefy_auth,
 )
@@ -137,18 +137,18 @@ def test_resolver_skips_stored_session_when_oidc_client_is_none(monkeypatch):
 
 @pytest.mark.unit
 def test_detect_omits_stored_session_when_oidc_client_is_none(monkeypatch):
-    """``detect_pipefy_tiers`` skips the stored-session probe with no client."""
+    """``detect_pipefy_auth_methods`` skips the stored-session probe with no client."""
 
     def _poison(**_kwargs):
         raise AssertionError("load_session must not be called when oidc_client is None")
 
     monkeypatch.setattr("pipefy_auth.resolver.load_session", _poison)
-    tiers = detect_pipefy_tiers(
+    methods = detect_pipefy_auth_methods(
         static_token="T",
         service_account=_service_account(),
         oidc_client=None,
     )
-    assert [type(tier) for tier in tiers] == [StaticTokenAuth, ServiceAccountAuth]
+    assert [type(method) for method in methods] == [StaticTokenAuth, ServiceAccountAuth]
 
 
 @pytest.mark.unit
@@ -179,12 +179,12 @@ def test_detect_lists_every_configured_tier_in_precedence_order(monkeypatch):
     monkeypatch.setattr(
         "pipefy_auth.resolver.load_session", lambda **_: _stored_session()
     )
-    tiers = detect_pipefy_tiers(
+    methods = detect_pipefy_auth_methods(
         static_token="T",
         service_account=_service_account(),
         oidc_client=_oidc(),
     )
-    assert [type(tier) for tier in tiers] == [
+    assert [type(method) for method in methods] == [
         StaticTokenAuth,
         ServiceAccountAuth,
         StoredSessionAuth,
@@ -194,8 +194,10 @@ def test_detect_lists_every_configured_tier_in_precedence_order(monkeypatch):
 @pytest.mark.unit
 def test_detect_skips_tiers_without_credentials(monkeypatch):
     monkeypatch.setattr("pipefy_auth.resolver.load_session", lambda **_: None)
-    tiers = detect_pipefy_tiers(static_token="T", service_account=_service_account())
-    assert [type(tier) for tier in tiers] == [StaticTokenAuth, ServiceAccountAuth]
+    methods = detect_pipefy_auth_methods(
+        static_token="T", service_account=_service_account()
+    )
+    assert [type(method) for method in methods] == [StaticTokenAuth, ServiceAccountAuth]
 
 
 @pytest.mark.unit

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -24,7 +24,7 @@ from pipefy_auth import (
     StaticTokenAuth,
     StoredSessionAuth,
     build_httpx_auth,
-    detect_pipefy_tiers,
+    detect_pipefy_auth_methods,
     ensure_fresh_session,
     missing_auth_message,
     resolve_pipefy_auth,
@@ -37,14 +37,14 @@ from pipefy_sdk import (
 from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 
 # Display labels for ``pipefy auth status``. The resolver knows the
-# static-token tier; the CLI restores the flag-vs-env distinction here.
+# static-token method; the CLI restores the flag-vs-env distinction here.
 FLAG_TOKEN_SOURCE: Final = "flag-token"
 ENV_TOKEN_SOURCE: Final = "env-token"
 
-# Locked JSON wire schema for ``pipefy auth status``: the resolver tier names,
-# with the static-token tier split into the CLI's flag-vs-env surfaces, plus an
-# explicit ``"none"`` sentinel for when no tier resolved. Produced by
-# :func:`detect_cli_sources` / :func:`_to_display_source`; ``commands.auth``
+# Locked JSON wire schema for ``pipefy auth status``: the auth-method names,
+# with the static-token method split into the CLI's flag-vs-env surfaces, plus
+# an explicit ``"none"`` sentinel for when no method resolved. Produced by
+# :func:`detect_cli_auth_methods` / :func:`_to_display_source`; ``commands.auth``
 # renders it.
 DisplaySource = Literal[
     "flag-token",
@@ -67,13 +67,13 @@ class BearerToken:
 class AuthContext:
     """Auth inputs for a single CLI invocation.
 
-    Each field maps to one resolver tier (bearer-token, service-account,
+    Each field maps to one auth method (bearer-token, service-account,
     stored-session). Built once at startup from the loaded
     :class:`pipefy_auth.AuthSettings` plus the per-invocation ``--token`` /
     ``PIPEFY_TOKEN`` resolution.
 
     ``oidc_client`` is ``None`` only when ``AuthSettings.disable_stored_session``
-    is set (env: PIPEFY_DISABLE_STORED_SESSION); the stored-session tier is
+    is set (env: PIPEFY_DISABLE_STORED_SESSION); the stored-session method is
     then skipped end-to-end. Otherwise ``auth_url`` defaults to the prod IdP
     and the client is always present.
     """
@@ -107,10 +107,10 @@ def _resolve(auth: AuthContext) -> ResolvedAuth | None:
 def to_display_source(
     resolved: ResolvedAuth, bearer: BearerToken | None
 ) -> DisplaySource:
-    """Map a resolved tier to its locked ``auth status`` wire value.
+    """Map a resolved auth method to its locked ``auth status`` wire value.
 
-    The static-token tier splits into the flag-vs-env distinction the CLI
-    surfaces; the other tiers map to their resolver wire name unchanged.
+    The static-token method splits into the flag-vs-env distinction the CLI
+    surfaces; the other methods map to their resolver wire name unchanged.
     """
     match resolved:
         case StaticTokenAuth():
@@ -127,14 +127,14 @@ def to_display_source(
             assert_never(resolved)
 
 
-def detect_cli_sources(auth: AuthContext) -> list[ResolvedAuth]:
-    """Return the detected resolver tiers for a CLI invocation, precedence-first.
+def detect_cli_auth_methods(auth: AuthContext) -> list[ResolvedAuth]:
+    """Return the detected auth methods for a CLI invocation, precedence-first.
 
-    The non-short-circuiting view of the chain: every configured tier, not just
-    the winner. ``pipefy auth status`` renders each via :func:`to_display_source`
-    and treats the first as the active source.
+    The non-short-circuiting view of the chain: every configured method, not
+    just the winner. ``pipefy auth status`` renders each via
+    :func:`to_display_source` and treats the first as the active source.
     """
-    return detect_pipefy_tiers(
+    return detect_pipefy_auth_methods(
         static_token=auth.bearer_token.value if auth.bearer_token else None,
         service_account=auth.service_account,
         oidc_client=auth.oidc_client,
@@ -151,8 +151,8 @@ def _cache_key(
     token, the service-account ``client_secret`` — don't linger in module
     state for the process lifetime. Adding a new field to
     :class:`PipefySettings` or :class:`AuthContext` automatically participates
-    in the key without touching this function. The resolved tier is omitted: it
-    is a pure function of the auth fields above, so it adds no distinction.
+    in the key without touching this function. The resolved method is omitted:
+    it is a pure function of the auth fields above, so it adds no distinction.
     """
     payload = json.dumps(
         {
@@ -218,7 +218,7 @@ __all__ = [
     "ENV_TOKEN_SOURCE",
     "FLAG_TOKEN_SOURCE",
     "clear_authenticated_client_cache",
-    "detect_cli_sources",
+    "detect_cli_auth_methods",
     "get_authenticated_client",
     "to_display_source",
 ]

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -96,8 +96,7 @@ def clear_authenticated_client_cache() -> None:
     _cached_client = None
 
 
-def resolve_cli_auth(auth: AuthContext) -> ResolvedAuth | None:
-    """Resolve the highest-precedence tier for a CLI invocation, or ``None``."""
+def _resolve(auth: AuthContext) -> ResolvedAuth | None:
     return resolve_pipefy_auth(
         static_token=auth.bearer_token.value if auth.bearer_token else None,
         service_account=auth.service_account,
@@ -105,7 +104,7 @@ def resolve_cli_auth(auth: AuthContext) -> ResolvedAuth | None:
     )
 
 
-def _to_display_source(
+def to_display_source(
     resolved: ResolvedAuth, bearer: BearerToken | None
 ) -> DisplaySource:
     """Map a resolved tier to its locked ``auth status`` wire value.
@@ -128,16 +127,18 @@ def _to_display_source(
             assert_never(resolved)
 
 
-def detect_cli_sources(auth: AuthContext) -> list[DisplaySource]:
-    """Return detected sources mapped to CLI display labels, precedence-first."""
-    return [
-        _to_display_source(resolved, auth.bearer_token)
-        for resolved in detect_pipefy_tiers(
-            static_token=auth.bearer_token.value if auth.bearer_token else None,
-            service_account=auth.service_account,
-            oidc_client=auth.oidc_client,
-        )
-    ]
+def detect_cli_sources(auth: AuthContext) -> list[ResolvedAuth]:
+    """Return the detected resolver tiers for a CLI invocation, precedence-first.
+
+    The non-short-circuiting view of the chain: every configured tier, not just
+    the winner. ``pipefy auth status`` renders each via :func:`to_display_source`
+    and treats the first as the active source.
+    """
+    return detect_pipefy_tiers(
+        static_token=auth.bearer_token.value if auth.bearer_token else None,
+        service_account=auth.service_account,
+        oidc_client=auth.oidc_client,
+    )
 
 
 def _cache_key(
@@ -176,7 +177,7 @@ def get_authenticated_client(
     """
     global _cached_signature, _cached_client
 
-    resolved = resolve_cli_auth(auth)
+    resolved = _resolve(auth)
     if resolved is None:
         typer.echo(f"{missing_auth_message()} See {DOCS_CLI_AUTH_REF}.", err=True)
         raise typer.Exit(2)
@@ -219,5 +220,5 @@ __all__ = [
     "clear_authenticated_client_cache",
     "detect_cli_sources",
     "get_authenticated_client",
-    "resolve_cli_auth",
+    "to_display_source",
 ]

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import asdict, dataclass, field
-from typing import Final, Literal, assert_never
+from typing import Any, Final, Literal, assert_never
 
 import typer
 from pipefy_auth import (
@@ -44,7 +44,7 @@ ENV_TOKEN_SOURCE: Final = "env-token"
 # Locked JSON wire schema for ``pipefy auth status``: the auth-method names,
 # with the static-token method split into the CLI's flag-vs-env surfaces, plus
 # an explicit ``"none"`` sentinel for when no method resolved. Produced by
-# :func:`detect_cli_auth_methods` / :func:`_to_display_source`; ``commands.auth``
+# :func:`detect_cli_auth_methods` / :func:`to_display_source`; ``commands.auth``
 # renders it.
 DisplaySource = Literal[
     "flag-token",
@@ -96,12 +96,17 @@ def clear_authenticated_client_cache() -> None:
     _cached_client = None
 
 
+def _resolver_kwargs(auth: AuthContext) -> dict[str, Any]:
+    """Map an :class:`AuthContext` onto the keyword inputs the resolver takes."""
+    return {
+        "static_token": auth.bearer_token.value if auth.bearer_token else None,
+        "service_account": auth.service_account,
+        "oidc_client": auth.oidc_client,
+    }
+
+
 def _resolve(auth: AuthContext) -> ResolvedAuth | None:
-    return resolve_pipefy_auth(
-        static_token=auth.bearer_token.value if auth.bearer_token else None,
-        service_account=auth.service_account,
-        oidc_client=auth.oidc_client,
-    )
+    return resolve_pipefy_auth(**_resolver_kwargs(auth))
 
 
 def to_display_source(
@@ -134,11 +139,7 @@ def detect_cli_auth_methods(auth: AuthContext) -> list[ResolvedAuth]:
     just the winner. ``pipefy auth status`` renders each via
     :func:`to_display_source` and treats the first as the active source.
     """
-    return detect_pipefy_auth_methods(
-        static_token=auth.bearer_token.value if auth.bearer_token else None,
-        service_account=auth.service_account,
-        oidc_client=auth.oidc_client,
-    )
+    return detect_pipefy_auth_methods(**_resolver_kwargs(auth))
 
 
 def _cache_key(

--- a/packages/cli/src/pipefy_cli/auth.py
+++ b/packages/cli/src/pipefy_cli/auth.py
@@ -12,15 +12,16 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import asdict, dataclass, field
-from typing import Literal
+from typing import Final, Literal, assert_never
 
 import typer
 from pipefy_auth import (
-    STATIC_TOKEN_TIER,
     OidcClient,
     RefreshError,
     ResolvedAuth,
     ServiceAccount,
+    ServiceAccountAuth,
+    StaticTokenAuth,
     StoredSessionAuth,
     build_httpx_auth,
     detect_pipefy_tiers,
@@ -37,8 +38,21 @@ from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 
 # Display labels for ``pipefy auth status``. The resolver knows the
 # static-token tier; the CLI restores the flag-vs-env distinction here.
-FLAG_TOKEN_SOURCE = "flag-token"
-ENV_TOKEN_SOURCE = "env-token"
+FLAG_TOKEN_SOURCE: Final = "flag-token"
+ENV_TOKEN_SOURCE: Final = "env-token"
+
+# Locked JSON wire schema for ``pipefy auth status``: the resolver tier names,
+# with the static-token tier split into the CLI's flag-vs-env surfaces, plus an
+# explicit ``"none"`` sentinel for when no tier resolved. Produced by
+# :func:`detect_cli_sources` / :func:`_to_display_source`; ``commands.auth``
+# renders it.
+DisplaySource = Literal[
+    "flag-token",
+    "env-token",
+    "service-account",
+    "stored-session",
+    "none",
+]
 
 
 @dataclass(frozen=True)
@@ -82,7 +96,8 @@ def clear_authenticated_client_cache() -> None:
     _cached_client = None
 
 
-def _resolve(auth: AuthContext) -> ResolvedAuth | None:
+def resolve_cli_auth(auth: AuthContext) -> ResolvedAuth | None:
+    """Resolve the highest-precedence tier for a CLI invocation, or ``None``."""
     return resolve_pipefy_auth(
         static_token=auth.bearer_token.value if auth.bearer_token else None,
         service_account=auth.service_account,
@@ -90,25 +105,39 @@ def _resolve(auth: AuthContext) -> ResolvedAuth | None:
     )
 
 
-def _to_display_source(tier: str, bearer: BearerToken | None) -> str:
-    """Map a resolver tier name to the locked JSON wire schema for ``auth status``."""
-    if tier == STATIC_TOKEN_TIER:
-        return (
-            FLAG_TOKEN_SOURCE
-            if bearer and bearer.source == "flag"
-            else ENV_TOKEN_SOURCE
+def _to_display_source(
+    resolved: ResolvedAuth, bearer: BearerToken | None
+) -> DisplaySource:
+    """Map a resolved tier to its locked ``auth status`` wire value.
+
+    The static-token tier splits into the flag-vs-env distinction the CLI
+    surfaces; the other tiers map to their resolver wire name unchanged.
+    """
+    match resolved:
+        case StaticTokenAuth():
+            return (
+                FLAG_TOKEN_SOURCE
+                if bearer and bearer.source == "flag"
+                else ENV_TOKEN_SOURCE
+            )
+        case ServiceAccountAuth():
+            return "service-account"
+        case StoredSessionAuth():
+            return "stored-session"
+        case _:
+            assert_never(resolved)
+
+
+def detect_cli_sources(auth: AuthContext) -> list[DisplaySource]:
+    """Return detected sources mapped to CLI display labels, precedence-first."""
+    return [
+        _to_display_source(resolved, auth.bearer_token)
+        for resolved in detect_pipefy_tiers(
+            static_token=auth.bearer_token.value if auth.bearer_token else None,
+            service_account=auth.service_account,
+            oidc_client=auth.oidc_client,
         )
-    return tier
-
-
-def detect_cli_sources(auth: AuthContext) -> list[str]:
-    """Return detected sources mapped to CLI display labels."""
-    detected = detect_pipefy_tiers(
-        static_token=auth.bearer_token.value if auth.bearer_token else None,
-        service_account=auth.service_account,
-        oidc_client=auth.oidc_client,
-    )
-    return [_to_display_source(tier, auth.bearer_token) for tier in detected]
+    ]
 
 
 def _cache_key(
@@ -147,7 +176,7 @@ def get_authenticated_client(
     """
     global _cached_signature, _cached_client
 
-    resolved = _resolve(auth)
+    resolved = resolve_cli_auth(auth)
     if resolved is None:
         typer.echo(f"{missing_auth_message()} See {DOCS_CLI_AUTH_REF}.", err=True)
         raise typer.Exit(2)
@@ -184,9 +213,11 @@ def get_authenticated_client(
 __all__ = [
     "AuthContext",
     "BearerToken",
+    "DisplaySource",
     "ENV_TOKEN_SOURCE",
     "FLAG_TOKEN_SOURCE",
     "clear_authenticated_client_cache",
     "detect_cli_sources",
     "get_authenticated_client",
+    "resolve_cli_auth",
 ]

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -23,6 +23,7 @@ from pipefy_auth import (
     RevocationError,
     RevocationUnsupportedError,
     SessionDeleteError,
+    StoredSessionAuth,
     delete_session,
     ensure_fresh_session,
     keychain_backend_name,
@@ -37,23 +38,13 @@ from pipefy_sdk import MePayload, PipefySettings
 from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 from pipefy_cli.auth import (
     AuthContext,
+    DisplaySource,
     detect_cli_sources,
     get_authenticated_client,
+    resolve_cli_auth,
 )
 from pipefy_cli.commands._common import settings_and_auth_from_ctx
 from pipefy_cli.output import render_json
-
-# Locked JSON wire schema. Matches the policy ``name`` field produced by
-# :func:`pipefy_cli.auth.build_policies` (so the resolver's identifiers reach
-# the wire unchanged), plus an explicit ``"none"`` sentinel for the case where
-# no policy resolved.
-DisplaySource = Literal[
-    "flag-token",
-    "env-token",
-    "service-account",
-    "stored-session",
-    "none",
-]
 
 AuthSessionState = Literal["active", "refresh-expired", "needs-login", "n/a"]
 
@@ -429,13 +420,7 @@ def auth_status(
 ) -> None:
     """Print which auth source is active, the authenticated identity, and session expiry."""
     settings, auth = settings_and_auth_from_ctx(ctx)
-    detected_names = detect_cli_sources(auth)
-    # The locked JSON wire schema matches the policy names exactly; cast for
-    # typing only — values are already constrained by ``build_policies``.
-    detected: list[DisplaySource] = [
-        name  # type: ignore[misc]
-        for name in detected_names
-    ]
+    detected = detect_cli_sources(auth)
     source: DisplaySource = detected[0] if detected else "none"
     report = AuthStatusReport(auth_source=source, detected_sources=detected)
     # Surface masking env vars whenever a stored session exists — that's the
@@ -447,16 +432,12 @@ def auth_status(
     try:
         if source == "none":
             raise _StatusExit(report=report, exit_code=2)
-        if source == "stored-session":
-            if auth.oidc_client is None:
-                # ``stored-session`` only enters ``detected`` when ``oidc_client``
-                # is non-None (resolver gates the tier on it); reaching here
-                # means that invariant is broken.
-                raise RuntimeError(
-                    "stored-session detected without an OIDC client "
-                    "(resolver invariant broken)."
-                )
-            _populate_stored_session(report, auth.oidc_client)
+        # The active source is the resolver's winner; a StoredSessionAuth carries
+        # its OIDC client by construction, so populating session details needs no
+        # presence check.
+        active = resolve_cli_auth(auth)
+        if isinstance(active, StoredSessionAuth):
+            _populate_stored_session(report, active.oidc_client)
         _fetch_identity(report, settings, auth)
     except _StatusExit as exit_:
         _render(exit_.report, json_out=json_out)

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -39,7 +39,7 @@ from pipefy_cli._docs import DOCS_CLI_AUTH_REF
 from pipefy_cli.auth import (
     AuthContext,
     DisplaySource,
-    detect_cli_sources,
+    detect_cli_auth_methods,
     get_authenticated_client,
     to_display_source,
 )
@@ -420,19 +420,19 @@ def auth_status(
 ) -> None:
     """Print which auth source is active, the authenticated identity, and session expiry."""
     settings, auth = settings_and_auth_from_ctx(ctx)
-    tiers = detect_cli_sources(auth)
-    detected: list[DisplaySource] = [
-        to_display_source(tier, auth.bearer_token) for tier in tiers
+    auth_methods = detect_cli_auth_methods(auth)
+    detected_sources: list[DisplaySource] = [
+        to_display_source(method, auth.bearer_token) for method in auth_methods
     ]
-    # Precedence-first, so the head is the active source and the same winner the
+    # Precedence-first, so the head is the active method and the same winner the
     # resolver would pick, without a second resolve pass.
-    active = tiers[0] if tiers else None
-    source: DisplaySource = detected[0] if detected else "none"
-    report = AuthStatusReport(auth_source=source, detected_sources=detected)
+    active = auth_methods[0] if auth_methods else None
+    source: DisplaySource = detected_sources[0] if detected_sources else "none"
+    report = AuthStatusReport(auth_source=source, detected_sources=detected_sources)
     # Surface masking env vars whenever a stored session exists: that's the
     # CI-overrides-keychain failure mode the field is for, and the higher-
     # precedence winner is the case where it matters.
-    if any(isinstance(tier, StoredSessionAuth) for tier in tiers):
+    if any(isinstance(method, StoredSessionAuth) for method in auth_methods):
         report.masking_env_vars = _session_masking_env_vars()
 
     try:

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -427,7 +427,9 @@ def auth_status(
     # Precedence-first, so the head is the active method and the same winner the
     # resolver would pick, without a second resolve pass.
     active = auth_methods[0] if auth_methods else None
-    source: DisplaySource = detected_sources[0] if detected_sources else "none"
+    source: DisplaySource = (
+        to_display_source(active, auth.bearer_token) if active else "none"
+    )
     report = AuthStatusReport(auth_source=source, detected_sources=detected_sources)
     # Surface masking env vars whenever a stored session exists: that's the
     # CI-overrides-keychain failure mode the field is for, and the higher-

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -41,7 +41,7 @@ from pipefy_cli.auth import (
     DisplaySource,
     detect_cli_sources,
     get_authenticated_client,
-    resolve_cli_auth,
+    to_display_source,
 )
 from pipefy_cli.commands._common import settings_and_auth_from_ctx
 from pipefy_cli.output import render_json
@@ -420,22 +420,26 @@ def auth_status(
 ) -> None:
     """Print which auth source is active, the authenticated identity, and session expiry."""
     settings, auth = settings_and_auth_from_ctx(ctx)
-    detected = detect_cli_sources(auth)
+    tiers = detect_cli_sources(auth)
+    detected: list[DisplaySource] = [
+        to_display_source(tier, auth.bearer_token) for tier in tiers
+    ]
+    # Precedence-first, so the head is the active source and the same winner the
+    # resolver would pick, without a second resolve pass.
+    active = tiers[0] if tiers else None
     source: DisplaySource = detected[0] if detected else "none"
     report = AuthStatusReport(auth_source=source, detected_sources=detected)
-    # Surface masking env vars whenever a stored session exists — that's the
+    # Surface masking env vars whenever a stored session exists: that's the
     # CI-overrides-keychain failure mode the field is for, and the higher-
     # precedence winner is the case where it matters.
-    if "stored-session" in detected:
+    if any(isinstance(tier, StoredSessionAuth) for tier in tiers):
         report.masking_env_vars = _session_masking_env_vars()
 
     try:
-        if source == "none":
+        if active is None:
             raise _StatusExit(report=report, exit_code=2)
-        # The active source is the resolver's winner; a StoredSessionAuth carries
-        # its OIDC client by construction, so populating session details needs no
-        # presence check.
-        active = resolve_cli_auth(auth)
+        # A StoredSessionAuth carries its OIDC client by construction, so
+        # populating session details needs no presence check.
         if isinstance(active, StoredSessionAuth):
             _populate_stored_session(report, active.oidc_client)
         _fetch_identity(report, settings, auth)

--- a/packages/cli/tests/test_auth.py
+++ b/packages/cli/tests/test_auth.py
@@ -12,6 +12,7 @@ from pipefy_auth import (
     RefreshableBearerAuth,
     ServiceAccount,
     StaticBearerAuth,
+    StaticTokenAuth,
     StoredSession,
     StoredSessionAuth,
     TokenResponse,
@@ -21,8 +22,8 @@ from pipefy_sdk import PipefySettings
 from pipefy_cli.auth import (
     AuthContext,
     BearerToken,
-    detect_cli_sources,
     get_authenticated_client,
+    to_display_source,
 )
 from pipefy_cli.main import app
 
@@ -146,16 +147,20 @@ def test_cli_uses_pipefy_token_env_when_no_flag(
 # --------------------------------------------------------------------------- #
 
 
-def test_detect_cli_sources_maps_static_token_to_flag_label(clean_pipefy_env):
+def test_to_display_source_maps_flag_token_to_flag_label():
     """``--token`` source surfaces as the locked ``flag-token`` wire value."""
-    sources = detect_cli_sources(_auth(bearer_token="t", bearer_source="flag"))
-    assert sources[0] == "flag-token"
+    source = to_display_source(
+        StaticTokenAuth("t"), BearerToken(value="t", source="flag")
+    )
+    assert source == "flag-token"
 
 
-def test_detect_cli_sources_maps_env_token_to_env_label(clean_pipefy_env):
+def test_to_display_source_maps_env_token_to_env_label():
     """``PIPEFY_TOKEN`` source surfaces as the locked ``env-token`` wire value."""
-    sources = detect_cli_sources(_auth(bearer_token="t", bearer_source="env"))
-    assert sources[0] == "env-token"
+    source = to_display_source(
+        StaticTokenAuth("t"), BearerToken(value="t", source="env")
+    )
+    assert source == "env-token"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Follows #343, which gave `resolve_pipefy_auth` a `ResolvedAuth` sum type but left its sibling `detect_pipefy_tiers` returning `list[str]` tier names. This finishes the migration.

## detect returns ResolvedAuth

The `list[str]` gap forced four awkward spots in the `pipefy auth status` path, all now resolved:

- `tier == STATIC_TOKEN_TIER` string compare, now a match on the variant in `to_display_source`
- a `# type: ignore[misc]` cast of the detected list to `DisplaySource`, now typed end to end
- an `auth.oidc_client is None` re-check raising an "invariant broken" `RuntimeError`, now gone: the OIDC client is read off a `StoredSessionAuth` that holds it by construction
- two ways to ask "is stored-session involved" (string membership vs isinstance), now isinstance throughout

`DisplaySource` moved next to the functions that produce it (`pipefy_cli.auth`), which also broke the import cycle behind the cast. The locked `auth status` JSON wire schema is unchanged.

A follow-up `/simplify` pass found the command still detected twice: it flattened to display strings, then re-resolved to recover the typed winner, running the precedence chain and its keychain probe twice. It now derives the display list, the active method (the precedence-first head), and the stored-session populate from one `list[ResolvedAuth]`. `resolve_pipefy_auth` keeps its own short-circuiting path: it must not probe the keychain when a higher-precedence token already wins, so it is not folded into the detect function. The now-dead `STATIC_TOKEN_TIER` / `SERVICE_ACCOUNT_TIER` / `STORED_SESSION_TIER` constants are removed (no consumers after the sum-type migration).

## Naming: "auth method" vs "tier"

`detect_pipefy_tiers` returned `list[ResolvedAuth]` but the CLI assigned it to a `tiers` variable from a `detect_cli_sources` function: one value wearing two labels, neither saying what it is. Each value is a way to authenticate, so it is now named that:

- `detect_pipefy_tiers` -> `detect_pipefy_auth_methods`
- `detect_cli_sources` -> `detect_cli_auth_methods` (it returns the resolved methods, not display sources)
- locals/loop vars: `tiers`/`tier` -> `auth_methods`/`method`

"tier" is kept where it means precedence rank ("short-circuits lower tiers"); "source" is kept for the CLI display labels (`DisplaySource`, `auth_source`). Kind and rank are now distinct words.

## Tests

`packages/auth` 175 passed, `packages/cli` 319 passed / 13 skipped, ruff clean. The wire-output tests and the display-label tests (on the now-public `to_display_source`) pass unchanged.
