### PR TITLE
refactor(auth): fold the inbound audience pair into an AudiencePolicy sum type

### DIFF
--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -60,10 +60,8 @@ from pipefy_auth.verification import (
     AudiencePolicy,
     JwtValidator,
     RequireAudience,
-    ResolvedJwtValidation,
     SkipAudience,
     TokenValidationError,
-    resolve_jwt_validation,
 )
 
 __all__ = [
@@ -71,9 +69,7 @@ __all__ = [
     "AuthSettings",
     "JwtValidationSettings",
     "RequireAudience",
-    "ResolvedJwtValidation",
     "SkipAudience",
-    "resolve_jwt_validation",
     "CallableBearerAuth",
     "DEFAULT_AUTH_CLIENT_ID",
     "DiscoveryPolicy",

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -56,11 +56,24 @@ from pipefy_auth.storage import (
     load_session,
     store_session,
 )
-from pipefy_auth.verification import JwtValidator, TokenValidationError
+from pipefy_auth.verification import (
+    AudiencePolicy,
+    JwtValidator,
+    RequireAudience,
+    ResolvedJwtValidation,
+    SkipAudience,
+    TokenValidationError,
+    resolve_jwt_validation,
+)
 
 __all__ = [
+    "AudiencePolicy",
     "AuthSettings",
     "JwtValidationSettings",
+    "RequireAudience",
+    "ResolvedJwtValidation",
+    "SkipAudience",
+    "resolve_jwt_validation",
     "CallableBearerAuth",
     "DEFAULT_AUTH_CLIENT_ID",
     "DiscoveryPolicy",

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -423,6 +423,16 @@ class JwtValidationSettings(BaseSettings):
             file_secret_settings,
         )
 
+    @field_validator("issuer_url", "audience", "jwks_uri", mode="before")
+    @classmethod
+    def _strip_str(cls, value: object) -> object:
+        # Mirror AuthSettings._strip_str: normalize once here so _validate_urls
+        # and resolve_jwt_validation read already-stripped values (env-var
+        # whitespace must not survive into jwt.decode's exact iss/aud compare).
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
     issuer_url: str | None = Field(
         default=None,
         description=(
@@ -475,20 +485,16 @@ class JwtValidationSettings(BaseSettings):
 
     @model_validator(mode="after")
     def _validate_urls(self) -> Self:
-        # Strip and shape-check both URL fields. Env-var whitespace would otherwise
-        # survive into the consumer: issuer_url into jwt.decode(issuer=...), which
-        # compares iss exactly, and jwks_uri into the JWKS fetch. A realm path is
-        # allowed, so only a query or fragment (which would corrupt URL building)
-        # is rejected.
+        # Shape-check both URL fields (already stripped by _strip_str). A realm
+        # path is allowed, so only a query or fragment (which would corrupt URL
+        # building) is rejected.
         for label in ("issuer_url", "jwks_uri"):
             value = getattr(self, label)
             if value is None:
                 continue
-            stripped = value.strip()
-            setattr(self, label, stripped)
-            security.assert_url_has_no_query_or_fragment(stripped, field_label=label)
+            security.assert_url_has_no_query_or_fragment(value, field_label=label)
             security.validate_https_url(
-                stripped, label, allow_insecure=self.allow_insecure_urls
+                value, label, allow_insecure=self.allow_insecure_urls
             )
         return self
 

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -427,8 +427,8 @@ class JwtValidationSettings(BaseSettings):
     @classmethod
     def _strip_str(cls, value: object) -> object:
         # Mirror AuthSettings._strip_str: normalize once here so _validate_urls
-        # and resolve_jwt_validation read already-stripped values (env-var
-        # whitespace must not survive into jwt.decode's exact iss/aud compare).
+        # and _validate_audience read already-stripped values (env-var whitespace
+        # must not survive into jwt.decode's exact iss/aud compare).
         if isinstance(value, str):
             return value.strip()
         return value
@@ -496,6 +496,17 @@ class JwtValidationSettings(BaseSettings):
             security.validate_https_url(
                 value, label, allow_insecure=self.allow_insecure_urls
             )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_audience(self) -> Self:
+        # verify_audience with no audience has nothing to check against: the two
+        # env vars only make sense together. Fail fast at construction (like
+        # _validate_urls) so the illegal pair never reaches the AudiencePolicy
+        # fold at the resource-server composition root. audience is already
+        # stripped by _strip_str, so a whitespace-only value collapses to "".
+        if self.verify_audience and not self.audience:
+            raise ValueError("verify_audience requires audience (PIPEFY_JWT_AUDIENCE).")
         return self
 
 

--- a/packages/auth/src/pipefy_auth/settings.py
+++ b/packages/auth/src/pipefy_auth/settings.py
@@ -474,9 +474,7 @@ class JwtValidationSettings(BaseSettings):
         return self.issuer_url or default
 
     @model_validator(mode="after")
-    def _validate_configuration(self) -> Self:
-        if self.verify_audience and not self.audience:
-            raise ValueError("verify_audience requires audience (PIPEFY_JWT_AUDIENCE).")
+    def _validate_urls(self) -> Self:
         # Strip and shape-check both URL fields. Env-var whitespace would otherwise
         # survive into the consumer: issuer_url into jwt.decode(issuer=...), which
         # compares iss exactly, and jwks_uri into the JWKS fetch. A realm path is

--- a/packages/auth/src/pipefy_auth/verification.py
+++ b/packages/auth/src/pipefy_auth/verification.py
@@ -16,7 +16,8 @@ offload :meth:`JwtValidator.validate` to a thread.
 from __future__ import annotations
 
 import threading
-from typing import Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, assert_never
 
 import jwt
 from jwt import PyJWKClient
@@ -24,7 +25,49 @@ from pipefy_infra import security
 
 from pipefy_auth.discovery import DiscoveryPolicy, fetch_provider_metadata
 
+if TYPE_CHECKING:
+    from pipefy_auth.settings import JwtValidationSettings
+
 _ALGORITHMS = ["RS256"]
+
+
+@dataclass(frozen=True)
+class SkipAudience:
+    """Do not check the ``aud`` claim.
+
+    The same-audience interim: it runs before the IdP issues an ``aud``, so
+    there is nothing to check against yet.
+    """
+
+
+@dataclass(frozen=True)
+class RequireAudience:
+    """Reject a token whose ``aud`` does not include ``audience``."""
+
+    audience: str
+
+
+# The two legal audience postures. "verify but against nothing" is unrepresentable:
+# RequireAudience cannot exist without its value, so JwtValidator is total over this
+# with no None branch and no separate verify flag.
+AudiencePolicy = SkipAudience | RequireAudience
+
+
+@dataclass(frozen=True)
+class ResolvedJwtValidation:
+    """Inbound-validation config after parsing, ready to build a :class:`JwtValidator`.
+
+    The frozen counterpart to the loose :class:`~pipefy_auth.JwtValidationSettings`
+    env reader: the audience posture is the :data:`AudiencePolicy` sum type (the
+    loose ``audience``/``verify_audience`` pair does not survive into this type),
+    and ``issuer_url`` is the resolved inbound issuer, not an override. Code holding
+    this may assume the cross-field rules already hold.
+    """
+
+    audience: AudiencePolicy
+    issuer_url: str
+    jwks_uri: str | None
+    allow_insecure_urls: bool
 
 
 class TokenValidationError(ValueError):
@@ -47,23 +90,30 @@ class JwtValidator:
     ``validate`` retries (the validator self-heals once the IdP is reachable). The
     underlying ``PyJWKClient`` caches signing keys across calls.
 
-    ``verify_audience`` is off by default: the same-audience interim runs before
-    the IdP issues an ``aud`` claim. Turn it on once the audience mapper is in
-    place; ``audience`` is then required by the caller.
+    The audience check is carried by ``audience_policy``: :class:`RequireAudience`
+    pins the expected ``aud``, :class:`SkipAudience` is the same-audience interim
+    (the default, before the IdP issues ``aud``). "Verify against a missing
+    audience" is unrepresentable, so :meth:`validate` needs no guard for it.
     """
 
     def __init__(
         self,
         *,
         issuer_url: str,
-        audience: str | None,
-        verify_audience: bool,
+        audience_policy: AudiencePolicy,
         allow_insecure_urls: bool = False,
         jwks_uri: str | None = None,
     ) -> None:
         self._issuer = issuer_url
-        self._audience = audience
-        self._verify_audience = verify_audience
+        # Resolve the fixed policy into jwt.decode kwargs once; validate() is the
+        # per-request hot path and the policy never changes after construction.
+        match audience_policy:
+            case RequireAudience(audience=expected):
+                self._audience, self._verify_aud = expected, True
+            case SkipAudience():
+                self._audience, self._verify_aud = None, False
+            case _:
+                assert_never(audience_policy)
         self._allow_insecure_urls = allow_insecure_urls
         # Guards the one-time lazy discovery in _jwks_client: validate() can run
         # concurrently, and a cold burst should resolve jwks_uri once rather than
@@ -148,10 +198,36 @@ class JwtValidator:
                 signing_key.key,
                 algorithms=_ALGORITHMS,
                 issuer=self._issuer,
-                audience=self._audience if self._verify_audience else None,
+                audience=self._audience,
                 # require exp so a token that simply omits it is rejected rather
                 # than treated as never-expiring (PyJWT only checks exp when present).
-                options={"verify_aud": self._verify_audience, "require": ["exp"]},
+                options={"verify_aud": self._verify_aud, "require": ["exp"]},
             )
         except Exception as exc:
             raise TokenValidationError(str(exc)) from exc
+
+
+def resolve_jwt_validation(
+    settings: JwtValidationSettings, *, issuer_url: str
+) -> ResolvedJwtValidation:
+    """Parse the loose env reader into the frozen inbound-validation config.
+
+    The audience parse step: the ``verify_audience`` / ``audience`` pair collapses
+    into an :data:`AudiencePolicy`, and the cross-field rule is enforced here once
+    (verifying against no audience is rejected) rather than re-checked downstream.
+    ``issuer_url`` is supplied already resolved: the override-vs-login-issuer
+    fallback and the "no issuer" error are the caller's concern (for the MCP
+    resource server, an inactive-vs-misconfigured distinction it must raise on).
+    """
+    if settings.verify_audience:
+        if not (settings.audience and settings.audience.strip()):
+            raise ValueError("verify_audience requires audience (PIPEFY_JWT_AUDIENCE).")
+        audience: AudiencePolicy = RequireAudience(settings.audience.strip())
+    else:
+        audience = SkipAudience()
+    return ResolvedJwtValidation(
+        audience=audience,
+        issuer_url=issuer_url,
+        jwks_uri=settings.jwks_uri,
+        allow_insecure_urls=settings.allow_insecure_urls,
+    )

--- a/packages/auth/src/pipefy_auth/verification.py
+++ b/packages/auth/src/pipefy_auth/verification.py
@@ -17,16 +17,13 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, assert_never
+from typing import Any, assert_never
 
 import jwt
 from jwt import PyJWKClient
 from pipefy_infra import security
 
 from pipefy_auth.discovery import DiscoveryPolicy, fetch_provider_metadata
-
-if TYPE_CHECKING:
-    from pipefy_auth.settings import JwtValidationSettings
 
 _ALGORITHMS = ["RS256"]
 
@@ -51,23 +48,6 @@ class RequireAudience:
 # RequireAudience cannot exist without its value, so JwtValidator is total over this
 # with no None branch and no separate verify flag.
 AudiencePolicy = SkipAudience | RequireAudience
-
-
-@dataclass(frozen=True)
-class ResolvedJwtValidation:
-    """Inbound-validation config after parsing, ready to build a :class:`JwtValidator`.
-
-    The frozen counterpart to the loose :class:`~pipefy_auth.JwtValidationSettings`
-    env reader: the audience posture is the :data:`AudiencePolicy` sum type (the
-    loose ``audience``/``verify_audience`` pair does not survive into this type),
-    and ``issuer_url`` is the resolved inbound issuer, not an override. Code holding
-    this may assume the cross-field rules already hold.
-    """
-
-    audience: AudiencePolicy
-    issuer_url: str
-    jwks_uri: str | None
-    allow_insecure_urls: bool
 
 
 class TokenValidationError(ValueError):
@@ -205,31 +185,3 @@ class JwtValidator:
             )
         except Exception as exc:
             raise TokenValidationError(str(exc)) from exc
-
-
-def resolve_jwt_validation(
-    settings: JwtValidationSettings, *, issuer_url: str
-) -> ResolvedJwtValidation:
-    """Parse the loose env reader into the frozen inbound-validation config.
-
-    The audience parse step: the ``verify_audience`` / ``audience`` pair collapses
-    into an :data:`AudiencePolicy`, and the cross-field rule is enforced here once
-    (verifying against no audience is rejected) rather than re-checked downstream.
-    ``issuer_url`` is supplied already resolved: the override-vs-login-issuer
-    fallback and the "no issuer" error are the caller's concern (for the MCP
-    resource server, an inactive-vs-misconfigured distinction it must raise on).
-    """
-    if settings.verify_audience:
-        # audience is already stripped by JwtValidationSettings._strip_str, so a
-        # whitespace-only value collapses to "" and is caught here.
-        if not settings.audience:
-            raise ValueError("verify_audience requires audience (PIPEFY_JWT_AUDIENCE).")
-        audience: AudiencePolicy = RequireAudience(settings.audience)
-    else:
-        audience = SkipAudience()
-    return ResolvedJwtValidation(
-        audience=audience,
-        issuer_url=issuer_url,
-        jwks_uri=settings.jwks_uri,
-        allow_insecure_urls=settings.allow_insecure_urls,
-    )

--- a/packages/auth/src/pipefy_auth/verification.py
+++ b/packages/auth/src/pipefy_auth/verification.py
@@ -220,9 +220,11 @@ def resolve_jwt_validation(
     resource server, an inactive-vs-misconfigured distinction it must raise on).
     """
     if settings.verify_audience:
-        if not (settings.audience and settings.audience.strip()):
+        # audience is already stripped by JwtValidationSettings._strip_str, so a
+        # whitespace-only value collapses to "" and is caught here.
+        if not settings.audience:
             raise ValueError("verify_audience requires audience (PIPEFY_JWT_AUDIENCE).")
-        audience: AudiencePolicy = RequireAudience(settings.audience.strip())
+        audience: AudiencePolicy = RequireAudience(settings.audience)
     else:
         audience = SkipAudience()
     return ResolvedJwtValidation(

--- a/packages/auth/tests/test_jwt_validation_settings.py
+++ b/packages/auth/tests/test_jwt_validation_settings.py
@@ -4,12 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from pipefy_auth import (
-    JwtValidationSettings,
-    RequireAudience,
-    SkipAudience,
-    resolve_jwt_validation,
-)
+from pipefy_auth import JwtValidationSettings
 
 _ISSUER = "https://idp.example.com/realms/x"
 
@@ -59,27 +54,18 @@ def test_resolve_issuer_url_is_none_when_neither_set():
 
 
 @pytest.mark.unit
-def test_resolve_defaults_to_skip_audience():
-    """No audience config parses to the skip posture, carrying the resolved issuer."""
-    resolved = resolve_jwt_validation(JwtValidationSettings(), issuer_url=_ISSUER)
-    assert resolved.audience == SkipAudience()
-    assert resolved.issuer_url == _ISSUER
-
-
-@pytest.mark.unit
-def test_resolve_verify_audience_requires_audience():
-    """Verifying without an audience is a misconfiguration, caught at the parse step."""
-    settings = JwtValidationSettings(verify_audience=True)
+def test_verify_audience_requires_audience():
+    """Verifying without an audience is a misconfiguration, caught at construction."""
     with pytest.raises(ValueError, match="verify_audience requires audience"):
-        resolve_jwt_validation(settings, issuer_url=_ISSUER)
+        JwtValidationSettings(verify_audience=True)
 
 
 @pytest.mark.unit
-def test_resolve_carries_the_required_audience():
-    """The valid pair parses into the sum type, so consumers never re-derive it."""
+def test_verify_audience_with_audience_constructs():
+    """The valid pair (verify on, audience present) is accepted at construction."""
     settings = JwtValidationSettings(audience="api://x", verify_audience=True)
-    resolved = resolve_jwt_validation(settings, issuer_url=_ISSUER)
-    assert resolved.audience == RequireAudience("api://x")
+    assert settings.verify_audience is True
+    assert settings.audience == "api://x"
 
 
 @pytest.mark.unit
@@ -91,11 +77,9 @@ def test_issuer_url_is_stripped():
 
 @pytest.mark.unit
 def test_audience_is_stripped_at_construction():
-    """audience is normalized by the reader, so the parsed policy carries no whitespace."""
+    """audience is normalized by the reader, so no consumer re-strips it."""
     settings = JwtValidationSettings(audience="  api://x  ", verify_audience=True)
     assert settings.audience == "api://x"
-    resolved = resolve_jwt_validation(settings, issuer_url=_ISSUER)
-    assert resolved.audience == RequireAudience("api://x")
 
 
 @pytest.mark.unit

--- a/packages/auth/tests/test_jwt_validation_settings.py
+++ b/packages/auth/tests/test_jwt_validation_settings.py
@@ -90,6 +90,15 @@ def test_issuer_url_is_stripped():
 
 
 @pytest.mark.unit
+def test_audience_is_stripped_at_construction():
+    """audience is normalized by the reader, so the parsed policy carries no whitespace."""
+    settings = JwtValidationSettings(audience="  api://x  ", verify_audience=True)
+    assert settings.audience == "api://x"
+    resolved = resolve_jwt_validation(settings, issuer_url=_ISSUER)
+    assert resolved.audience == RequireAudience("api://x")
+
+
+@pytest.mark.unit
 def test_issuer_url_rejects_query_or_fragment():
     """A query/fragment would corrupt the .well-known concatenation."""
     with pytest.raises(ValueError):

--- a/packages/auth/tests/test_jwt_validation_settings.py
+++ b/packages/auth/tests/test_jwt_validation_settings.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from pipefy_auth import JwtValidationSettings
+from pipefy_auth import (
+    JwtValidationSettings,
+    RequireAudience,
+    SkipAudience,
+    resolve_jwt_validation,
+)
 
 _ISSUER = "https://idp.example.com/realms/x"
 
@@ -54,10 +59,27 @@ def test_resolve_issuer_url_is_none_when_neither_set():
 
 
 @pytest.mark.unit
-def test_verify_audience_requires_audience():
-    """Turning on audience checks without an audience is a misconfiguration."""
+def test_resolve_defaults_to_skip_audience():
+    """No audience config parses to the skip posture, carrying the resolved issuer."""
+    resolved = resolve_jwt_validation(JwtValidationSettings(), issuer_url=_ISSUER)
+    assert resolved.audience == SkipAudience()
+    assert resolved.issuer_url == _ISSUER
+
+
+@pytest.mark.unit
+def test_resolve_verify_audience_requires_audience():
+    """Verifying without an audience is a misconfiguration, caught at the parse step."""
+    settings = JwtValidationSettings(verify_audience=True)
     with pytest.raises(ValueError, match="verify_audience requires audience"):
-        JwtValidationSettings(verify_audience=True)
+        resolve_jwt_validation(settings, issuer_url=_ISSUER)
+
+
+@pytest.mark.unit
+def test_resolve_carries_the_required_audience():
+    """The valid pair parses into the sum type, so consumers never re-derive it."""
+    settings = JwtValidationSettings(audience="api://x", verify_audience=True)
+    resolved = resolve_jwt_validation(settings, issuer_url=_ISSUER)
+    assert resolved.audience == RequireAudience("api://x")
 
 
 @pytest.mark.unit

--- a/packages/auth/tests/test_verification.py
+++ b/packages/auth/tests/test_verification.py
@@ -10,7 +10,12 @@ import jwt
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from pipefy_auth.verification import JwtValidator, TokenValidationError
+from pipefy_auth.verification import (
+    JwtValidator,
+    RequireAudience,
+    SkipAudience,
+    TokenValidationError,
+)
 
 _ISSUER = "https://idp.example.com/realms/pipefy"
 _AUDIENCE = "https://mcp.example.com/mcp"
@@ -45,8 +50,7 @@ def _validator(monkeypatch: pytest.MonkeyPatch, **kwargs: Any) -> JwtValidator:
     """
     defaults = {
         "issuer_url": _ISSUER,
-        "audience": _AUDIENCE,
-        "verify_audience": False,
+        "audience_policy": SkipAudience(),
         "jwks_uri": _JWKS_URI,
     }
     defaults.update(kwargs)
@@ -106,7 +110,7 @@ def test_wrong_issuer_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_wrong_audience_is_rejected_when_verifying(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    validator = _validator(monkeypatch, verify_audience=True)
+    validator = _validator(monkeypatch, audience_policy=RequireAudience(_AUDIENCE))
     with pytest.raises(TokenValidationError):
         validator.validate(_sign(_claims(aud="https://other.example.com")))
 
@@ -116,8 +120,8 @@ def test_wrong_audience_passes_when_not_verifying(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # The toggle: the same wrong-aud token the previous test rejects is accepted
-    # when verify_audience is off (the same-audience interim).
-    validator = _validator(monkeypatch, verify_audience=False)
+    # when audience verification is off (the same-audience interim).
+    validator = _validator(monkeypatch, audience_policy=SkipAudience())
     claims = validator.validate(_sign(_claims(aud="https://other.example.com")))
     assert claims["aud"] == "https://other.example.com"
 
@@ -131,9 +135,7 @@ def test_jwks_uri_resolved_from_discovery(monkeypatch: pytest.MonkeyPatch) -> No
         "pipefy_auth.verification.fetch_provider_metadata",
         lambda issuer_url, policy: metadata,
     )
-    validator = JwtValidator(
-        issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False
-    )
+    validator = JwtValidator(issuer_url=_ISSUER, audience_policy=SkipAudience())
     assert validator._jwks is None  # deferred, not resolved at construction
     assert validator._jwks_client().uri == _JWKS_URI
 
@@ -149,9 +151,7 @@ def test_discovery_path_does_no_network_at_construction(
         raise AssertionError("discovery must not run at construction")
 
     monkeypatch.setattr("pipefy_auth.verification.fetch_provider_metadata", _fail)
-    validator = JwtValidator(
-        issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False
-    )
+    validator = JwtValidator(issuer_url=_ISSUER, audience_policy=SkipAudience())
     assert validator._jwks is None
 
 
@@ -163,9 +163,7 @@ def test_discovery_without_jwks_uri_raises(monkeypatch: pytest.MonkeyPatch) -> N
         "pipefy_auth.verification.fetch_provider_metadata",
         lambda issuer_url, policy: SimpleNamespace(jwks_uri=None),
     )
-    validator = JwtValidator(
-        issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False
-    )
+    validator = JwtValidator(issuer_url=_ISSUER, audience_policy=SkipAudience())
     with pytest.raises(TokenValidationError, match="jwks_uri"):
         validator.validate(_sign(_claims()))
 
@@ -183,9 +181,7 @@ def test_discovery_failure_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> Non
         return SimpleNamespace(jwks_uri=_JWKS_URI)
 
     monkeypatch.setattr("pipefy_auth.verification.fetch_provider_metadata", _flaky)
-    validator = JwtValidator(
-        issuer_url=_ISSUER, audience=_AUDIENCE, verify_audience=False
-    )
+    validator = JwtValidator(issuer_url=_ISSUER, audience_policy=SkipAudience())
 
     with pytest.raises(TokenValidationError, match="transient discovery outage"):
         validator.validate(_sign(_claims()))
@@ -209,8 +205,7 @@ def test_explicit_http_jwks_uri_is_rejected() -> None:
     with pytest.raises(ValueError, match="jwks_uri"):
         JwtValidator(
             issuer_url=_ISSUER,
-            audience=_AUDIENCE,
-            verify_audience=False,
+            audience_policy=SkipAudience(),
             jwks_uri="http://idp.example.com/protocol/openid-connect/certs",
         )
 
@@ -220,8 +215,7 @@ def test_explicit_internal_host_jwks_uri_is_rejected() -> None:
     with pytest.raises(ValueError, match="jwks_uri"):
         JwtValidator(
             issuer_url=_ISSUER,
-            audience=_AUDIENCE,
-            verify_audience=False,
+            audience_policy=SkipAudience(),
             jwks_uri="https://127.0.0.1/certs",
         )
 
@@ -231,8 +225,7 @@ def test_explicit_jwks_uri_with_query_is_rejected() -> None:
     with pytest.raises(ValueError, match="jwks_uri"):
         JwtValidator(
             issuer_url=_ISSUER,
-            audience=_AUDIENCE,
-            verify_audience=False,
+            audience_policy=SkipAudience(),
             jwks_uri=f"{_JWKS_URI}?rotate=1",
         )
 
@@ -243,8 +236,7 @@ def test_explicit_insecure_jwks_uri_allowed_when_opted_in() -> None:
     # mirroring the discovery path's policy.
     validator = JwtValidator(
         issuer_url=_ISSUER,
-        audience=_AUDIENCE,
-        verify_audience=False,
+        audience_policy=SkipAudience(),
         allow_insecure_urls=True,
         jwks_uri="http://127.0.0.1/certs",
     )

--- a/packages/mcp/src/pipefy_mcp/auth/resource_server.py
+++ b/packages/mcp/src/pipefy_mcp/auth/resource_server.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.server.auth.settings import AuthSettings as FastMcpAuthSettings
-from pipefy_auth import JwtValidationSettings, JwtValidator
+from pipefy_auth import JwtValidationSettings, JwtValidator, resolve_jwt_validation
 
 from pipefy_mcp.settings import ResourceServerSettings
 
@@ -144,13 +144,13 @@ def build_resource_server_auth(
             "resolvable: set PIPEFY_JWT_ISSUER_URL, or leave the stored-session "
             "login enabled so its issuer can be reused."
         )
+    validation = resolve_jwt_validation(jwt_validation, issuer_url=issuer_url)
     verifier = JwtTokenVerifier(
         JwtValidator(
-            issuer_url=issuer_url,
-            audience=jwt_validation.audience,
-            verify_audience=jwt_validation.verify_audience,
-            allow_insecure_urls=jwt_validation.allow_insecure_urls,
-            jwks_uri=jwt_validation.jwks_uri,
+            issuer_url=validation.issuer_url,
+            audience_policy=validation.audience,
+            allow_insecure_urls=validation.allow_insecure_urls,
+            jwks_uri=validation.jwks_uri,
         ),
         resource=rs.resource_server_url,
     )

--- a/packages/mcp/src/pipefy_mcp/auth/resource_server.py
+++ b/packages/mcp/src/pipefy_mcp/auth/resource_server.py
@@ -26,7 +26,13 @@ from typing import Any
 
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.server.auth.settings import AuthSettings as FastMcpAuthSettings
-from pipefy_auth import JwtValidationSettings, JwtValidator, resolve_jwt_validation
+from pipefy_auth import (
+    AudiencePolicy,
+    JwtValidationSettings,
+    JwtValidator,
+    RequireAudience,
+    SkipAudience,
+)
 
 from pipefy_mcp.settings import ResourceServerSettings
 
@@ -144,13 +150,20 @@ def build_resource_server_auth(
             "resolvable: set PIPEFY_JWT_ISSUER_URL, or leave the stored-session "
             "login enabled so its issuer can be reused."
         )
-    validation = resolve_jwt_validation(jwt_validation, issuer_url=issuer_url)
+    # Fold the loose audience pair into the AudiencePolicy sum type. A
+    # verify-without-audience is already rejected at JwtValidationSettings
+    # construction, so `is not None` only narrows the Optional for the type
+    # checker here; it is never the deciding branch.
+    if jwt_validation.verify_audience and jwt_validation.audience is not None:
+        audience_policy: AudiencePolicy = RequireAudience(jwt_validation.audience)
+    else:
+        audience_policy = SkipAudience()
     verifier = JwtTokenVerifier(
         JwtValidator(
-            issuer_url=validation.issuer_url,
-            audience_policy=validation.audience,
-            allow_insecure_urls=validation.allow_insecure_urls,
-            jwks_uri=validation.jwks_uri,
+            issuer_url=issuer_url,
+            audience_policy=audience_policy,
+            allow_insecure_urls=jwt_validation.allow_insecure_urls,
+            jwks_uri=jwt_validation.jwks_uri,
         ),
         resource=rs.resource_server_url,
     )

--- a/packages/mcp/tests/auth/test_resource_server.py
+++ b/packages/mcp/tests/auth/test_resource_server.py
@@ -168,6 +168,34 @@ def test_build_stamps_resource_server_url_not_audience() -> None:
 
 
 @pytest.mark.unit
+def test_build_skips_audience_by_default() -> None:
+    """No audience config folds to SkipAudience: the validator does not check aud."""
+    verifier, _ = build_resource_server_auth(
+        ResourceServerSettings(resource_server_url=_RESOURCE),
+        JwtValidationSettings(jwks_uri="https://idp.example.com/jwks"),
+        default_issuer_url=_ISSUER,
+    )
+    assert verifier._validator._verify_aud is False
+    assert verifier._validator._audience is None
+
+
+@pytest.mark.unit
+def test_build_requires_audience_when_verifying() -> None:
+    """verify_audience with an audience folds to RequireAudience(audience)."""
+    verifier, _ = build_resource_server_auth(
+        ResourceServerSettings(resource_server_url=_RESOURCE),
+        JwtValidationSettings(
+            audience="api://x",
+            verify_audience=True,
+            jwks_uri="https://idp.example.com/jwks",
+        ),
+        default_issuer_url=_ISSUER,
+    )
+    assert verifier._validator._verify_aud is True
+    assert verifier._validator._audience == "api://x"
+
+
+@pytest.mark.unit
 def test_build_inactive_when_unconfigured() -> None:
     """No resource_server_url means no auth: the profile is off, not an error."""
     assert (


### PR DESCRIPTION
Follows #344's observation that "verify_audience requires audience" is a sum type wearing two fields, and finishes that thought for the inbound-validation config.

## The loose shape

`JwtValidationSettings` carries the inbound audience config as two co-dependent fields, `audience: str | None` and `verify_audience: bool`, whose only legal states are "skip the audience check" or "verify against a present audience". Nothing in the types rules out the third combination, and `JwtValidator.validate()` re-derived the decision on every request (the `audience if verify else None` ternary plus a parallel `verify_aud` flag).

## The sum type

`AudiencePolicy = SkipAudience | RequireAudience`. `RequireAudience` cannot exist without its value, so "verify against nothing" is unrepresentable. `JwtValidator` takes the policy and resolves it into the `jwt.decode` kwargs once in `__init__`, since the policy is fixed and `validate()` is the per-request hot path. The match is total with `assert_never`, mirroring `build_httpx_auth` on the outbound side.

## Where each rule lives

- `JwtValidationSettings` stays a pure reader for the two env vars (`PIPEFY_JWT_AUDIENCE`, `PIPEFY_JWT_VERIFY_AUDIENCE`); env/dotenv/toml layering is unchanged. A `model_validator` rejects verify-without-audience at construction, alongside the existing URL checks, so the illegal pair never escapes the reader.
- The MCP resource-server composition root (`build_resource_server_auth`) folds the pair into an `AudiencePolicy` and builds the `JwtValidator` directly.

## Scope

This is deliberately the audience slice only. It does not add a `Resolved*` config object: the audience posture is the one part that needed a domain type, and a frozen bag of bare-`str` URL fields would carry no guarantee its constructor did not enforce (a hand-written instance with a bad URL would still construct). Turning the issuer and JWKS URLs into a self-validating type is a separate change, kept orthogonal to this one.

## Tests

`packages/auth` 177 passed, `packages/mcp` 1386 passed, ruff clean. The verify-without-audience misconfiguration is asserted at settings construction; the fold outcome (skip by default, required audience when verifying) is pinned in the resource-server builder tests. Issuer resolution and the "no issuer" `RuntimeError` are unchanged.
