### PR TITLE
docs(agents): self-guaranteeing types + per-app runtime conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,19 @@ In practice:
 
 A function that accepts the parsed type may assume the guarantee and must not re-check it. This pairs with the boundary rule above: that one says where to validate, this one says what the check should hand back.
 
+### Parsed types are self-guaranteeing
+
+A parsed type rejects invalid construction itself; it does not rely on the pipeline that usually builds it. Its constructor enforces every invariant it claims, so holding an instance is proof it is valid and a hand-written instance cannot be invalid. The domain name is the guarantee, not the resolver that happens to produce it.
+
+- A recurring (value + invariant) pair earns a dedicated leaf type rather than a bare `str`, so every field holding one inherits the guarantee instead of re-checking it. A one-off invariant stays with its owner.
+- When validity depends on a policy, carry the policy as part of the value so the constructor has the context to judge it.
+- A runtime-erased alias does not qualify: it disappears at runtime, so an invalid value still constructs. Reach for a type whose constructor actually runs.
+- Settings models stay pure data readers. A cross-field rule fails fast at construction, not through a projection method a consumer must remember to call, which makes the parse optional and invites a silent `None`.
+
+### Composition: the per-app runtime
+
+Parsed types are decisions and cost no I/O to build. Effects (keychain reads, network, building clients or verifiers) live in a per-application runtime built once at startup: the single place raw settings become domain types and wired resources. Downstream depends on the runtime or the types it holds, never on raw settings or an ad-hoc resolve. The runtime lives in the app package; shared packages export parsed types and resolvers, not app wiring or effects. Whether an app wires eagerly (fail fast at boot) or keeps effectful members lazy is a per-app choice.
+
 ## Testing
 - `pytest-asyncio`, `pytest-cov`, `pytest-mock`.
 - Unit tests: default (no marker needed). Integration tests: `@pytest.mark.integration` (needs `PIPEFY_*` credentials).


### PR DESCRIPTION
Extends the "Parse, don't validate" section of `AGENTS.md` with two subsections, both tagged `tracking: #346`, so the phased refactor has documented conventions and parallel work does not drift:

- **Parsed types are self-guaranteeing** — domain types enforce their own invariants (frozen dataclasses with validating constructors; sum types for illegal-combination-unrepresentable; leaf types like `ValidatedUrl`; policy-as-field for context-dependent validity). Settings models stay pure readers: no `to_X()` projection methods, cross-field rules are a `model_validator`, not a custom source.
- **Composition: the per-app runtime** — parsed types are decisions (pure); effects (keychain, network, clients, verifiers) live in a per-app runtime (`McpRuntime` / `CliRuntime`) built once at startup. `pipefy_auth` stays a library.

Tracking issue: #346. Docs-only; no code changes.