### PR TITLE
feat: add automation execution metrics capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Open-source toolkit for **Pipefy** developers: a Model Context Protocol (MCP) se
 
 | Component | Package / path | Purpose |
 |-----------|----------------|---------|
-| **MCP server** | `pipefy-mcp-server` | Exposes **152** tools to MCP clients (Cursor, Claude Desktop, Claude Code, and others). |
+| **MCP server** | `pipefy-mcp-server` | Exposes **153** tools to MCP clients (Cursor, Claude Desktop, Claude Code, and others). |
 | **CLI** | `pipefy-cli` | Terminal commands aligned with MCP capabilities; see [`docs/parity.md`](docs/parity.md). |
 | **SDK** | `pipefy-sdk` | Vendor GraphQL client, services, and models shared by MCP and CLI. |
 | **Skills** | [`skills/`](skills/) | Markdown playbooks (Anthropic Skills format) for common Pipefy workflows. |
@@ -148,7 +148,7 @@ Deprecation and semver (post-1.0): [`docs/DEPRECATION.md`](docs/DEPRECATION.md).
 
 ## MCP server
 
-The server registers **152 tools** across ten domains. Canonical names: `PIPEFY_TOOL_NAMES` in [`packages/mcp/src/pipefy_mcp/tools/registry.py`](packages/mcp/src/pipefy_mcp/tools/registry.py).
+The server registers **153 tools** across ten domains. Canonical names: `PIPEFY_TOOL_NAMES` in [`packages/mcp/src/pipefy_mcp/tools/registry.py`](packages/mcp/src/pipefy_mcp/tools/registry.py).
 
 Tool descriptions and `Args:` blocks come from Python docstrings (what MCP clients show to models). Per-area reference docs cover parameters, edge cases, and cross-cutting behavior.
 

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -2,7 +2,7 @@
 
 This matrix is the source of truth for **MCP tool ↔ `pipefy` CLI** coverage. Update it whenever MCP tools or CLI commands are added, renamed, or removed.
 
-**Registry source:** `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` (must stay in sync with this table: **152** tools).
+**Registry source:** `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` (must stay in sync with this table: **153** tools).
 
 **Later CLI coverage:** areas such as attachments, field conditions, email, audit export, traditional automations, exports/usage, introspection, and raw GraphQL appear as **shipped** below when the matching Typer commands exist in `packages/cli`.
 
@@ -92,6 +92,7 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | `get_automation` | `pipefy automation get` | shipped | — |
 | `get_automation_actions` | `pipefy automation actions list` | shipped | (`--pipe`). |
 | `get_automation_event_attributes` | `pipefy automation event-attributes` | shipped | Official ``field_map`` event-attribute token catalog. |
+| `get_automation_execution_metrics` | `pipefy usage execution-metrics` | shipped | (`--organization`, optional repeatable `--automation`, optional `--repo`, `--period`). Omit `--automation` to fetch metrics for all automations in the org. Partial success: returns metrics for permitted automations plus `partial_errors` for denied ids. |
 | `get_automation_events` | `pipefy automation events list` | shipped | (`--pipe`). |
 | `get_automation_jobs_export` | `pipefy automation export status` | shipped | (export id argument). |
 | `get_automation_jobs_export_csv` | `pipefy export automation-jobs-csv` (also `pipefy automation export csv`) | shipped | (export id argument). |

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -92,7 +92,7 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | `get_automation` | `pipefy automation get` | shipped | — |
 | `get_automation_actions` | `pipefy automation actions list` | shipped | (`--pipe`). |
 | `get_automation_event_attributes` | `pipefy automation event-attributes` | shipped | Official ``field_map`` event-attribute token catalog. |
-| `get_automation_execution_metrics` | `pipefy usage execution-metrics` | shipped | (`--organization`, optional repeatable `--automation`, optional `--repo`, `--period`). Omit `--automation` to fetch metrics for all automations in the org. Partial success: returns metrics for permitted automations plus `partial_errors` for denied ids. |
+| `get_automation_execution_metrics` | `pipefy usage execution-metrics` | shipped | (`--organization`, optional repeatable `--automation`, optional `--repo`, `--period`; filters `--action`, `--event`, `--active/--inactive`, `--search`, `--sort-by`, `--sort-order`; paging `--first`, `--after`). Omit `--automation` to fetch metrics for all automations in the org. Partial success: returns metrics for permitted automations plus `partial_errors` for denied ids. |
 | `get_automation_events` | `pipefy automation events list` | shipped | (`--pipe`). |
 | `get_automation_jobs_export` | `pipefy automation export status` | shipped | (export id argument). |
 | `get_automation_jobs_export_csv` | `pipefy export automation-jobs-csv` (also `pipefy automation export csv`) | shipped | (export id argument). |

--- a/packages/cli/src/pipefy_cli/commands/usage.py
+++ b/packages/cli/src/pipefy_cli/commands/usage.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import typer
-from pipefy_sdk import PipefyClient
+from pipefy_sdk import AUTOMATION_EXECUTION_METRICS_PERIODS, PipefyClient
 
 from pipefy_cli.commands._common import parse_json_object, run_cli_command
 
 usage_app = typer.Typer(help="AI and automation usage metrics.", no_args_is_help=True)
+
+_EXECUTION_METRICS_PERIOD_HELP = " | ".join(AUTOMATION_EXECUTION_METRICS_PERIODS)
 
 
 def _parse_date_range(from_iso: str, to_iso: str) -> dict[str, str]:
@@ -102,7 +104,7 @@ def usage_execution_metrics(
     period: str = typer.Option(
         "SIXTY_MINUTES",
         "--period",
-        help="FIFTEEN_MINUTES | SIXTY_MINUTES | TWELVE_HOURS | TWENTY_FOUR_HOURS",
+        help=_EXECUTION_METRICS_PERIOD_HELP,
     ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:

--- a/packages/cli/src/pipefy_cli/commands/usage.py
+++ b/packages/cli/src/pipefy_cli/commands/usage.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import typer
-from pipefy_sdk import AUTOMATION_EXECUTION_METRICS_PERIODS, PipefyClient
+from pipefy_sdk import (
+    AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
+    AUTOMATION_EXECUTION_METRICS_PERIODS,
+    PipefyClient,
+)
 
 from pipefy_cli.commands._common import parse_json_object, run_cli_command
 
@@ -107,7 +111,9 @@ def usage_execution_metrics(
         help=_EXECUTION_METRICS_PERIOD_HELP,
     ),
     first: int = typer.Option(
-        30, "--first", help="Page size (1-50; the server caps a page at 50)."
+        30,
+        "--first",
+        help=f"Page size (1-{AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE}).",
     ),
     after: str | None = typer.Option(
         None, "--after", help="Cursor from a previous page's page_info.endCursor."

--- a/packages/cli/src/pipefy_cli/commands/usage.py
+++ b/packages/cli/src/pipefy_cli/commands/usage.py
@@ -81,6 +81,45 @@ def usage_automations(
     run_cli_command(ctx, json_out, factory)
 
 
+@usage_app.command("execution-metrics")
+def usage_execution_metrics(
+    ctx: typer.Context,
+    organization: str = typer.Option(
+        ...,
+        "--organization",
+        "--org",
+        help="Organization ID (numeric org id, same as in the Pipefy URL).",
+    ),
+    automation_ids: list[str] = typer.Option(
+        [],
+        "--automation",
+        "-a",
+        help="Automation ID to fetch metrics for (repeat for multiple; omit to fetch all automations in the organization).",
+    ),
+    repo: str | None = typer.Option(
+        None, "--repo", help="Optional pipe/repo ID to scope the query."
+    ),
+    period: str = typer.Option(
+        "SIXTY_MINUTES",
+        "--period",
+        help="FIFTEEN_MINUTES | SIXTY_MINUTES | TWELVE_HOURS | TWENTY_FOUR_HOURS",
+    ),
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """Automation execution metrics (``get_automation_execution_metrics``).
+
+    Returns metrics for the automations the token may read plus a ``partial_errors``
+    list naming any that were denied.
+    """
+
+    async def factory(client: PipefyClient):
+        return await client.get_automation_execution_metrics(
+            organization, automation_ids or None, repo_id=repo, period=period
+        )
+
+    run_cli_command(ctx, json_out, factory)
+
+
 @usage_app.command("credits")
 def usage_credits(
     ctx: typer.Context,

--- a/packages/cli/src/pipefy_cli/commands/usage.py
+++ b/packages/cli/src/pipefy_cli/commands/usage.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import typer
 from pipefy_sdk import (
+    AUTOMATION_EVENT_IDS,
     AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
     AUTOMATION_EXECUTION_METRICS_PERIODS,
+    AUTOMATION_SORT_BY,
+    AUTOMATION_SORT_ORDER,
     PipefyClient,
 )
 
@@ -14,6 +17,9 @@ from pipefy_cli.commands._common import parse_json_object, run_cli_command
 usage_app = typer.Typer(help="AI and automation usage metrics.", no_args_is_help=True)
 
 _EXECUTION_METRICS_PERIOD_HELP = " | ".join(AUTOMATION_EXECUTION_METRICS_PERIODS)
+_EXECUTION_METRICS_EVENT_HELP = " | ".join(AUTOMATION_EVENT_IDS)
+_EXECUTION_METRICS_SORT_BY_HELP = " | ".join(AUTOMATION_SORT_BY)
+_EXECUTION_METRICS_SORT_ORDER_HELP = " | ".join(AUTOMATION_SORT_ORDER)
 
 
 def _parse_date_range(from_iso: str, to_iso: str) -> dict[str, str]:
@@ -105,6 +111,32 @@ def usage_execution_metrics(
     repo: str | None = typer.Option(
         None, "--repo", help="Optional pipe/repo ID to scope the query."
     ),
+    action_ids: list[str] = typer.Option(
+        [],
+        "--action",
+        help="Action ID to filter by (repeat for multiple).",
+    ),
+    event: str | None = typer.Option(
+        None,
+        "--event",
+        help=f"Filter by trigger event: {_EXECUTION_METRICS_EVENT_HELP}.",
+    ),
+    active: bool | None = typer.Option(
+        None,
+        "--active/--inactive",
+        help="Filter enabled (--active) or disabled (--inactive) automations.",
+    ),
+    search: str | None = typer.Option(
+        None, "--search", help="Free-text match on automation name."
+    ),
+    sort_by: str | None = typer.Option(
+        None, "--sort-by", help=f"Sort field: {_EXECUTION_METRICS_SORT_BY_HELP}."
+    ),
+    sort_order: str | None = typer.Option(
+        None,
+        "--sort-order",
+        help=f"Sort direction: {_EXECUTION_METRICS_SORT_ORDER_HELP}.",
+    ),
     period: str = typer.Option(
         "SIXTY_MINUTES",
         "--period",
@@ -131,6 +163,12 @@ def usage_execution_metrics(
             organization,
             automation_ids or None,
             repo_id=repo,
+            action_ids=action_ids or None,
+            event_id=event,
+            active=active,
+            search=search,
+            sort_by=sort_by,
+            sort_order=sort_order,
             period=period,
             first=first,
             after=after,

--- a/packages/cli/src/pipefy_cli/commands/usage.py
+++ b/packages/cli/src/pipefy_cli/commands/usage.py
@@ -106,17 +106,28 @@ def usage_execution_metrics(
         "--period",
         help=_EXECUTION_METRICS_PERIOD_HELP,
     ),
+    first: int = typer.Option(
+        30, "--first", help="Page size (1-50; the server caps a page at 50)."
+    ),
+    after: str | None = typer.Option(
+        None, "--after", help="Cursor from a previous page's page_info.endCursor."
+    ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
     """Automation execution metrics (``get_automation_execution_metrics``).
 
     Returns metrics for the automations the token may read plus a ``partial_errors``
-    list naming any that were denied.
+    list naming any that were denied, and a ``page_info`` for paging with ``--after``.
     """
 
     async def factory(client: PipefyClient):
         return await client.get_automation_execution_metrics(
-            organization, automation_ids or None, repo_id=repo, period=period
+            organization,
+            automation_ids or None,
+            repo_id=repo,
+            period=period,
+            first=first,
+            after=after,
         )
 
     run_cli_command(ctx, json_out, factory)

--- a/packages/cli/src/pipefy_cli/commands/usage.py
+++ b/packages/cli/src/pipefy_cli/commands/usage.py
@@ -111,7 +111,7 @@ def usage_execution_metrics(
         help=_EXECUTION_METRICS_PERIOD_HELP,
     ),
     first: int = typer.Option(
-        30,
+        AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
         "--first",
         help=f"Page size (1-{AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE}).",
     ),

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -2888,9 +2888,11 @@ Usage: pipefy usage [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ agents        AI agent usage for an org (``get_agents_usage``).              │
-│ automations   Automation usage for an org (``get_automations_usage``).       │
-│ credits       AI credit usage dashboard (``get_ai_credit_usage``).           │
+│ agents              AI agent usage for an org (``get_agents_usage``).        │
+│ automations         Automation usage for an org (``get_automations_usage``). │
+│ execution-metrics   Automation execution metrics                             │
+│                     (``get_automation_execution_metrics``).                  │
+│ credits             AI credit usage dashboard (``get_ai_credit_usage``).     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP usage/agents
@@ -2940,6 +2942,30 @@ Usage: pipefy usage credits [OPTIONS]
 │    --period                      TEXT  current_month | last_month |          │
 │                                        last_3_months                         │
 │                                        [default: current_month]              │
+│    --json                -j                                                  │
+│    --help                              Show this message and exit.           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP usage/execution-metrics
+Usage: pipefy usage execution-metrics [OPTIONS]
+
+ Automation execution metrics (``get_automation_execution_metrics``).
+
+ Returns metrics for the automations the token may read plus a
+ ``partial_errors`` list naming any that were denied.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --organization,--org          TEXT  Organization ID (numeric org id, same │
+│                                        as in the Pipefy URL).                │
+│                                        [required]                            │
+│    --automation          -a      TEXT  Automation ID to fetch metrics for    │
+│                                        (repeat for multiple; omit to fetch   │
+│                                        all automations in the organization). │
+│    --repo                        TEXT  Optional pipe/repo ID to scope the    │
+│                                        query.                                │
+│    --period                      TEXT  FIFTEEN_MINUTES | SIXTY_MINUTES |     │
+│                                        TWELVE_HOURS | TWENTY_FOUR_HOURS      │
+│                                        [default: SIXTY_MINUTES]              │
 │    --json                -j                                                  │
 │    --help                              Show this message and exit.           │
 ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -2968,7 +2968,7 @@ Usage: pipefy usage execution-metrics [OPTIONS]
 │    --period                      TEXT     FIFTEEN_MINUTES | SIXTY_MINUTES |  │
 │                                           TWELVE_HOURS | TWENTY_FOUR_HOURS   │
 │                                           [default: SIXTY_MINUTES]           │
-│    --first                       INTEGER  Page size (1-50). [default: 30]    │
+│    --first                       INTEGER  Page size (1-50). [default: 50]    │
 │    --after                       TEXT     Cursor from a previous page's      │
 │                                           page_info.endCursor.               │
 │    --json                -j                                                  │

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -2968,9 +2968,7 @@ Usage: pipefy usage execution-metrics [OPTIONS]
 │    --period                      TEXT     FIFTEEN_MINUTES | SIXTY_MINUTES |  │
 │                                           TWELVE_HOURS | TWENTY_FOUR_HOURS   │
 │                                           [default: SIXTY_MINUTES]           │
-│    --first                       INTEGER  Page size (1-50; the server caps a │
-│                                           page at 50).                       │
-│                                           [default: 30]                      │
+│    --first                       INTEGER  Page size (1-50). [default: 30]    │
 │    --after                       TEXT     Cursor from a previous page's      │
 │                                           page_info.endCursor.               │
 │    --json                -j                                                  │

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -2956,23 +2956,52 @@ Usage: pipefy usage execution-metrics [OPTIONS]
  paging with ``--after``.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ *  --organization,--org          TEXT     Organization ID (numeric org id,   │
-│                                           same as in the Pipefy URL).        │
-│                                           [required]                         │
-│    --automation          -a      TEXT     Automation ID to fetch metrics for │
-│                                           (repeat for multiple; omit to      │
-│                                           fetch all automations in the       │
-│                                           organization).                     │
-│    --repo                        TEXT     Optional pipe/repo ID to scope the │
-│                                           query.                             │
-│    --period                      TEXT     FIFTEEN_MINUTES | SIXTY_MINUTES |  │
-│                                           TWELVE_HOURS | TWENTY_FOUR_HOURS   │
-│                                           [default: SIXTY_MINUTES]           │
-│    --first                       INTEGER  Page size (1-50). [default: 50]    │
-│    --after                       TEXT     Cursor from a previous page's      │
-│                                           page_info.endCursor.               │
+│ *  --organization,--org                    TEXT     Organization ID (numeric │
+│                                                     org id, same as in the   │
+│                                                     Pipefy URL).             │
+│                                                     [required]               │
+│    --automation          -a                TEXT     Automation ID to fetch   │
+│                                                     metrics for (repeat for  │
+│                                                     multiple; omit to fetch  │
+│                                                     all automations in the   │
+│                                                     organization).           │
+│    --repo                                  TEXT     Optional pipe/repo ID to │
+│                                                     scope the query.         │
+│    --action                                TEXT     Action ID to filter by   │
+│                                                     (repeat for multiple).   │
+│    --event                                 TEXT     Filter by trigger event: │
+│                                                     card_moved |             │
+│                                                     field_updated |          │
+│                                                     card_created | scheduler │
+│                                                     | sla_based |            │
+│                                                     card_left_phase |        │
+│                                                     card_inbox_received_ema… │
+│                                                     | all_children_in_phase  │
+│                                                     | http_response_received │
+│                                                     | manually_triggered.    │
+│    --active                  --inactive             Filter enabled           │
+│                                                     (--active) or disabled   │
+│                                                     (--inactive)             │
+│                                                     automations.             │
+│    --search                                TEXT     Free-text match on       │
+│                                                     automation name.         │
+│    --sort-by                               TEXT     Sort field: created_at | │
+│                                                     name.                    │
+│    --sort-order                            TEXT     Sort direction: asc |    │
+│                                                     desc.                    │
+│    --period                                TEXT     FIFTEEN_MINUTES |        │
+│                                                     SIXTY_MINUTES |          │
+│                                                     TWELVE_HOURS |           │
+│                                                     TWENTY_FOUR_HOURS        │
+│                                                     [default: SIXTY_MINUTES] │
+│    --first                                 INTEGER  Page size (1-50).        │
+│                                                     [default: 50]            │
+│    --after                                 TEXT     Cursor from a previous   │
+│                                                     page's                   │
+│                                                     page_info.endCursor.     │
 │    --json                -j                                                  │
-│    --help                                 Show this message and exit.        │
+│    --help                                           Show this message and    │
+│                                                     exit.                    │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP webhook

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -2952,22 +2952,29 @@ Usage: pipefy usage execution-metrics [OPTIONS]
  Automation execution metrics (``get_automation_execution_metrics``).
 
  Returns metrics for the automations the token may read plus a
- ``partial_errors`` list naming any that were denied.
+ ``partial_errors`` list naming any that were denied, and a ``page_info`` for
+ paging with ``--after``.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ *  --organization,--org          TEXT  Organization ID (numeric org id, same │
-│                                        as in the Pipefy URL).                │
-│                                        [required]                            │
-│    --automation          -a      TEXT  Automation ID to fetch metrics for    │
-│                                        (repeat for multiple; omit to fetch   │
-│                                        all automations in the organization). │
-│    --repo                        TEXT  Optional pipe/repo ID to scope the    │
-│                                        query.                                │
-│    --period                      TEXT  FIFTEEN_MINUTES | SIXTY_MINUTES |     │
-│                                        TWELVE_HOURS | TWENTY_FOUR_HOURS      │
-│                                        [default: SIXTY_MINUTES]              │
+│ *  --organization,--org          TEXT     Organization ID (numeric org id,   │
+│                                           same as in the Pipefy URL).        │
+│                                           [required]                         │
+│    --automation          -a      TEXT     Automation ID to fetch metrics for │
+│                                           (repeat for multiple; omit to      │
+│                                           fetch all automations in the       │
+│                                           organization).                     │
+│    --repo                        TEXT     Optional pipe/repo ID to scope the │
+│                                           query.                             │
+│    --period                      TEXT     FIFTEEN_MINUTES | SIXTY_MINUTES |  │
+│                                           TWELVE_HOURS | TWENTY_FOUR_HOURS   │
+│                                           [default: SIXTY_MINUTES]           │
+│    --first                       INTEGER  Page size (1-50; the server caps a │
+│                                           page at 50).                       │
+│                                           [default: 30]                      │
+│    --after                       TEXT     Cursor from a previous page's      │
+│                                           page_info.endCursor.               │
 │    --json                -j                                                  │
-│    --help                              Show this message and exit.           │
+│    --help                                 Show this message and exit.        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP webhook

--- a/packages/cli/tests/test_cli_agent_automation_smoke.py
+++ b/packages/cli/tests/test_cli_agent_automation_smoke.py
@@ -171,6 +171,32 @@ def test_usage_credits_invokes_client(
     mock_client.get_ai_credit_usage.assert_awaited_once()
 
 
+def test_usage_execution_metrics_invokes_client(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    oauth_env("usage-em")
+    mock_client = MagicMock()
+    mock_client.get_automation_execution_metrics = AsyncMock(
+        return_value={"automations": [], "partial_errors": [], "page_info": {}}
+    )
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "usage",
+                "execution-metrics",
+                "--organization",
+                "1",
+                "--json",
+            ],
+        )
+    assert r.exit_code == 0
+    mock_client.get_automation_execution_metrics.assert_awaited_once()
+
+
 def test_org_get_json(runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env):
     oauth_env("org-g")
     mock_client = MagicMock()

--- a/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
@@ -32,6 +32,9 @@ _VALID_EXECUTION_METRICS_PERIODS = frozenset(AUTOMATION_EXECUTION_METRICS_PERIOD
 # Pagination
 _MIN_PAGE_SIZE = 1
 _MAX_PAGE_SIZE = 100
+# The automations connection caps a page at 50; asking for more is rejected up front
+# rather than silently returning 50.
+_MAX_EXECUTION_METRICS_PAGE_SIZE = 50
 
 # CSV / export download limits
 _MIN_CSV_CHARS = 256
@@ -415,15 +418,19 @@ class ObservabilityTools:
             automation_ids: list[PipefyId] | None = None,
             repo_id: PipefyId | None = None,
             period: str = "SIXTY_MINUTES",
+            first: int = 30,
+            after: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Get execution metrics (totalRuns, successRate, failureRate, averageDuration, lastRun) for one or more automations over a rolling window. Returns metrics for the automations you can access plus a `partial_errors` list naming any that were denied (PERMISSION_DENIED); this is a partial result, not a hard failure. `period`: FIFTEEN_MINUTES, SIXTY_MINUTES (default), TWELVE_HOURS, or TWENTY_FOUR_HOURS.
+            """Get execution metrics (totalRuns, successRate, failureRate, averageDuration, lastRun) for one or more automations over a rolling window. Returns metrics for the automations you can access plus a `partial_errors` list naming any that were denied (PERMISSION_DENIED); this is a partial result, not a hard failure. Results are paginated: `page_info` carries `hasNextPage` and `endCursor`, and the server caps a page at 50 automations, so pass `endCursor` back as `after` to fetch the rest. `period`: FIFTEEN_MINUTES, SIXTY_MINUTES (default), TWELVE_HOURS, or TWENTY_FOUR_HOURS.
 
             Args:
                 organization_id: Organization ID (numeric org id, same as in the Pipefy URL).
                 automation_ids: Optional automation IDs to fetch metrics for. Omit to fetch metrics for every automation in the organization (optionally scoped by repo_id). When provided, it must contain at least one ID.
                 repo_id: Optional pipe/repo ID to scope the query.
                 period: AutomationExecutionMetricsPeriod (FIFTEEN_MINUTES, SIXTY_MINUTES, TWELVE_HOURS, TWENTY_FOUR_HOURS). Defaults to SIXTY_MINUTES, matching the API.
+                first: Page size, 1 to 50 (default 30).
+                after: Cursor from a previous page's page_info.endCursor.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -445,12 +452,21 @@ class ObservabilityTools:
                         f"{sorted(_VALID_EXECUTION_METRICS_PERIODS)}."
                     ),
                 )
+            if not _MIN_PAGE_SIZE <= first <= _MAX_EXECUTION_METRICS_PAGE_SIZE:
+                return build_observability_error_payload(
+                    message=(
+                        f"Invalid 'first': must be between {_MIN_PAGE_SIZE} and "
+                        f"{_MAX_EXECUTION_METRICS_PAGE_SIZE}."
+                    ),
+                )
             try:
                 raw = await client.get_automation_execution_metrics(
                     organization_id,
                     normalized_ids,
                     repo_id=normalized_repo_id,
                     period=period,
+                    first=first,
+                    after=after,
                 )
             except ValueError as exc:
                 return build_observability_error_payload(message=str(exc))

--- a/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
@@ -22,6 +22,14 @@ from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
 _VALID_PERIODS = {"current_month", "last_month", "last_3_months"}
 
+# AutomationExecutionMetricsPeriod enum: rolling windows for execution metrics.
+_VALID_EXECUTION_METRICS_PERIODS = {
+    "FIFTEEN_MINUTES",
+    "SIXTY_MINUTES",
+    "TWELVE_HOURS",
+    "TWENTY_FOUR_HOURS",
+}
+
 # Pagination
 _MIN_PAGE_SIZE = 1
 _MAX_PAGE_SIZE = 100
@@ -397,6 +405,75 @@ class ObservabilityTools:
                 )
             return build_observability_read_success_payload(
                 raw, message="AI credit usage retrieved."
+            )
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=True),
+        )
+        async def get_automation_execution_metrics(
+            organization_id: PipefyId,
+            ctx: Context,
+            automation_ids: list[PipefyId] | None = None,
+            repo_id: PipefyId | None = None,
+            period: str = "SIXTY_MINUTES",
+            debug: bool = False,
+        ) -> dict[str, Any]:
+            """Get execution metrics (totalRuns, successRate, failureRate, averageDuration, lastRun) for one or more automations over a rolling window. Returns metrics for the automations you can access plus a `partial_errors` list naming any that were denied (PERMISSION_DENIED) — a partial result, not a hard failure. `period`: FIFTEEN_MINUTES, SIXTY_MINUTES (default), TWELVE_HOURS, or TWENTY_FOUR_HOURS.
+
+            Args:
+                organization_id: Organization ID (numeric org id, same as in the Pipefy URL).
+                automation_ids: Optional automation IDs to fetch metrics for. Omit to fetch metrics for every automation in the organization (optionally scoped by repo_id). When provided, it must contain at least one ID.
+                repo_id: Optional pipe/repo ID to scope the query.
+                period: AutomationExecutionMetricsPeriod (FIFTEEN_MINUTES, SIXTY_MINUTES, TWELVE_HOURS, TWENTY_FOUR_HOURS). Defaults to SIXTY_MINUTES, matching the API.
+                debug: When True, append GraphQL codes and correlation_id to errors.
+            """
+            client = get_pipefy_client(ctx)
+            organization_id, err = validate_tool_id(organization_id, "organization_id")
+            if err is not None:
+                return err
+            normalized_ids: list[str] | None = None
+            if automation_ids is not None:
+                if not automation_ids:
+                    return build_observability_error_payload(
+                        message="Invalid 'automation_ids': when provided, it must contain at least one automation ID.",
+                    )
+                normalized_ids = []
+                for raw_id in automation_ids:
+                    norm_id, id_err = validate_tool_id(raw_id, "automation_ids")
+                    if id_err is not None:
+                        return id_err
+                    normalized_ids.append(norm_id)
+            normalized_repo_id: str | None = None
+            if repo_id is not None:
+                normalized_repo_id, err = validate_tool_id(repo_id, "repo_id")
+                if err is not None:
+                    return err
+            if period not in _VALID_EXECUTION_METRICS_PERIODS:
+                return build_observability_error_payload(
+                    message=(
+                        "Invalid 'period': must be one of "
+                        f"{sorted(_VALID_EXECUTION_METRICS_PERIODS)}."
+                    ),
+                )
+            try:
+                raw = await client.get_automation_execution_metrics(
+                    organization_id,
+                    normalized_ids,
+                    repo_id=normalized_repo_id,
+                    period=period,
+                )
+            except ValueError as exc:
+                return build_observability_error_payload(message=str(exc))
+            except Exception as exc:  # noqa: BLE001
+                return handle_observability_tool_graphql_error(
+                    exc,
+                    "Get automation execution metrics failed.",
+                    debug=debug,
+                    resource_kind="organization",
+                    resource_id=str(organization_id),
+                )
+            return build_observability_read_success_payload(
+                raw, message="Automation execution metrics retrieved."
             )
 
         @mcp.tool(

--- a/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
@@ -7,8 +7,11 @@ from typing import Any
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 from pipefy_sdk import (
+    AUTOMATION_EVENT_IDS,
     AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
     AUTOMATION_EXECUTION_METRICS_PERIODS,
+    AUTOMATION_SORT_BY,
+    AUTOMATION_SORT_ORDER,
     PipefyId,
 )
 
@@ -415,6 +418,12 @@ class ObservabilityTools:
             ctx: Context,
             automation_ids: list[PipefyId] | None = None,
             repo_id: PipefyId | None = None,
+            action_ids: list[PipefyId] | None = None,
+            event_id: str | None = None,
+            active: bool | None = None,
+            search: str | None = None,
+            sort_by: str | None = None,
+            sort_order: str | None = None,
             period: str = "SIXTY_MINUTES",
             first: int = AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
             after: str | None = None,
@@ -424,8 +433,14 @@ class ObservabilityTools:
 
             Args:
                 organization_id: Organization ID (numeric org id, same as in the Pipefy URL).
-                automation_ids: Automation IDs to fetch. Omit to fetch every automation in the organization (optionally scoped by repo_id); when provided, must be non-empty.
+                automation_ids: Automation IDs to fetch. Omit to fetch every automation in the organization (optionally narrowed by the filters below); when provided, must be non-empty.
                 repo_id: Optional pipe/repo ID to scope the query.
+                action_ids: Optional action IDs to filter by; when provided, must be non-empty.
+                event_id: Optional trigger event: card_moved, field_updated, card_created, scheduler, sla_based, card_left_phase, card_inbox_received_email, all_children_in_phase, http_response_received, manually_triggered.
+                active: Optional filter for enabled (true) or disabled (false) automations.
+                search: Optional free-text match on automation name.
+                sort_by: Optional sort field: created_at or name.
+                sort_order: Optional sort direction: asc or desc.
                 period: One of FIFTEEN_MINUTES, SIXTY_MINUTES (default), TWELVE_HOURS, TWENTY_FOUR_HOURS.
                 first: Page size, 1 to 50 (default 50).
                 after: Cursor from a previous page's page_info.endCursor.
@@ -443,13 +458,21 @@ class ObservabilityTools:
             _, normalized_repo_id, err = validate_optional_tool_id(repo_id, "repo_id")
             if err is not None:
                 return err
-            if period not in AUTOMATION_EXECUTION_METRICS_PERIODS:
-                return build_observability_error_payload(
-                    message=(
-                        "Invalid 'period': must be one of "
-                        f"{list(AUTOMATION_EXECUTION_METRICS_PERIODS)}."
-                    ),
-                )
+            normalized_action_ids, err = validate_optional_tool_id_list(
+                action_ids, "action_ids"
+            )
+            if err is not None:
+                return err
+            for value, allowed, label in (
+                (period, AUTOMATION_EXECUTION_METRICS_PERIODS, "period"),
+                (event_id, AUTOMATION_EVENT_IDS, "event_id"),
+                (sort_by, AUTOMATION_SORT_BY, "sort_by"),
+                (sort_order, AUTOMATION_SORT_ORDER, "sort_order"),
+            ):
+                if value is not None and value not in allowed:
+                    return build_observability_error_payload(
+                        message=f"Invalid '{label}': must be one of {list(allowed)}.",
+                    )
             if (
                 not _MIN_PAGE_SIZE
                 <= first
@@ -461,11 +484,20 @@ class ObservabilityTools:
                         f"{AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE}."
                     ),
                 )
+            normalized_search = search.strip() if search is not None else None
+            if not normalized_search:
+                normalized_search = None
             try:
                 raw = await client.get_automation_execution_metrics(
                     organization_id,
                     normalized_ids,
                     repo_id=normalized_repo_id,
+                    action_ids=normalized_action_ids,
+                    event_id=event_id,
+                    active=active,
+                    search=normalized_search,
+                    sort_by=sort_by,
+                    sort_order=sort_order,
                     period=period,
                     first=first,
                     after=after,

--- a/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
@@ -416,18 +416,18 @@ class ObservabilityTools:
             automation_ids: list[PipefyId] | None = None,
             repo_id: PipefyId | None = None,
             period: str = "SIXTY_MINUTES",
-            first: int = 30,
+            first: int = AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
             after: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Get execution metrics (totalRuns, successRate, failureRate, averageDuration, lastRun) for one or more automations over a rolling window. Returns metrics for the automations you can access plus a `partial_errors` list naming any that were denied (PERMISSION_DENIED); this is a partial result, not a hard failure. Results are paginated: `page_info` carries `hasNextPage` and `endCursor`, and a page contains at most 50 automations, so pass `endCursor` back as `after` to fetch the rest. `period`: FIFTEEN_MINUTES, SIXTY_MINUTES (default), TWELVE_HOURS, or TWENTY_FOUR_HOURS.
+            """Get execution metrics (totalRuns, successRate, failureRate, averageDuration, lastRun) for one or more automations over a rolling window. Returns metrics for the automations you can access plus a `partial_errors` list naming any that were denied; a partial result, not a hard failure. Paginated: a page holds at most 50 automations; pass `page_info.endCursor` back as `after` to fetch the rest.
 
             Args:
                 organization_id: Organization ID (numeric org id, same as in the Pipefy URL).
-                automation_ids: Optional automation IDs to fetch metrics for. Omit to fetch metrics for every automation in the organization (optionally scoped by repo_id). When provided, it must contain at least one ID.
+                automation_ids: Automation IDs to fetch. Omit to fetch every automation in the organization (optionally scoped by repo_id); when provided, must be non-empty.
                 repo_id: Optional pipe/repo ID to scope the query.
-                period: AutomationExecutionMetricsPeriod (FIFTEEN_MINUTES, SIXTY_MINUTES, TWELVE_HOURS, TWENTY_FOUR_HOURS). Defaults to SIXTY_MINUTES, matching the API.
-                first: Page size, 1 to 50 (default 30).
+                period: One of FIFTEEN_MINUTES, SIXTY_MINUTES (default), TWELVE_HOURS, TWENTY_FOUR_HOURS.
+                first: Page size, 1 to 50 (default 50).
                 after: Cursor from a previous page's page_info.endCursor.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """

--- a/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
@@ -444,7 +444,7 @@ class ObservabilityTools:
                 period: One of FIFTEEN_MINUTES, SIXTY_MINUTES (default), TWELVE_HOURS, TWENTY_FOUR_HOURS.
                 first: Page size, 1 to 50 (default 50).
                 after: Cursor from a previous page's page_info.endCursor.
-                debug: When True, append GraphQL codes and correlation_id to errors.
+                debug: When True, append GraphQL codes and correlation_id to transport-level GraphQL errors. Top-level failures (unknown org, no org access) return a plain message; per-automation denials already carry correlation_id in partial_errors.
             """
             client = get_pipefy_client(ctx)
             organization_id, err = validate_tool_id(organization_id, "organization_id")

--- a/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
@@ -6,7 +6,11 @@ from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
-from pipefy_sdk import AUTOMATION_EXECUTION_METRICS_PERIODS, PipefyId
+from pipefy_sdk import (
+    AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
+    AUTOMATION_EXECUTION_METRICS_PERIODS,
+    PipefyId,
+)
 
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
 from pipefy_mcp.tools.observability_tool_helpers import (
@@ -26,15 +30,9 @@ from pipefy_mcp.tools.validation_helpers import (
 
 _VALID_PERIODS = {"current_month", "last_month", "last_3_months"}
 
-# Rolling windows for execution metrics; single-sourced from the SDK's schema enum.
-_VALID_EXECUTION_METRICS_PERIODS = frozenset(AUTOMATION_EXECUTION_METRICS_PERIODS)
-
 # Pagination
 _MIN_PAGE_SIZE = 1
 _MAX_PAGE_SIZE = 100
-# The automations connection caps a page at 50; asking for more is rejected up front
-# rather than silently returning 50.
-_MAX_EXECUTION_METRICS_PAGE_SIZE = 50
 
 # CSV / export download limits
 _MIN_CSV_CHARS = 256
@@ -422,7 +420,7 @@ class ObservabilityTools:
             after: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Get execution metrics (totalRuns, successRate, failureRate, averageDuration, lastRun) for one or more automations over a rolling window. Returns metrics for the automations you can access plus a `partial_errors` list naming any that were denied (PERMISSION_DENIED); this is a partial result, not a hard failure. Results are paginated: `page_info` carries `hasNextPage` and `endCursor`, and the server caps a page at 50 automations, so pass `endCursor` back as `after` to fetch the rest. `period`: FIFTEEN_MINUTES, SIXTY_MINUTES (default), TWELVE_HOURS, or TWENTY_FOUR_HOURS.
+            """Get execution metrics (totalRuns, successRate, failureRate, averageDuration, lastRun) for one or more automations over a rolling window. Returns metrics for the automations you can access plus a `partial_errors` list naming any that were denied (PERMISSION_DENIED); this is a partial result, not a hard failure. Results are paginated: `page_info` carries `hasNextPage` and `endCursor`, and a page contains at most 50 automations, so pass `endCursor` back as `after` to fetch the rest. `period`: FIFTEEN_MINUTES, SIXTY_MINUTES (default), TWELVE_HOURS, or TWENTY_FOUR_HOURS.
 
             Args:
                 organization_id: Organization ID (numeric org id, same as in the Pipefy URL).
@@ -445,18 +443,22 @@ class ObservabilityTools:
             _, normalized_repo_id, err = validate_optional_tool_id(repo_id, "repo_id")
             if err is not None:
                 return err
-            if period not in _VALID_EXECUTION_METRICS_PERIODS:
+            if period not in AUTOMATION_EXECUTION_METRICS_PERIODS:
                 return build_observability_error_payload(
                     message=(
                         "Invalid 'period': must be one of "
-                        f"{sorted(_VALID_EXECUTION_METRICS_PERIODS)}."
+                        f"{list(AUTOMATION_EXECUTION_METRICS_PERIODS)}."
                     ),
                 )
-            if not _MIN_PAGE_SIZE <= first <= _MAX_EXECUTION_METRICS_PAGE_SIZE:
+            if (
+                not _MIN_PAGE_SIZE
+                <= first
+                <= AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE
+            ):
                 return build_observability_error_payload(
                     message=(
                         f"Invalid 'first': must be between {_MIN_PAGE_SIZE} and "
-                        f"{_MAX_EXECUTION_METRICS_PAGE_SIZE}."
+                        f"{AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE}."
                     ),
                 )
             try:

--- a/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
-from pipefy_sdk import PipefyId
+from pipefy_sdk import AUTOMATION_EXECUTION_METRICS_PERIODS, PipefyId
 
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
 from pipefy_mcp.tools.observability_tool_helpers import (
@@ -16,19 +16,18 @@ from pipefy_mcp.tools.observability_tool_helpers import (
     handle_observability_tool_graphql_error,
 )
 from pipefy_mcp.tools.tool_context import get_pipefy_client
-from pipefy_mcp.tools.validation_helpers import validate_tool_id
+from pipefy_mcp.tools.validation_helpers import (
+    validate_optional_tool_id,
+    validate_optional_tool_id_list,
+    validate_tool_id,
+)
 
 # --- Validation constants ---
 
 _VALID_PERIODS = {"current_month", "last_month", "last_3_months"}
 
-# AutomationExecutionMetricsPeriod enum: rolling windows for execution metrics.
-_VALID_EXECUTION_METRICS_PERIODS = {
-    "FIFTEEN_MINUTES",
-    "SIXTY_MINUTES",
-    "TWELVE_HOURS",
-    "TWENTY_FOUR_HOURS",
-}
+# Rolling windows for execution metrics; single-sourced from the SDK's schema enum.
+_VALID_EXECUTION_METRICS_PERIODS = frozenset(AUTOMATION_EXECUTION_METRICS_PERIODS)
 
 # Pagination
 _MIN_PAGE_SIZE = 1
@@ -418,7 +417,7 @@ class ObservabilityTools:
             period: str = "SIXTY_MINUTES",
             debug: bool = False,
         ) -> dict[str, Any]:
-            """Get execution metrics (totalRuns, successRate, failureRate, averageDuration, lastRun) for one or more automations over a rolling window. Returns metrics for the automations you can access plus a `partial_errors` list naming any that were denied (PERMISSION_DENIED) — a partial result, not a hard failure. `period`: FIFTEEN_MINUTES, SIXTY_MINUTES (default), TWELVE_HOURS, or TWENTY_FOUR_HOURS.
+            """Get execution metrics (totalRuns, successRate, failureRate, averageDuration, lastRun) for one or more automations over a rolling window. Returns metrics for the automations you can access plus a `partial_errors` list naming any that were denied (PERMISSION_DENIED); this is a partial result, not a hard failure. `period`: FIFTEEN_MINUTES, SIXTY_MINUTES (default), TWELVE_HOURS, or TWENTY_FOUR_HOURS.
 
             Args:
                 organization_id: Organization ID (numeric org id, same as in the Pipefy URL).
@@ -431,23 +430,14 @@ class ObservabilityTools:
             organization_id, err = validate_tool_id(organization_id, "organization_id")
             if err is not None:
                 return err
-            normalized_ids: list[str] | None = None
-            if automation_ids is not None:
-                if not automation_ids:
-                    return build_observability_error_payload(
-                        message="Invalid 'automation_ids': when provided, it must contain at least one automation ID.",
-                    )
-                normalized_ids = []
-                for raw_id in automation_ids:
-                    norm_id, id_err = validate_tool_id(raw_id, "automation_ids")
-                    if id_err is not None:
-                        return id_err
-                    normalized_ids.append(norm_id)
-            normalized_repo_id: str | None = None
-            if repo_id is not None:
-                normalized_repo_id, err = validate_tool_id(repo_id, "repo_id")
-                if err is not None:
-                    return err
+            normalized_ids, err = validate_optional_tool_id_list(
+                automation_ids, "automation_ids"
+            )
+            if err is not None:
+                return err
+            _, normalized_repo_id, err = validate_optional_tool_id(repo_id, "repo_id")
+            if err is not None:
+                return err
             if period not in _VALID_EXECUTION_METRICS_PERIODS:
                 return build_observability_error_payload(
                     message=(

--- a/packages/mcp/src/pipefy_mcp/tools/registry.py
+++ b/packages/mcp/src/pipefy_mcp/tools/registry.py
@@ -100,6 +100,7 @@ PIPEFY_TOOL_NAMES = frozenset(
         "get_automation",
         "get_automation_actions",
         "get_automation_event_attributes",
+        "get_automation_execution_metrics",
         "get_automation_events",
         "get_automation_jobs_export",
         "get_automation_jobs_export_csv",

--- a/packages/mcp/src/pipefy_mcp/tools/validation_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/validation_helpers.py
@@ -101,14 +101,9 @@ def validate_optional_tool_id_list(
 ) -> tuple[list[str] | None, dict[str, object] | None]:
     """Validate an optional list of Pipefy IDs at the tool boundary.
 
-    ``None`` passes through as ``(None, None)`` (the filter is omitted). A present
-    list must be non-empty and each element must pass :func:`validate_tool_id`;
-    elements are returned cleaned (stripped, int→str). Returns
-    ``(cleaned_ids_or_none, error_payload_or_none)``.
-
-    Args:
-        values: Optional list of raw ID values from the tool parameter.
-        label: Parameter name for the error message.
+    ``None`` passes through as ``(None, None)``; a present list must be non-empty
+    and every element pass :func:`validate_tool_id`. Returns
+    ``(cleaned_ids, error_payload)``.
     """
     if values is None:
         return None, None
@@ -119,9 +114,9 @@ def validate_optional_tool_id_list(
     cleaned: list[str] = []
     for value in values:
         cleaned_id, err = validate_tool_id(value, label)
-        if err is not None:
+        if cleaned_id is None:
             return None, err
-        cleaned.append(cleaned_id)  # type: ignore[arg-type]
+        cleaned.append(cleaned_id)
     return cleaned, None
 
 

--- a/packages/mcp/src/pipefy_mcp/tools/validation_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/validation_helpers.py
@@ -95,6 +95,36 @@ def validate_optional_tool_id(
     return True, cleaned, None
 
 
+def validate_optional_tool_id_list(
+    values: list[str | int] | None,
+    label: str = "ids",
+) -> tuple[list[str] | None, dict[str, object] | None]:
+    """Validate an optional list of Pipefy IDs at the tool boundary.
+
+    ``None`` passes through as ``(None, None)`` (the filter is omitted). A present
+    list must be non-empty and each element must pass :func:`validate_tool_id`;
+    elements are returned cleaned (stripped, int→str). Returns
+    ``(cleaned_ids_or_none, error_payload_or_none)``.
+
+    Args:
+        values: Optional list of raw ID values from the tool parameter.
+        label: Parameter name for the error message.
+    """
+    if values is None:
+        return None, None
+    if not values:
+        return None, tool_error(
+            f"Invalid '{label}': when provided, it must contain at least one ID."
+        )
+    cleaned: list[str] = []
+    for value in values:
+        cleaned_id, err = validate_tool_id(value, label)
+        if err is not None:
+            return None, err
+        cleaned.append(cleaned_id)  # type: ignore[arg-type]
+    return cleaned, None
+
+
 def mutation_error_if_not_optional_dict(
     value: Any,
     *,

--- a/packages/mcp/tests/tools/test_observability_tools.py
+++ b/packages/mcp/tests/tools/test_observability_tools.py
@@ -348,7 +348,18 @@ async def test_get_automation_execution_metrics_partial_success(
 
     assert result.isError is False
     mock_observability_client.get_automation_execution_metrics.assert_awaited_once_with(
-        "3", ["25", "124"], repo_id="16", period="SIXTY_MINUTES", first=50, after=None
+        "3",
+        ["25", "124"],
+        repo_id="16",
+        action_ids=None,
+        event_id=None,
+        active=None,
+        search=None,
+        sort_by=None,
+        sort_order=None,
+        period="SIXTY_MINUTES",
+        first=50,
+        after=None,
     )
     payload = extract_payload(result)
     assert payload["success"] is True
@@ -375,7 +386,18 @@ async def test_get_automation_execution_metrics_without_ids_fetches_all(
 
     assert result.isError is False
     mock_observability_client.get_automation_execution_metrics.assert_awaited_once_with(
-        "3", None, repo_id=None, period="SIXTY_MINUTES", first=50, after=None
+        "3",
+        None,
+        repo_id=None,
+        action_ids=None,
+        event_id=None,
+        active=None,
+        search=None,
+        sort_by=None,
+        sort_order=None,
+        period="SIXTY_MINUTES",
+        first=50,
+        after=None,
     )
     assert extract_payload(result)["success"] is True
 
@@ -459,10 +481,109 @@ async def test_get_automation_execution_metrics_forwards_pagination(
 
     assert result.isError is False
     mock_observability_client.get_automation_execution_metrics.assert_awaited_once_with(
-        "3", None, repo_id=None, period="SIXTY_MINUTES", first=50, after="cur-0"
+        "3",
+        None,
+        repo_id=None,
+        action_ids=None,
+        event_id=None,
+        active=None,
+        search=None,
+        sort_by=None,
+        sort_order=None,
+        period="SIXTY_MINUTES",
+        first=50,
+        after="cur-0",
     )
     payload = extract_payload(result)
     assert payload["data"]["page_info"] == {"hasNextPage": True, "endCursor": "cur-1"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_execution_metrics_forwards_filters(
+    observability_session, mock_observability_client, extract_payload
+):
+    """All filter params reach the client; search is stripped."""
+    mock_observability_client.get_automation_execution_metrics.return_value = {
+        "automations": [],
+        "partial_errors": [],
+    }
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_execution_metrics",
+            {
+                "organization_id": "3",
+                "action_ids": ["9", "10"],
+                "event_id": "card_moved",
+                "active": True,
+                "search": "  welcome  ",
+                "sort_by": "name",
+                "sort_order": "asc",
+            },
+        )
+
+    assert result.isError is False
+    mock_observability_client.get_automation_execution_metrics.assert_awaited_once_with(
+        "3",
+        None,
+        repo_id=None,
+        action_ids=["9", "10"],
+        event_id="card_moved",
+        active=True,
+        search="welcome",
+        sort_by="name",
+        sort_order="asc",
+        period="SIXTY_MINUTES",
+        first=50,
+        after=None,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+@pytest.mark.parametrize(
+    ("arg", "value"),
+    [
+        ("event_id", "bogus_event"),
+        ("sort_by", "priority"),
+        ("sort_order", "descending"),
+    ],
+)
+async def test_get_automation_execution_metrics_rejects_invalid_enum(
+    observability_session, mock_observability_client, extract_payload, arg, value
+):
+    """Invalid enum-valued filters are rejected before any API call."""
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_execution_metrics",
+            {"organization_id": "3", arg: value},
+        )
+
+    assert result.isError is False
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert arg in tool_error_message(p)
+    mock_observability_client.get_automation_execution_metrics.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_execution_metrics_rejects_empty_action_ids(
+    observability_session, mock_observability_client, extract_payload
+):
+    """A present-but-empty action_ids list is rejected like automation_ids."""
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_execution_metrics",
+            {"organization_id": "3", "action_ids": []},
+        )
+
+    assert result.isError is False
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "action_ids" in tool_error_message(p)
+    mock_observability_client.get_automation_execution_metrics.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_observability_tools.py
+++ b/packages/mcp/tests/tools/test_observability_tools.py
@@ -588,6 +588,28 @@ async def test_get_automation_execution_metrics_rejects_empty_action_ids(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_execution_metrics_value_error_from_client(
+    observability_session, mock_observability_client, extract_payload
+):
+    """A total failure (SDK raises ValueError) comes back as a plain error envelope."""
+    mock_observability_client.get_automation_execution_metrics.side_effect = ValueError(
+        "Couldn't find Organization with 'id'=999"
+    )
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_execution_metrics",
+            {"organization_id": "999"},
+        )
+
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "Couldn't find Organization" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
 async def test_get_ai_credit_usage_success(
     observability_session, mock_observability_client, extract_payload
 ):

--- a/packages/mcp/tests/tools/test_observability_tools.py
+++ b/packages/mcp/tests/tools/test_observability_tools.py
@@ -348,7 +348,7 @@ async def test_get_automation_execution_metrics_partial_success(
 
     assert result.isError is False
     mock_observability_client.get_automation_execution_metrics.assert_awaited_once_with(
-        "3", ["25", "124"], repo_id="16", period="SIXTY_MINUTES"
+        "3", ["25", "124"], repo_id="16", period="SIXTY_MINUTES", first=30, after=None
     )
     payload = extract_payload(result)
     assert payload["success"] is True
@@ -375,7 +375,7 @@ async def test_get_automation_execution_metrics_without_ids_fetches_all(
 
     assert result.isError is False
     mock_observability_client.get_automation_execution_metrics.assert_awaited_once_with(
-        "3", None, repo_id=None, period="SIXTY_MINUTES"
+        "3", None, repo_id=None, period="SIXTY_MINUTES", first=30, after=None
     )
     assert extract_payload(result)["success"] is True
 
@@ -418,6 +418,51 @@ async def test_get_automation_execution_metrics_rejects_empty_ids(
     assert p["success"] is False
     assert "automation_ids" in tool_error_message(p)
     mock_observability_client.get_automation_execution_metrics.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_execution_metrics_rejects_first_over_cap(
+    observability_session, mock_observability_client, extract_payload
+):
+    """first above the server's 50-per-page cap is rejected before any API call."""
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_execution_metrics",
+            {"organization_id": "3", "first": 51},
+        )
+
+    assert result.isError is False
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "first" in tool_error_message(p)
+    mock_observability_client.get_automation_execution_metrics.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_execution_metrics_forwards_pagination(
+    observability_session, mock_observability_client, extract_payload
+):
+    """first and after reach the client; page_info rides back in the payload."""
+    mock_observability_client.get_automation_execution_metrics.return_value = {
+        "automations": [],
+        "partial_errors": [],
+        "page_info": {"hasNextPage": True, "endCursor": "cur-1"},
+    }
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_execution_metrics",
+            {"organization_id": "3", "first": 50, "after": "cur-0"},
+        )
+
+    assert result.isError is False
+    mock_observability_client.get_automation_execution_metrics.assert_awaited_once_with(
+        "3", None, repo_id=None, period="SIXTY_MINUTES", first=50, after="cur-0"
+    )
+    payload = extract_payload(result)
+    assert payload["data"]["page_info"] == {"hasNextPage": True, "endCursor": "cur-1"}
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_observability_tools.py
+++ b/packages/mcp/tests/tools/test_observability_tools.py
@@ -28,6 +28,7 @@ def mock_observability_client():
     client.get_automation_logs_by_repo = AsyncMock()
     client.get_agents_usage = AsyncMock()
     client.get_automations_usage = AsyncMock()
+    client.get_automation_execution_metrics = AsyncMock()
     client.get_ai_credit_usage = AsyncMock()
     client.export_automation_jobs = AsyncMock()
     client.get_automation_jobs_export = AsyncMock()
@@ -307,6 +308,116 @@ async def test_get_automations_usage_success(
     payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["data"]["automationsUsageDetails"]["usage"] == 500
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_execution_metrics_partial_success(
+    observability_session, mock_observability_client, extract_payload
+):
+    """Permitted automations + denied ids both surface; defaults applied."""
+    mock_observability_client.get_automation_execution_metrics.return_value = {
+        "automations": [
+            {
+                "id": "25",
+                "name": "Loop 51",
+                "executionMetrics": {
+                    "lastRun": None,
+                    "failureRate": 0.0,
+                    "successRate": 0.0,
+                    "averageDuration": None,
+                    "totalRuns": 0,
+                },
+            }
+        ],
+        "partial_errors": [
+            {
+                "automation_id": "124",
+                "code": "PERMISSION_DENIED",
+                "message": "Permission denied",
+                "correlation_id": "c86ccfa6",
+            }
+        ],
+    }
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_execution_metrics",
+            {"organization_id": "3", "automation_ids": ["25", "124"], "repo_id": "16"},
+        )
+
+    assert result.isError is False
+    mock_observability_client.get_automation_execution_metrics.assert_awaited_once_with(
+        "3", ["25", "124"], repo_id="16", period="SIXTY_MINUTES"
+    )
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert [a["id"] for a in payload["data"]["automations"]] == ["25"]
+    assert payload["data"]["partial_errors"][0]["automation_id"] == "124"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_execution_metrics_without_ids_fetches_all(
+    observability_session, mock_observability_client, extract_payload
+):
+    """Omitting automation_ids fetches every automation in the org (ids passed as None)."""
+    mock_observability_client.get_automation_execution_metrics.return_value = {
+        "automations": [],
+        "partial_errors": [],
+    }
+
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_execution_metrics",
+            {"organization_id": "3"},
+        )
+
+    assert result.isError is False
+    mock_observability_client.get_automation_execution_metrics.assert_awaited_once_with(
+        "3", None, repo_id=None, period="SIXTY_MINUTES"
+    )
+    assert extract_payload(result)["success"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_execution_metrics_rejects_invalid_period(
+    observability_session, mock_observability_client, extract_payload
+):
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_execution_metrics",
+            {
+                "organization_id": "3",
+                "automation_ids": ["25"],
+                "period": "current_month",
+            },
+        )
+
+    assert result.isError is False
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "period" in tool_error_message(p)
+    mock_observability_client.get_automation_execution_metrics.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("observability_session", [None], indirect=True)
+async def test_get_automation_execution_metrics_rejects_empty_ids(
+    observability_session, mock_observability_client, extract_payload
+):
+    async with observability_session as session:
+        result = await session.call_tool(
+            "get_automation_execution_metrics",
+            {"organization_id": "3", "automation_ids": []},
+        )
+
+    assert result.isError is False
+    p = extract_payload(result)
+    assert p["success"] is False
+    assert "automation_ids" in tool_error_message(p)
+    mock_observability_client.get_automation_execution_metrics.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_observability_tools.py
+++ b/packages/mcp/tests/tools/test_observability_tools.py
@@ -348,7 +348,7 @@ async def test_get_automation_execution_metrics_partial_success(
 
     assert result.isError is False
     mock_observability_client.get_automation_execution_metrics.assert_awaited_once_with(
-        "3", ["25", "124"], repo_id="16", period="SIXTY_MINUTES", first=30, after=None
+        "3", ["25", "124"], repo_id="16", period="SIXTY_MINUTES", first=50, after=None
     )
     payload = extract_payload(result)
     assert payload["success"] is True
@@ -375,7 +375,7 @@ async def test_get_automation_execution_metrics_without_ids_fetches_all(
 
     assert result.isError is False
     mock_observability_client.get_automation_execution_metrics.assert_awaited_once_with(
-        "3", None, repo_id=None, period="SIXTY_MINUTES", first=30, after=None
+        "3", None, repo_id=None, period="SIXTY_MINUTES", first=50, after=None
     )
     assert extract_payload(result)["success"] is True
 

--- a/packages/sdk/src/pipefy_sdk/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/__init__.py
@@ -45,6 +45,9 @@ from pipefy_sdk.services.automation_graphql_types import (
     AutomationRuleSummary,
 )
 from pipefy_sdk.services.observability_export_csv import download_bytes, stream_bytes
+from pipefy_sdk.services.observability_service import (
+    AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
+)
 from pipefy_sdk.services.table_service import (
     UPDATE_TABLE_RECORD_ALLOWED_FIELD_KEYS,
     UPDATE_TABLE_RECORD_FIELDS_ERROR_MESSAGE,
@@ -60,6 +63,7 @@ from pipefy_sdk.settings import PipefySettings
 __all__ = [
     "__version__",
     "AiAgentGraphPayload",
+    "AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE",
     "AUTOMATION_EXECUTION_METRICS_PERIODS",
     "Attachment",
     "AttachmentTarget",

--- a/packages/sdk/src/pipefy_sdk/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/__init__.py
@@ -36,7 +36,10 @@ from pipefy_sdk.models import (
 )
 from pipefy_sdk.models.form import create_form_model
 from pipefy_sdk.queries.observability_queries import (
+    AUTOMATION_EVENT_IDS,
     AUTOMATION_EXECUTION_METRICS_PERIODS,
+    AUTOMATION_SORT_BY,
+    AUTOMATION_SORT_ORDER,
 )
 from pipefy_sdk.services.automation_graphql_types import (
     AutomationActionRow,
@@ -63,8 +66,11 @@ from pipefy_sdk.settings import PipefySettings
 __all__ = [
     "__version__",
     "AiAgentGraphPayload",
+    "AUTOMATION_EVENT_IDS",
     "AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE",
     "AUTOMATION_EXECUTION_METRICS_PERIODS",
+    "AUTOMATION_SORT_BY",
+    "AUTOMATION_SORT_ORDER",
     "Attachment",
     "AttachmentTarget",
     "AttachmentUploadError",

--- a/packages/sdk/src/pipefy_sdk/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/__init__.py
@@ -35,6 +35,9 @@ from pipefy_sdk.models import (
     infer_content_type,
 )
 from pipefy_sdk.models.form import create_form_model
+from pipefy_sdk.queries.observability_queries import (
+    AUTOMATION_EXECUTION_METRICS_PERIODS,
+)
 from pipefy_sdk.services.automation_graphql_types import (
     AutomationActionRow,
     AutomationEventRow,
@@ -57,6 +60,7 @@ from pipefy_sdk.settings import PipefySettings
 __all__ = [
     "__version__",
     "AiAgentGraphPayload",
+    "AUTOMATION_EXECUTION_METRICS_PERIODS",
     "Attachment",
     "AttachmentTarget",
     "AttachmentUploadError",

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -1805,6 +1805,33 @@ class PipefyClient:
             organization_uuid, filter_date, filters=filters, search=search, sort=sort
         )
 
+    async def get_automation_execution_metrics(
+        self,
+        organization_id: str,
+        automation_ids: list[str] | None = None,
+        *,
+        repo_id: str | None = None,
+        period: str = "SIXTY_MINUTES",
+    ) -> dict[str, Any]:
+        """Get execution metrics for one or more automations within a rolling period.
+
+        Returns metrics for the automations this token may read plus a
+        ``partial_errors`` list for any that failed (e.g. ``PERMISSION_DENIED``).
+
+        Args:
+            organization_id: Organization ID (numeric org id, not a UUID).
+            automation_ids: Automation IDs to fetch metrics for. Omit to fetch
+                metrics for every automation in the organization (optionally
+                scoped by ``repo_id``).
+            repo_id: Optional pipe/repo ID to scope the query.
+            period: AutomationExecutionMetricsPeriod enum value (FIFTEEN_MINUTES,
+                SIXTY_MINUTES, TWELVE_HOURS, TWENTY_FOUR_HOURS). Defaults to
+                SIXTY_MINUTES, matching the API default.
+        """
+        return await self._observability_service.get_automation_execution_metrics(
+            organization_id, automation_ids, repo_id=repo_id, period=period
+        )
+
     async def get_ai_credit_usage(
         self,
         organization_uuid: str,

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -1814,6 +1814,12 @@ class PipefyClient:
         automation_ids: list[str] | None = None,
         *,
         repo_id: str | None = None,
+        action_ids: list[str] | None = None,
+        event_id: str | None = None,
+        active: bool | None = None,
+        search: str | None = None,
+        sort_by: str | None = None,
+        sort_order: str | None = None,
         period: str = "SIXTY_MINUTES",
         first: int = AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
         after: str | None = None,
@@ -1827,8 +1833,15 @@ class PipefyClient:
         Args:
             organization_id: Numeric org id, not a UUID.
             automation_ids: IDs to fetch metrics for. Omit to fetch every
-                automation in the organization (optionally scoped by ``repo_id``).
+                automation in the organization (optionally narrowed by the
+                filters below).
             repo_id: Optional pipe/repo ID to scope the query.
+            action_ids: Optional action IDs to filter by.
+            event_id: Optional trigger event, one of ``AUTOMATION_EVENT_IDS``.
+            active: Optional enabled/disabled filter.
+            search: Optional free-text match on automation name.
+            sort_by: Optional sort field, one of ``AUTOMATION_SORT_BY``.
+            sort_order: Optional sort direction, one of ``AUTOMATION_SORT_ORDER``.
             period: One of ``AUTOMATION_EXECUTION_METRICS_PERIODS`` (default
                 SIXTY_MINUTES, the API default).
             first: Page size (default and max 50).
@@ -1838,6 +1851,12 @@ class PipefyClient:
             organization_id,
             automation_ids,
             repo_id=repo_id,
+            action_ids=action_ids,
+            event_id=event_id,
+            active=active,
+            search=search,
+            sort_by=sort_by,
+            sort_order=sort_order,
             period=period,
             first=first,
             after=after,

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -45,7 +45,10 @@ from pipefy_sdk.services.automation_graphql_types import (
 from pipefy_sdk.services.automation_service import AutomationService
 from pipefy_sdk.services.card_service import CardService
 from pipefy_sdk.services.member_service import MemberService
-from pipefy_sdk.services.observability_service import ObservabilityService
+from pipefy_sdk.services.observability_service import (
+    _DEFAULT_PAGE_SIZE,
+    ObservabilityService,
+)
 from pipefy_sdk.services.organization_service import OrganizationService
 from pipefy_sdk.services.pipe_config_service import PipeConfigService
 from pipefy_sdk.services.pipe_service import (
@@ -1812,7 +1815,7 @@ class PipefyClient:
         *,
         repo_id: str | None = None,
         period: str = "SIXTY_MINUTES",
-        first: int = 30,
+        first: int = _DEFAULT_PAGE_SIZE,
         after: str | None = None,
     ) -> dict[str, Any]:
         """Get execution metrics for one or more automations within a rolling period.
@@ -1830,7 +1833,7 @@ class PipefyClient:
             period: AutomationExecutionMetricsPeriod enum value (FIFTEEN_MINUTES,
                 SIXTY_MINUTES, TWELVE_HOURS, TWENTY_FOUR_HOURS). Defaults to
                 SIXTY_MINUTES, matching the API default.
-            first: Page size (default 30; the server caps a page at 50).
+            first: Page size (default 30, max 50).
             after: Cursor from a previous page's ``page_info.endCursor``.
         """
         return await self._observability_service.get_automation_execution_metrics(

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -46,7 +46,7 @@ from pipefy_sdk.services.automation_service import AutomationService
 from pipefy_sdk.services.card_service import CardService
 from pipefy_sdk.services.member_service import MemberService
 from pipefy_sdk.services.observability_service import (
-    _DEFAULT_PAGE_SIZE,
+    AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
     ObservabilityService,
 )
 from pipefy_sdk.services.organization_service import OrganizationService
@@ -1815,26 +1815,24 @@ class PipefyClient:
         *,
         repo_id: str | None = None,
         period: str = "SIXTY_MINUTES",
-        first: int = _DEFAULT_PAGE_SIZE,
+        first: int = AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
         after: str | None = None,
     ) -> dict[str, Any]:
-        """Get execution metrics for one or more automations within a rolling period.
+        """Get execution metrics for automations within a rolling period.
 
-        Returns metrics for the automations this token may read plus a
-        ``partial_errors`` list for any that failed (e.g. ``PERMISSION_DENIED``),
-        and a ``page_info`` with ``hasNextPage`` and ``endCursor``.
+        Partial success: returns metrics for the automations this token may read
+        plus a ``partial_errors`` list naming any that failed. ``page_info``
+        carries the cursor for paging past the 50-automation max page.
 
         Args:
-            organization_id: Organization ID (numeric org id, not a UUID).
-            automation_ids: Automation IDs to fetch metrics for. Omit to fetch
-                metrics for every automation in the organization (optionally
-                scoped by ``repo_id``), one page at a time.
+            organization_id: Numeric org id, not a UUID.
+            automation_ids: IDs to fetch metrics for. Omit to fetch every
+                automation in the organization (optionally scoped by ``repo_id``).
             repo_id: Optional pipe/repo ID to scope the query.
-            period: AutomationExecutionMetricsPeriod enum value (FIFTEEN_MINUTES,
-                SIXTY_MINUTES, TWELVE_HOURS, TWENTY_FOUR_HOURS). Defaults to
-                SIXTY_MINUTES, matching the API default.
-            first: Page size (default 30, max 50).
-            after: Cursor from a previous page's ``page_info.endCursor``.
+            period: One of ``AUTOMATION_EXECUTION_METRICS_PERIODS`` (default
+                SIXTY_MINUTES, the API default).
+            first: Page size (default and max 50).
+            after: Cursor from the previous page's ``page_info.endCursor``.
         """
         return await self._observability_service.get_automation_execution_metrics(
             organization_id,

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -1812,24 +1812,34 @@ class PipefyClient:
         *,
         repo_id: str | None = None,
         period: str = "SIXTY_MINUTES",
+        first: int = 30,
+        after: str | None = None,
     ) -> dict[str, Any]:
         """Get execution metrics for one or more automations within a rolling period.
 
         Returns metrics for the automations this token may read plus a
-        ``partial_errors`` list for any that failed (e.g. ``PERMISSION_DENIED``).
+        ``partial_errors`` list for any that failed (e.g. ``PERMISSION_DENIED``),
+        and a ``page_info`` with ``hasNextPage`` and ``endCursor``.
 
         Args:
             organization_id: Organization ID (numeric org id, not a UUID).
             automation_ids: Automation IDs to fetch metrics for. Omit to fetch
                 metrics for every automation in the organization (optionally
-                scoped by ``repo_id``).
+                scoped by ``repo_id``), one page at a time.
             repo_id: Optional pipe/repo ID to scope the query.
             period: AutomationExecutionMetricsPeriod enum value (FIFTEEN_MINUTES,
                 SIXTY_MINUTES, TWELVE_HOURS, TWENTY_FOUR_HOURS). Defaults to
                 SIXTY_MINUTES, matching the API default.
+            first: Page size (default 30; the server caps a page at 50).
+            after: Cursor from a previous page's ``page_info.endCursor``.
         """
         return await self._observability_service.get_automation_execution_metrics(
-            organization_id, automation_ids, repo_id=repo_id, period=period
+            organization_id,
+            automation_ids,
+            repo_id=repo_id,
+            period=period,
+            first=first,
+            after=after,
         )
 
     async def get_ai_credit_usage(

--- a/packages/sdk/src/pipefy_sdk/graphql_executor.py
+++ b/packages/sdk/src/pipefy_sdk/graphql_executor.py
@@ -8,16 +8,18 @@ from gql import Client
 from gql.graphql_request import GraphQLRequest
 from gql.transport.exceptions import TransportQueryError
 from gql.transport.httpx import HTTPXAsyncTransport
-from graphql import DocumentNode, GraphQLSchema
+from graphql import DocumentNode, ExecutionResult, GraphQLSchema
 from httpx import Auth, Timeout
 
 
 class GraphQLExecutor(Protocol):
     """The GraphQL execution seam services depend on.
 
-    Narrow by design: it exposes only the operation services need and leaks
+    Narrow by design: it exposes only the operations services need and leaks
     nothing about the httpx/gql transport. Services receive an implementation
-    through their constructor and call ``execute_query``; tests inject a fake.
+    through their constructor and call ``execute_query``, or
+    ``execute_query_allow_partial`` when a response can mix ``data`` with
+    per-node ``errors``; tests inject a fake.
     ``query`` is a parsed ``DocumentNode``: callers build one with ``gql()`` (the
     raw ``execute_graphql`` passthrough parses its string before reaching here).
     """
@@ -25,6 +27,10 @@ class GraphQLExecutor(Protocol):
     async def execute_query(
         self, query: DocumentNode, variables: dict[str, Any]
     ) -> dict: ...
+
+    async def execute_query_allow_partial(
+        self, query: DocumentNode, variables: dict[str, Any]
+    ) -> ExecutionResult: ...
 
 
 def _graphql_request_with_variables(
@@ -72,16 +78,26 @@ class HttpxGraphQLExecutor:
         self._fetched_gql_schema: GraphQLSchema | None = None
         self._fetched_gql_schema_lock = asyncio.Lock()
 
-    async def execute_query(
-        self, query: DocumentNode, variables: dict[str, Any]
-    ) -> dict:
-        """Execute a GraphQL query/mutation with variables.
+    async def _execute_request(
+        self,
+        query: DocumentNode,
+        variables: dict[str, Any],
+        *,
+        get_execution_result: bool,
+    ) -> Any:
+        """Run a GraphQL request on a fresh transport, honoring schema caching.
 
         A fresh HTTPXAsyncTransport is created per call so concurrent invocations
         each get their own isolated connection state.
         By default the gql client does not fetch the remote schema (no introspection
         per request). When ``cache_schema`` is True the schema is fetched once per
         executor instance, cached, and reused for local validation.
+
+        ``get_execution_result`` is forwarded to gql's ``session.execute``: when
+        ``False`` gql returns the ``data`` dict and raises ``TransportQueryError`` if
+        the response carries GraphQL ``errors``; when ``True`` gql returns an
+        ``ExecutionResult`` carrying ``data`` and ``errors`` together without raising,
+        so partial-success responses are preserved.
         """
         transport = HTTPXAsyncTransport(
             url=self._graphql_url,
@@ -90,39 +106,68 @@ class HttpxGraphQLExecutor:
             verify=True,
             headers=self._headers,
         )
-        try:
-            if self._cache_schema:
-                if self._fetched_gql_schema is None:
-                    async with self._fetched_gql_schema_lock:
-                        if self._fetched_gql_schema is None:
-                            client = Client(
-                                transport=transport,
-                                fetch_schema_from_transport=True,
+        request = _graphql_request_with_variables(query, variables)
+        if self._cache_schema:
+            if self._fetched_gql_schema is None:
+                async with self._fetched_gql_schema_lock:
+                    if self._fetched_gql_schema is None:
+                        client = Client(
+                            transport=transport,
+                            fetch_schema_from_transport=True,
+                        )
+                        async with client as session:
+                            result = await session.execute(
+                                request, get_execution_result=get_execution_result
                             )
-                            async with client as session:
-                                result = await session.execute(
-                                    _graphql_request_with_variables(query, variables)
-                                )
-                            if client.schema is not None:
-                                self._fetched_gql_schema = client.schema
-                            return result
-                reuse_client = Client(
-                    transport=transport,
-                    schema=self._fetched_gql_schema,
-                    fetch_schema_from_transport=False,
-                )
-                async with reuse_client as session:
-                    return await session.execute(
-                        _graphql_request_with_variables(query, variables)
-                    )
-
-            async with Client(
-                transport=transport, fetch_schema_from_transport=False
-            ) as session:
+                        if client.schema is not None:
+                            self._fetched_gql_schema = client.schema
+                        return result
+            reuse_client = Client(
+                transport=transport,
+                schema=self._fetched_gql_schema,
+                fetch_schema_from_transport=False,
+            )
+            async with reuse_client as session:
                 return await session.execute(
-                    _graphql_request_with_variables(query, variables)
+                    request, get_execution_result=get_execution_result
                 )
+
+        async with Client(
+            transport=transport, fetch_schema_from_transport=False
+        ) as session:
+            return await session.execute(
+                request, get_execution_result=get_execution_result
+            )
+
+    async def execute_query(
+        self, query: DocumentNode, variables: dict[str, Any]
+    ) -> dict:
+        """Execute a GraphQL query/mutation with variables.
+
+        All-or-nothing semantics: gql raises ``TransportQueryError`` if the response
+        carries any GraphQL ``errors`` (the partial ``data`` is discarded). For
+        responses that intentionally mix data and per-node errors, use
+        :meth:`execute_query_allow_partial` instead.
+        """
+        try:
+            return await self._execute_request(
+                query, variables, get_execution_result=False
+            )
         except TransportQueryError as exc:
             if self._on_graphql_error is None:
                 raise
             raise ValueError(self._on_graphql_error(exc.errors or [])) from exc
+
+    async def execute_query_allow_partial(
+        self, query: DocumentNode, variables: dict[str, Any]
+    ) -> ExecutionResult:
+        """Execute a query preserving partial ``data`` alongside GraphQL ``errors``.
+
+        Pipefy can return ``data`` for the nodes a token may access AND per-node
+        ``errors`` (e.g. ``PERMISSION_DENIED`` carrying ``automation_id`` in
+        ``extensions``) in a single response. :meth:`execute_query` would raise and
+        drop the partial ``data``; this path uses gql's ``get_execution_result=True``
+        so callers receive both ``result.data`` and ``result.errors`` and can report a
+        partial success. Transport-level failures still raise as ``TransportError``.
+        """
+        return await self._execute_request(query, variables, get_execution_result=True)

--- a/packages/sdk/src/pipefy_sdk/graphql_executor.py
+++ b/packages/sdk/src/pipefy_sdk/graphql_executor.py
@@ -31,11 +31,9 @@ class PartialQueryResult:
 class GraphQLExecutor(Protocol):
     """The GraphQL execution seam services depend on.
 
-    Narrow by design: it exposes only the operations services need and leaks
+    Narrow by design: it exposes only the operation services need and leaks
     nothing about the httpx/gql transport. Services receive an implementation
-    through their constructor and call ``execute_query``, or
-    ``execute_query_allow_partial`` when a response can mix ``data`` with
-    per-node ``errors``; tests inject a fake.
+    through their constructor and call ``execute_query``; tests inject a fake.
     ``query`` is a parsed ``DocumentNode``: callers build one with ``gql()`` (the
     raw ``execute_graphql`` passthrough parses its string before reaching here).
     """
@@ -43,6 +41,16 @@ class GraphQLExecutor(Protocol):
     async def execute_query(
         self, query: DocumentNode, variables: dict[str, Any]
     ) -> dict: ...
+
+
+class PartialGraphQLExecutor(GraphQLExecutor, Protocol):
+    """:class:`GraphQLExecutor` plus a partial-tolerant execute path.
+
+    Required only by services whose queries can mix ``data`` with per-node
+    ``errors`` in one response (e.g. ``automations.executionMetrics``);
+    everything else depends on the narrower :class:`GraphQLExecutor` so the
+    shared seam stays one method.
+    """
 
     async def execute_query_allow_partial(
         self, query: DocumentNode, variables: dict[str, Any]

--- a/packages/sdk/src/pipefy_sdk/graphql_executor.py
+++ b/packages/sdk/src/pipefy_sdk/graphql_executor.py
@@ -15,13 +15,10 @@ from httpx import Auth, Timeout
 
 @dataclass(frozen=True)
 class PartialQueryResult:
-    """A GraphQL response that carries ``data`` and per-node ``errors`` together.
+    """GraphQL ``data`` plus the raw per-node error dicts from one response.
 
-    The executor's own value type for the partial-tolerant path, so services
-    and their tests never touch gql or graphql-core objects. ``errors`` holds
-    the raw GraphQL error dicts from the response body (``message`` plus an
-    ``extensions`` mapping); ``data`` holds the partial payload. A response with
-    no data at all is a failure and raises, so ``data`` is always a dict here.
+    Owned by the executor so services and their tests never touch gql objects.
+    ``data`` is always a dict: a response with no data raises instead.
     """
 
     data: dict[str, Any]
@@ -46,10 +43,8 @@ class GraphQLExecutor(Protocol):
 class PartialGraphQLExecutor(GraphQLExecutor, Protocol):
     """:class:`GraphQLExecutor` plus a partial-tolerant execute path.
 
-    Required only by services whose queries can mix ``data`` with per-node
-    ``errors`` in one response (e.g. ``automations.executionMetrics``);
-    everything else depends on the narrower :class:`GraphQLExecutor` so the
-    shared seam stays one method.
+    For services whose queries mix ``data`` with per-node ``errors`` in one
+    response; everything else depends on the narrower protocol.
     """
 
     async def execute_query_allow_partial(
@@ -113,9 +108,8 @@ class HttpxGraphQLExecutor:
         per request). When ``cache_schema`` is True the schema is fetched once per
         executor instance, cached, and reused for local validation.
 
-        Returns the ``data`` dict and raises ``TransportQueryError`` if the response
-        carries GraphQL ``errors`` (gql raises even when partial ``data`` is present).
-        The partial ``data`` and the ``errors`` are both available on the exception.
+        Any GraphQL ``errors`` raise ``TransportQueryError`` (even alongside partial
+        ``data``); the exception carries both ``data`` and ``errors``.
         """
         transport = HTTPXAsyncTransport(
             url=self._graphql_url,
@@ -152,12 +146,6 @@ class HttpxGraphQLExecutor:
             return await session.execute(request)
 
     def _reraise_graphql_error(self, exc: TransportQueryError) -> NoReturn:
-        """Reraise a gql error as the executor's error type.
-
-        With ``on_graphql_error`` set (the Internal API executor) the gql exception
-        is converted to ``ValueError`` carrying the formatter's ``[code=…]`` envelope;
-        otherwise the original ``TransportQueryError`` propagates unchanged.
-        """
         if self._on_graphql_error is None:
             raise exc
         raise ValueError(self._on_graphql_error(exc.errors or [])) from exc
@@ -167,10 +155,9 @@ class HttpxGraphQLExecutor:
     ) -> dict:
         """Execute a GraphQL query/mutation with variables.
 
-        All-or-nothing semantics: gql raises ``TransportQueryError`` if the response
-        carries any GraphQL ``errors`` (the partial ``data`` is discarded). For
-        responses that intentionally mix data and per-node errors, use
-        :meth:`execute_query_allow_partial` instead.
+        All-or-nothing: any GraphQL ``errors`` raise and partial ``data`` is
+        discarded; for responses that mix both, use
+        :meth:`execute_query_allow_partial`.
         """
         try:
             return await self._execute_request(query, variables)
@@ -182,14 +169,10 @@ class HttpxGraphQLExecutor:
     ) -> PartialQueryResult:
         """Execute a query preserving partial ``data`` alongside GraphQL ``errors``.
 
-        Pipefy can return ``data`` for the nodes a token may access AND per-node
-        ``errors`` (e.g. ``PERMISSION_DENIED`` carrying ``automation_id`` in
-        ``extensions``) in a single response. gql raises ``TransportQueryError`` on
-        any ``errors`` even in this mode, but attaches the partial ``data`` and the
-        ``errors`` to the exception, so this rebuilds them into a
-        :class:`PartialQueryResult`. A response with no ``data`` at all is a real
-        failure and reraises like :meth:`execute_query`; transport-level failures
-        always raise.
+        gql raises on any ``errors`` but attaches the partial ``data`` and the raw
+        error dicts to the exception; this rebuilds them into a
+        :class:`PartialQueryResult`. A response with no ``data`` at all reraises
+        like :meth:`execute_query`.
         """
         try:
             data = await self._execute_request(query, variables)

--- a/packages/sdk/src/pipefy_sdk/graphql_executor.py
+++ b/packages/sdk/src/pipefy_sdk/graphql_executor.py
@@ -18,7 +18,7 @@ class PartialQueryResult:
     """GraphQL ``data`` plus the raw per-node error dicts from one response.
 
     Owned by the executor so services and their tests never touch gql objects.
-    ``data`` is always a dict: a response with no data raises instead.
+    ``data`` is always a dict; a fully null response yields an empty one.
     """
 
     data: dict[str, Any]
@@ -171,13 +171,14 @@ class HttpxGraphQLExecutor:
 
         gql raises on any ``errors`` but attaches the partial ``data`` and the raw
         error dicts to the exception; this rebuilds them into a
-        :class:`PartialQueryResult`. A response with no ``data`` at all reraises
-        like :meth:`execute_query`.
+        :class:`PartialQueryResult`. A fully null response yields ``data={}`` with
+        its errors preserved: whether an empty result is a failure is the caller's
+        decision, not the transport's.
         """
         try:
             data = await self._execute_request(query, variables)
         except TransportQueryError as exc:
-            if exc.data is None:
-                self._reraise_graphql_error(exc)
-            return PartialQueryResult(data=exc.data, errors=list(exc.errors or []))
+            return PartialQueryResult(
+                data=exc.data or {}, errors=list(exc.errors or [])
+            )
         return PartialQueryResult(data=data, errors=[])

--- a/packages/sdk/src/pipefy_sdk/graphql_executor.py
+++ b/packages/sdk/src/pipefy_sdk/graphql_executor.py
@@ -2,14 +2,30 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from typing import Any, ClassVar, Protocol
+from dataclasses import dataclass
+from typing import Any, ClassVar, NoReturn, Protocol
 
 from gql import Client
 from gql.graphql_request import GraphQLRequest
 from gql.transport.exceptions import TransportQueryError
 from gql.transport.httpx import HTTPXAsyncTransport
-from graphql import DocumentNode, ExecutionResult, GraphQLSchema
+from graphql import DocumentNode, GraphQLSchema
 from httpx import Auth, Timeout
+
+
+@dataclass(frozen=True)
+class PartialQueryResult:
+    """A GraphQL response that carries ``data`` and per-node ``errors`` together.
+
+    The executor's own value type for the partial-tolerant path, so services
+    and their tests never touch gql or graphql-core objects. ``errors`` holds
+    the raw GraphQL error dicts from the response body (``message`` plus an
+    ``extensions`` mapping); ``data`` holds the partial payload. A response with
+    no data at all is a failure and raises, so ``data`` is always a dict here.
+    """
+
+    data: dict[str, Any]
+    errors: list[dict[str, Any]]
 
 
 class GraphQLExecutor(Protocol):
@@ -30,7 +46,7 @@ class GraphQLExecutor(Protocol):
 
     async def execute_query_allow_partial(
         self, query: DocumentNode, variables: dict[str, Any]
-    ) -> ExecutionResult: ...
+    ) -> PartialQueryResult: ...
 
 
 def _graphql_request_with_variables(
@@ -79,12 +95,8 @@ class HttpxGraphQLExecutor:
         self._fetched_gql_schema_lock = asyncio.Lock()
 
     async def _execute_request(
-        self,
-        query: DocumentNode,
-        variables: dict[str, Any],
-        *,
-        get_execution_result: bool,
-    ) -> Any:
+        self, query: DocumentNode, variables: dict[str, Any]
+    ) -> dict:
         """Run a GraphQL request on a fresh transport, honoring schema caching.
 
         A fresh HTTPXAsyncTransport is created per call so concurrent invocations
@@ -93,11 +105,9 @@ class HttpxGraphQLExecutor:
         per request). When ``cache_schema`` is True the schema is fetched once per
         executor instance, cached, and reused for local validation.
 
-        ``get_execution_result`` is forwarded to gql's ``session.execute``: when
-        ``False`` gql returns the ``data`` dict and raises ``TransportQueryError`` if
-        the response carries GraphQL ``errors``; when ``True`` gql returns an
-        ``ExecutionResult`` carrying ``data`` and ``errors`` together without raising,
-        so partial-success responses are preserved.
+        Returns the ``data`` dict and raises ``TransportQueryError`` if the response
+        carries GraphQL ``errors`` (gql raises even when partial ``data`` is present).
+        The partial ``data`` and the ``errors`` are both available on the exception.
         """
         transport = HTTPXAsyncTransport(
             url=self._graphql_url,
@@ -116,9 +126,7 @@ class HttpxGraphQLExecutor:
                             fetch_schema_from_transport=True,
                         )
                         async with client as session:
-                            result = await session.execute(
-                                request, get_execution_result=get_execution_result
-                            )
+                            result = await session.execute(request)
                         if client.schema is not None:
                             self._fetched_gql_schema = client.schema
                         return result
@@ -128,16 +136,23 @@ class HttpxGraphQLExecutor:
                 fetch_schema_from_transport=False,
             )
             async with reuse_client as session:
-                return await session.execute(
-                    request, get_execution_result=get_execution_result
-                )
+                return await session.execute(request)
 
         async with Client(
             transport=transport, fetch_schema_from_transport=False
         ) as session:
-            return await session.execute(
-                request, get_execution_result=get_execution_result
-            )
+            return await session.execute(request)
+
+    def _reraise_graphql_error(self, exc: TransportQueryError) -> NoReturn:
+        """Reraise a gql error as the executor's error type.
+
+        With ``on_graphql_error`` set (the Internal API executor) the gql exception
+        is converted to ``ValueError`` carrying the formatter's ``[code=…]`` envelope;
+        otherwise the original ``TransportQueryError`` propagates unchanged.
+        """
+        if self._on_graphql_error is None:
+            raise exc
+        raise ValueError(self._on_graphql_error(exc.errors or [])) from exc
 
     async def execute_query(
         self, query: DocumentNode, variables: dict[str, Any]
@@ -150,24 +165,28 @@ class HttpxGraphQLExecutor:
         :meth:`execute_query_allow_partial` instead.
         """
         try:
-            return await self._execute_request(
-                query, variables, get_execution_result=False
-            )
+            return await self._execute_request(query, variables)
         except TransportQueryError as exc:
-            if self._on_graphql_error is None:
-                raise
-            raise ValueError(self._on_graphql_error(exc.errors or [])) from exc
+            self._reraise_graphql_error(exc)
 
     async def execute_query_allow_partial(
         self, query: DocumentNode, variables: dict[str, Any]
-    ) -> ExecutionResult:
+    ) -> PartialQueryResult:
         """Execute a query preserving partial ``data`` alongside GraphQL ``errors``.
 
         Pipefy can return ``data`` for the nodes a token may access AND per-node
         ``errors`` (e.g. ``PERMISSION_DENIED`` carrying ``automation_id`` in
-        ``extensions``) in a single response. :meth:`execute_query` would raise and
-        drop the partial ``data``; this path uses gql's ``get_execution_result=True``
-        so callers receive both ``result.data`` and ``result.errors`` and can report a
-        partial success. Transport-level failures still raise as ``TransportError``.
+        ``extensions``) in a single response. gql raises ``TransportQueryError`` on
+        any ``errors`` even in this mode, but attaches the partial ``data`` and the
+        ``errors`` to the exception, so this rebuilds them into a
+        :class:`PartialQueryResult`. A response with no ``data`` at all is a real
+        failure and reraises like :meth:`execute_query`; transport-level failures
+        always raise.
         """
-        return await self._execute_request(query, variables, get_execution_result=True)
+        try:
+            data = await self._execute_request(query, variables)
+        except TransportQueryError as exc:
+            if exc.data is None:
+                self._reraise_graphql_error(exc)
+            return PartialQueryResult(data=exc.data, errors=list(exc.errors or []))
+        return PartialQueryResult(data=data, errors=[])

--- a/packages/sdk/src/pipefy_sdk/queries/observability_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/observability_queries.py
@@ -239,6 +239,16 @@ GET_AUTOMATIONS_USAGE_QUERY = gql(
     """
 )
 
+# AutomationExecutionMetricsPeriod enum values, ascending by window length. Single
+# source for the `$period` variable so the MCP validation set and CLI help stay in
+# step with the schema instead of drifting across hand-copied prose.
+AUTOMATION_EXECUTION_METRICS_PERIODS: tuple[str, ...] = (
+    "FIFTEEN_MINUTES",
+    "SIXTY_MINUTES",
+    "TWELVE_HOURS",
+    "TWENTY_FOUR_HOURS",
+)
+
 GET_AUTOMATION_EXECUTION_METRICS_QUERY = gql(
     """
     query AutomationExecutionMetrics(
@@ -343,6 +353,7 @@ GET_AUTOMATION_JOBS_EXPORT_QUERY = gql(
 )
 
 __all__ = [
+    "AUTOMATION_EXECUTION_METRICS_PERIODS",
     "CREATE_AUTOMATION_JOBS_EXPORT_MUTATION",
     "GET_AUTOMATION_EXECUTION_METRICS_QUERY",
     "GET_AUTOMATION_JOBS_EXPORT_QUERY",

--- a/packages/sdk/src/pipefy_sdk/queries/observability_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/observability_queries.py
@@ -256,12 +256,20 @@ GET_AUTOMATION_EXECUTION_METRICS_QUERY = gql(
         $repoId: ID
         $automationIds: [ID!]
         $period: AutomationExecutionMetricsPeriod
+        $first: Int
+        $after: String
     ) {
         automations(
             organizationId: $organizationId
             repoId: $repoId
             automationIds: $automationIds
+            first: $first
+            after: $after
         ) {
+            pageInfo {
+                hasNextPage
+                endCursor
+            }
             edges {
                 node {
                     id

--- a/packages/sdk/src/pipefy_sdk/queries/observability_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/observability_queries.py
@@ -239,9 +239,6 @@ GET_AUTOMATIONS_USAGE_QUERY = gql(
     """
 )
 
-# AutomationExecutionMetricsPeriod enum values, ascending by window length. Single
-# source for the `$period` variable so the MCP validation set and CLI help stay in
-# step with the schema instead of drifting across hand-copied prose.
 AUTOMATION_EXECUTION_METRICS_PERIODS: tuple[str, ...] = (
     "FIFTEEN_MINUTES",
     "SIXTY_MINUTES",

--- a/packages/sdk/src/pipefy_sdk/queries/observability_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/observability_queries.py
@@ -246,12 +246,37 @@ AUTOMATION_EXECUTION_METRICS_PERIODS: tuple[str, ...] = (
     "TWENTY_FOUR_HOURS",
 )
 
+# AutomationsEvents enum values accepted by the `automations` query's `eventId`
+# filter. Single source so the MCP validation set and CLI help stay in step with
+# the schema instead of drifting across hand-copied prose.
+AUTOMATION_EVENT_IDS: tuple[str, ...] = (
+    "card_moved",
+    "field_updated",
+    "card_created",
+    "scheduler",
+    "sla_based",
+    "card_left_phase",
+    "card_inbox_received_email",
+    "all_children_in_phase",
+    "http_response_received",
+    "manually_triggered",
+)
+
+# AutomationSortCriteria fields: `by` (AutomationSortBy) and `order` (SortDirection).
+AUTOMATION_SORT_BY: tuple[str, ...] = ("created_at", "name")
+AUTOMATION_SORT_ORDER: tuple[str, ...] = ("asc", "desc")
+
 GET_AUTOMATION_EXECUTION_METRICS_QUERY = gql(
     """
     query AutomationExecutionMetrics(
         $organizationId: ID!
         $repoId: ID
         $automationIds: [ID!]
+        $actionIds: [ID!]
+        $eventId: AutomationsEvents
+        $active: Boolean
+        $search: String
+        $sort: AutomationSortCriteria
         $period: AutomationExecutionMetricsPeriod
         $first: Int
         $after: String
@@ -260,6 +285,11 @@ GET_AUTOMATION_EXECUTION_METRICS_QUERY = gql(
             organizationId: $organizationId
             repoId: $repoId
             automationIds: $automationIds
+            actionIds: $actionIds
+            eventId: $eventId
+            active: $active
+            search: $search
+            sort: $sort
             first: $first
             after: $after
         ) {
@@ -358,7 +388,10 @@ GET_AUTOMATION_JOBS_EXPORT_QUERY = gql(
 )
 
 __all__ = [
+    "AUTOMATION_EVENT_IDS",
     "AUTOMATION_EXECUTION_METRICS_PERIODS",
+    "AUTOMATION_SORT_BY",
+    "AUTOMATION_SORT_ORDER",
     "CREATE_AUTOMATION_JOBS_EXPORT_MUTATION",
     "GET_AUTOMATION_EXECUTION_METRICS_QUERY",
     "GET_AUTOMATION_JOBS_EXPORT_QUERY",

--- a/packages/sdk/src/pipefy_sdk/queries/observability_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/observability_queries.py
@@ -239,6 +239,43 @@ GET_AUTOMATIONS_USAGE_QUERY = gql(
     """
 )
 
+GET_AUTOMATION_EXECUTION_METRICS_QUERY = gql(
+    """
+    query AutomationExecutionMetrics(
+        $organizationId: ID!
+        $repoId: ID
+        $automationIds: [ID!]
+        $period: AutomationExecutionMetricsPeriod
+    ) {
+        automations(
+            organizationId: $organizationId
+            repoId: $repoId
+            automationIds: $automationIds
+        ) {
+            edges {
+                node {
+                    id
+                    name
+                    event_id
+                    action_id
+                    event_repo {
+                        id
+                        name
+                    }
+                    executionMetrics(period: $period) {
+                        lastRun
+                        failureRate
+                        successRate
+                        averageDuration
+                        totalRuns
+                    }
+                }
+            }
+        }
+    }
+    """
+)
+
 RESOLVE_ORGANIZATION_UUID_QUERY = gql(
     """
     query ResolveOrganizationUuid($id: ID!) {
@@ -307,6 +344,7 @@ GET_AUTOMATION_JOBS_EXPORT_QUERY = gql(
 
 __all__ = [
     "CREATE_AUTOMATION_JOBS_EXPORT_MUTATION",
+    "GET_AUTOMATION_EXECUTION_METRICS_QUERY",
     "GET_AUTOMATION_JOBS_EXPORT_QUERY",
     "GET_AGENTS_USAGE_QUERY",
     "GET_AI_AGENT_LOG_DETAILS_QUERY",

--- a/packages/sdk/src/pipefy_sdk/services/observability_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/observability_service.py
@@ -118,6 +118,10 @@ def _normalize_execution_metrics_result(result: PartialQueryResult) -> dict[str,
     An empty ``edges`` list (every requested automation denied) stays a partial
     success with a populated ``partial_errors``.
 
+    ``page_info`` carries the connection's ``pageInfo`` (``hasNextPage``,
+    ``endCursor``); the server caps each page at 50 automations, so callers page
+    with ``after`` until ``hasNextPage`` is false.
+
     Args:
         result: PartialQueryResult from ``execute_query_allow_partial``.
     """
@@ -126,7 +130,12 @@ def _normalize_execution_metrics_result(result: PartialQueryResult) -> dict[str,
         raise ValueError(result.errors[0].get("message") or "Query failed.")
     automations = unwrap_relay_connection_nodes(connection)
     partial_errors = [_partial_error(err) for err in result.errors]
-    return {"automations": automations, "partial_errors": partial_errors}
+    page_info = connection.get("pageInfo") if isinstance(connection, dict) else None
+    return {
+        "automations": automations,
+        "partial_errors": partial_errors,
+        "page_info": page_info,
+    }
 
 
 class ObservabilityService:
@@ -142,6 +151,8 @@ class ObservabilityService:
         *,
         repo_id: str | None = None,
         period: str = "SIXTY_MINUTES",
+        first: int = _DEFAULT_PAGE_SIZE,
+        after: str | None = None,
     ) -> dict[str, Any]:
         """Get execution metrics for one or more automations within a rolling period.
 
@@ -150,26 +161,35 @@ class ObservabilityService:
         (e.g. ``PERMISSION_DENIED``). The ``automations`` query reports per-node
         errors alongside data, so this uses the partial-tolerant execute path.
 
+        The connection is paginated (the server caps each page at 50 automations).
+        The returned ``page_info`` carries ``hasNextPage`` and ``endCursor``; pass
+        ``endCursor`` back as ``after`` to fetch the next page.
+
         Args:
             organization_id: Organization ID (required by the ``automations`` query;
                 a numeric org id, not a UUID).
             automation_ids: Automation IDs to fetch metrics for. When ``None``,
                 the ``automationIds`` filter is omitted and the query returns
                 metrics for every automation in the organization (optionally
-                scoped by ``repo_id``).
+                scoped by ``repo_id``), one page at a time.
             repo_id: Optional pipe/repo ID to scope the query.
             period: AutomationExecutionMetricsPeriod enum value (FIFTEEN_MINUTES,
                 SIXTY_MINUTES, TWELVE_HOURS, TWENTY_FOUR_HOURS). Defaults to
                 SIXTY_MINUTES, matching the API default.
+            first: Page size (default 30; the server caps a page at 50).
+            after: Cursor from a previous page's ``page_info.endCursor``.
         """
         variables: dict[str, Any] = {
             "organizationId": organization_id,
             "period": period,
+            "first": first,
         }
         if automation_ids is not None:
             variables["automationIds"] = automation_ids
         if repo_id is not None:
             variables["repoId"] = repo_id
+        if after is not None:
+            variables["after"] = after
         result = await self._executor.execute_query_allow_partial(
             GET_AUTOMATION_EXECUTION_METRICS_QUERY, variables
         )

--- a/packages/sdk/src/pipefy_sdk/services/observability_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/observability_service.py
@@ -104,18 +104,7 @@ def _build_execution_metrics_variables(
     first: int,
     after: str | None,
 ) -> dict[str, Any]:
-    """Build the GraphQL variables dict for the execution-metrics query.
-
-    Optional filters are omitted when ``None`` rather than sent as nulls.
-
-    Args:
-        organization_id: Organization ID.
-        automation_ids: Optional automation IDs filter.
-        repo_id: Optional pipe/repo ID to scope the query.
-        period: AutomationExecutionMetricsPeriod enum value.
-        first: Page size.
-        after: Cursor for the next page.
-    """
+    """Build the execution-metrics variables, omitting optional filters that are ``None``."""
     variables: dict[str, Any] = {
         "organizationId": organization_id,
         "period": period,
@@ -144,24 +133,10 @@ def _partial_error(err: dict[str, Any]) -> dict[str, Any]:
 def _normalize_execution_metrics_result(result: PartialQueryResult) -> dict[str, Any]:
     """Split a partial ``automations.executionMetrics`` response into nodes and errors.
 
-    ``result.data`` carries the automations the token may read (each with its
-    ``executionMetrics``); ``result.errors`` carries per-automation failures
-    (e.g. ``PERMISSION_DENIED``) with ``automation_id`` in ``extensions``. Both are
-    returned so the caller can report a partial success.
-
     A null ``automations`` connection means the lookup itself failed (bad org, no
-    org access) rather than individual nodes being denied; that is a total failure,
-    so this raises ``ValueError`` (with the response's first error message when
-    present) instead of reporting an empty partial success. An empty ``edges``
-    list (every requested automation denied) stays a partial success with a
-    populated ``partial_errors``.
-
-    ``page_info`` carries the connection's ``pageInfo`` (``hasNextPage``,
-    ``endCursor``); a page contains at most 50 automations (the connection's max
-    page size), so callers page with ``after`` until ``hasNextPage`` is false.
-
-    Args:
-        result: PartialQueryResult from ``execute_query_allow_partial``.
+    org access), so it raises ``ValueError``; an empty ``edges`` list (every
+    requested automation denied) stays a partial success. ``page_info`` carries
+    the connection's ``pageInfo`` for cursor paging.
     """
     connection = result.data.get("automations")
     if connection is None:
@@ -190,33 +165,24 @@ class ObservabilityService:
         *,
         repo_id: str | None = None,
         period: str = "SIXTY_MINUTES",
-        first: int = _DEFAULT_PAGE_SIZE,
+        first: int = AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
         after: str | None = None,
     ) -> dict[str, Any]:
-        """Get execution metrics for one or more automations within a rolling period.
+        """Get execution metrics for automations within a rolling period.
 
-        Partial success: returns metrics for the automations this token may read,
-        plus a ``partial_errors`` list naming any automations that failed
-        (e.g. ``PERMISSION_DENIED``). The ``automations`` query reports per-node
-        errors alongside data, so this uses the partial-tolerant execute path.
-
-        The connection is paginated with a max page size of 50.
-        The returned ``page_info`` carries ``hasNextPage`` and ``endCursor``; pass
-        ``endCursor`` back as ``after`` to fetch the next page.
+        Partial success: returns metrics for the automations this token may read
+        plus a ``partial_errors`` list naming any that failed. ``page_info``
+        carries the cursor for paging past the 50-automation max page.
 
         Args:
-            organization_id: Organization ID (required by the ``automations`` query;
-                a numeric org id, not a UUID).
-            automation_ids: Automation IDs to fetch metrics for. When ``None``,
-                the ``automationIds`` filter is omitted and the query returns
-                metrics for every automation in the organization (optionally
-                scoped by ``repo_id``), one page at a time.
+            organization_id: Numeric org id, not a UUID.
+            automation_ids: IDs to fetch metrics for. ``None`` fetches every
+                automation in the organization (optionally scoped by ``repo_id``).
             repo_id: Optional pipe/repo ID to scope the query.
-            period: AutomationExecutionMetricsPeriod enum value (FIFTEEN_MINUTES,
-                SIXTY_MINUTES, TWELVE_HOURS, TWENTY_FOUR_HOURS). Defaults to
-                SIXTY_MINUTES, matching the API default.
-            first: Page size (default 30, max 50).
-            after: Cursor from a previous page's ``page_info.endCursor``.
+            period: One of ``AUTOMATION_EXECUTION_METRICS_PERIODS`` (default
+                SIXTY_MINUTES, the API default).
+            first: Page size (default and max 50).
+            after: Cursor from the previous page's ``page_info.endCursor``.
         """
         variables = _build_execution_metrics_variables(
             organization_id,

--- a/packages/sdk/src/pipefy_sdk/services/observability_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/observability_service.py
@@ -95,6 +95,22 @@ def _build_usage_variables(
     return variables
 
 
+def _build_sort_criteria(
+    sort_by: str | None, sort_order: str | None
+) -> dict[str, str] | None:
+    """Assemble an ``AutomationSortCriteria`` input, or ``None`` when unset.
+
+    Each field is included only when provided, so a caller may sort by field
+    alone, order alone, or both.
+    """
+    sort: dict[str, str] = {}
+    if sort_by is not None:
+        sort["by"] = sort_by
+    if sort_order is not None:
+        sort["order"] = sort_order
+    return sort or None
+
+
 def _build_execution_metrics_variables(
     organization_id: str,
     automation_ids: list[str] | None,
@@ -103,6 +119,12 @@ def _build_execution_metrics_variables(
     period: str,
     first: int,
     after: str | None,
+    action_ids: list[str] | None = None,
+    event_id: str | None = None,
+    active: bool | None = None,
+    search: str | None = None,
+    sort_by: str | None = None,
+    sort_order: str | None = None,
 ) -> dict[str, Any]:
     """Build the execution-metrics variables, omitting optional filters that are ``None``."""
     variables: dict[str, Any] = {
@@ -114,6 +136,17 @@ def _build_execution_metrics_variables(
         variables["automationIds"] = automation_ids
     if repo_id is not None:
         variables["repoId"] = repo_id
+    if action_ids is not None:
+        variables["actionIds"] = action_ids
+    if event_id is not None:
+        variables["eventId"] = event_id
+    if active is not None:
+        variables["active"] = active
+    if search is not None:
+        variables["search"] = search
+    sort = _build_sort_criteria(sort_by, sort_order)
+    if sort is not None:
+        variables["sort"] = sort
     if after is not None:
         variables["after"] = after
     return variables
@@ -164,6 +197,12 @@ class ObservabilityService:
         automation_ids: list[str] | None = None,
         *,
         repo_id: str | None = None,
+        action_ids: list[str] | None = None,
+        event_id: str | None = None,
+        active: bool | None = None,
+        search: str | None = None,
+        sort_by: str | None = None,
+        sort_order: str | None = None,
         period: str = "SIXTY_MINUTES",
         first: int = AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE,
         after: str | None = None,
@@ -177,8 +216,15 @@ class ObservabilityService:
         Args:
             organization_id: Numeric org id, not a UUID.
             automation_ids: IDs to fetch metrics for. ``None`` fetches every
-                automation in the organization (optionally scoped by ``repo_id``).
+                automation in the organization (optionally narrowed by the
+                filters below).
             repo_id: Optional pipe/repo ID to scope the query.
+            action_ids: Optional action IDs to filter by.
+            event_id: Optional trigger event, one of ``AUTOMATION_EVENT_IDS``.
+            active: Optional enabled/disabled filter.
+            search: Optional free-text match on automation name.
+            sort_by: Optional sort field, one of ``AUTOMATION_SORT_BY``.
+            sort_order: Optional sort direction, one of ``AUTOMATION_SORT_ORDER``.
             period: One of ``AUTOMATION_EXECUTION_METRICS_PERIODS`` (default
                 SIXTY_MINUTES, the API default).
             first: Page size (default and max 50).
@@ -191,6 +237,12 @@ class ObservabilityService:
             period=period,
             first=first,
             after=after,
+            action_ids=action_ids,
+            event_id=event_id,
+            active=active,
+            search=search,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
         result = await self._executor.execute_query_allow_partial(
             GET_AUTOMATION_EXECUTION_METRICS_QUERY, variables

--- a/packages/sdk/src/pipefy_sdk/services/observability_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/observability_service.py
@@ -6,6 +6,7 @@ from typing import Any, TypedDict
 from zipfile import BadZipFile
 
 import httpx
+from graphql import ExecutionResult
 from openpyxl.utils.exceptions import InvalidFileException
 
 from pipefy_sdk.graphql_executor import GraphQLExecutor
@@ -15,6 +16,7 @@ from pipefy_sdk.queries.observability_queries import (
     GET_AI_AGENT_LOG_DETAILS_QUERY,
     GET_AI_AGENT_LOGS_QUERY,
     GET_AI_CREDIT_USAGE_QUERY,
+    GET_AUTOMATION_EXECUTION_METRICS_QUERY,
     GET_AUTOMATION_JOBS_EXPORT_QUERY,
     GET_AUTOMATION_LOGS_BY_REPO_QUERY,
     GET_AUTOMATION_LOGS_QUERY,
@@ -25,6 +27,7 @@ from pipefy_sdk.services.observability_export_csv import (
     xlsx_first_sheet_to_csv_limited,
 )
 from pipefy_sdk.utils.organization_identifiers import resolve_organization_uuid
+from pipefy_sdk.utils.relay import unwrap_relay_connection_nodes
 
 _DEFAULT_PAGE_SIZE = 30
 
@@ -91,11 +94,78 @@ def _build_usage_variables(
     return variables
 
 
+def _normalize_execution_metrics_result(result: ExecutionResult) -> dict[str, Any]:
+    """Split a partial ``automations.executionMetrics`` response into nodes and errors.
+
+    ``result.data`` carries the automations the token may read (each with its
+    ``executionMetrics``); ``result.errors`` carries per-automation failures
+    (e.g. ``PERMISSION_DENIED``) with ``automation_id`` in ``extensions``. Both are
+    returned so the caller can report a partial success.
+
+    Args:
+        result: ExecutionResult from ``execute_query_allow_partial``.
+    """
+    data = result.data or {}
+    automations = unwrap_relay_connection_nodes(data.get("automations"))
+    partial_errors: list[dict[str, Any]] = []
+    for err in result.errors or []:
+        extensions = getattr(err, "extensions", None) or {}
+        partial_errors.append(
+            {
+                "automation_id": extensions.get("automation_id"),
+                "code": extensions.get("code"),
+                "message": getattr(err, "message", str(err)),
+                "correlation_id": extensions.get("correlation_id"),
+            }
+        )
+    return {"automations": automations, "partial_errors": partial_errors}
+
+
 class ObservabilityService:
     """Reads for AI agent logs, automation logs, usage stats, and credit dashboard."""
 
     def __init__(self, *, executor: GraphQLExecutor) -> None:
         self._executor = executor
+
+    async def get_automation_execution_metrics(
+        self,
+        organization_id: str,
+        automation_ids: list[str] | None = None,
+        *,
+        repo_id: str | None = None,
+        period: str = "SIXTY_MINUTES",
+    ) -> dict[str, Any]:
+        """Get execution metrics for one or more automations within a rolling period.
+
+        Partial success: returns metrics for the automations this token may read,
+        plus a ``partial_errors`` list naming any automations that failed
+        (e.g. ``PERMISSION_DENIED``). The ``automations`` query reports per-node
+        errors alongside data, so this uses the partial-tolerant execute path.
+
+        Args:
+            organization_id: Organization ID (required by the ``automations`` query;
+                a numeric org id, not a UUID).
+            automation_ids: Automation IDs to fetch metrics for. When ``None``,
+                the ``automationIds`` filter is omitted and the query returns
+                metrics for every automation in the organization (optionally
+                scoped by ``repo_id``).
+            repo_id: Optional pipe/repo ID to scope the query.
+            period: AutomationExecutionMetricsPeriod enum value (FIFTEEN_MINUTES,
+                SIXTY_MINUTES, TWELVE_HOURS, TWENTY_FOUR_HOURS). Defaults to
+                SIXTY_MINUTES, matching the API default.
+        """
+        variables: dict[str, Any] = {
+            "organizationId": organization_id,
+            "period": period,
+        }
+        if automation_ids is not None:
+            variables["automationIds"] = automation_ids
+        if repo_id is not None:
+            variables["repoId"] = repo_id
+        result = await self._executor.execute_query_allow_partial(
+            GET_AUTOMATION_EXECUTION_METRICS_QUERY, variables
+        )
+        return _normalize_execution_metrics_result(result)
 
     async def get_ai_agent_logs(
         self,

--- a/packages/sdk/src/pipefy_sdk/services/observability_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/observability_service.py
@@ -6,10 +6,9 @@ from typing import Any, TypedDict
 from zipfile import BadZipFile
 
 import httpx
-from graphql import ExecutionResult
 from openpyxl.utils.exceptions import InvalidFileException
 
-from pipefy_sdk.graphql_executor import GraphQLExecutor
+from pipefy_sdk.graphql_executor import GraphQLExecutor, PartialQueryResult
 from pipefy_sdk.queries.observability_queries import (
     CREATE_AUTOMATION_JOBS_EXPORT_MUTATION,
     GET_AGENTS_USAGE_QUERY,
@@ -94,7 +93,18 @@ def _build_usage_variables(
     return variables
 
 
-def _normalize_execution_metrics_result(result: ExecutionResult) -> dict[str, Any]:
+def _partial_error(err: dict[str, Any]) -> dict[str, Any]:
+    """Project one raw GraphQL error dict onto the per-automation failure shape."""
+    extensions = err.get("extensions") or {}
+    return {
+        "automation_id": extensions.get("automation_id"),
+        "code": extensions.get("code"),
+        "message": err.get("message"),
+        "correlation_id": extensions.get("correlation_id"),
+    }
+
+
+def _normalize_execution_metrics_result(result: PartialQueryResult) -> dict[str, Any]:
     """Split a partial ``automations.executionMetrics`` response into nodes and errors.
 
     ``result.data`` carries the automations the token may read (each with its
@@ -102,22 +112,20 @@ def _normalize_execution_metrics_result(result: ExecutionResult) -> dict[str, An
     (e.g. ``PERMISSION_DENIED``) with ``automation_id`` in ``extensions``. Both are
     returned so the caller can report a partial success.
 
+    A null ``automations`` connection means the lookup itself failed (bad org, no
+    org access) rather than individual nodes being denied; that is a total failure,
+    so this raises ``ValueError`` instead of reporting an empty partial success.
+    An empty ``edges`` list (every requested automation denied) stays a partial
+    success with a populated ``partial_errors``.
+
     Args:
-        result: ExecutionResult from ``execute_query_allow_partial``.
+        result: PartialQueryResult from ``execute_query_allow_partial``.
     """
-    data = result.data or {}
-    automations = unwrap_relay_connection_nodes(data.get("automations"))
-    partial_errors: list[dict[str, Any]] = []
-    for err in result.errors or []:
-        extensions = getattr(err, "extensions", None) or {}
-        partial_errors.append(
-            {
-                "automation_id": extensions.get("automation_id"),
-                "code": extensions.get("code"),
-                "message": getattr(err, "message", str(err)),
-                "correlation_id": extensions.get("correlation_id"),
-            }
-        )
+    connection = result.data.get("automations")
+    if connection is None and result.errors:
+        raise ValueError(result.errors[0].get("message") or "Query failed.")
+    automations = unwrap_relay_connection_nodes(connection)
+    partial_errors = [_partial_error(err) for err in result.errors]
     return {"automations": automations, "partial_errors": partial_errors}
 
 

--- a/packages/sdk/src/pipefy_sdk/services/observability_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/observability_service.py
@@ -8,7 +8,7 @@ from zipfile import BadZipFile
 import httpx
 from openpyxl.utils.exceptions import InvalidFileException
 
-from pipefy_sdk.graphql_executor import GraphQLExecutor, PartialQueryResult
+from pipefy_sdk.graphql_executor import PartialGraphQLExecutor, PartialQueryResult
 from pipefy_sdk.queries.observability_queries import (
     CREATE_AUTOMATION_JOBS_EXPORT_MUTATION,
     GET_AGENTS_USAGE_QUERY,
@@ -29,6 +29,8 @@ from pipefy_sdk.utils.organization_identifiers import resolve_organization_uuid
 from pipefy_sdk.utils.relay import unwrap_relay_connection_nodes
 
 _DEFAULT_PAGE_SIZE = 30
+
+AUTOMATION_EXECUTION_METRICS_MAX_PAGE_SIZE: int = 50
 
 
 DateRange = TypedDict("DateRange", {"from": str, "to": str})
@@ -93,6 +95,41 @@ def _build_usage_variables(
     return variables
 
 
+def _build_execution_metrics_variables(
+    organization_id: str,
+    automation_ids: list[str] | None,
+    *,
+    repo_id: str | None,
+    period: str,
+    first: int,
+    after: str | None,
+) -> dict[str, Any]:
+    """Build the GraphQL variables dict for the execution-metrics query.
+
+    Optional filters are omitted when ``None`` rather than sent as nulls.
+
+    Args:
+        organization_id: Organization ID.
+        automation_ids: Optional automation IDs filter.
+        repo_id: Optional pipe/repo ID to scope the query.
+        period: AutomationExecutionMetricsPeriod enum value.
+        first: Page size.
+        after: Cursor for the next page.
+    """
+    variables: dict[str, Any] = {
+        "organizationId": organization_id,
+        "period": period,
+        "first": first,
+    }
+    if automation_ids is not None:
+        variables["automationIds"] = automation_ids
+    if repo_id is not None:
+        variables["repoId"] = repo_id
+    if after is not None:
+        variables["after"] = after
+    return variables
+
+
 def _partial_error(err: dict[str, Any]) -> dict[str, Any]:
     """Project one raw GraphQL error dict onto the per-automation failure shape."""
     extensions = err.get("extensions") or {}
@@ -114,20 +151,22 @@ def _normalize_execution_metrics_result(result: PartialQueryResult) -> dict[str,
 
     A null ``automations`` connection means the lookup itself failed (bad org, no
     org access) rather than individual nodes being denied; that is a total failure,
-    so this raises ``ValueError`` instead of reporting an empty partial success.
-    An empty ``edges`` list (every requested automation denied) stays a partial
-    success with a populated ``partial_errors``.
+    so this raises ``ValueError`` (with the response's first error message when
+    present) instead of reporting an empty partial success. An empty ``edges``
+    list (every requested automation denied) stays a partial success with a
+    populated ``partial_errors``.
 
     ``page_info`` carries the connection's ``pageInfo`` (``hasNextPage``,
-    ``endCursor``); the server caps each page at 50 automations, so callers page
-    with ``after`` until ``hasNextPage`` is false.
+    ``endCursor``); a page contains at most 50 automations (the connection's max
+    page size), so callers page with ``after`` until ``hasNextPage`` is false.
 
     Args:
         result: PartialQueryResult from ``execute_query_allow_partial``.
     """
     connection = result.data.get("automations")
-    if connection is None and result.errors:
-        raise ValueError(result.errors[0].get("message") or "Query failed.")
+    if connection is None:
+        message = result.errors[0].get("message") if result.errors else None
+        raise ValueError(message or "Query failed.")
     automations = unwrap_relay_connection_nodes(connection)
     partial_errors = [_partial_error(err) for err in result.errors]
     page_info = connection.get("pageInfo") if isinstance(connection, dict) else None
@@ -141,7 +180,7 @@ def _normalize_execution_metrics_result(result: PartialQueryResult) -> dict[str,
 class ObservabilityService:
     """Reads for AI agent logs, automation logs, usage stats, and credit dashboard."""
 
-    def __init__(self, *, executor: GraphQLExecutor) -> None:
+    def __init__(self, *, executor: PartialGraphQLExecutor) -> None:
         self._executor = executor
 
     async def get_automation_execution_metrics(
@@ -161,7 +200,7 @@ class ObservabilityService:
         (e.g. ``PERMISSION_DENIED``). The ``automations`` query reports per-node
         errors alongside data, so this uses the partial-tolerant execute path.
 
-        The connection is paginated (the server caps each page at 50 automations).
+        The connection is paginated with a max page size of 50.
         The returned ``page_info`` carries ``hasNextPage`` and ``endCursor``; pass
         ``endCursor`` back as ``after`` to fetch the next page.
 
@@ -176,20 +215,17 @@ class ObservabilityService:
             period: AutomationExecutionMetricsPeriod enum value (FIFTEEN_MINUTES,
                 SIXTY_MINUTES, TWELVE_HOURS, TWENTY_FOUR_HOURS). Defaults to
                 SIXTY_MINUTES, matching the API default.
-            first: Page size (default 30; the server caps a page at 50).
+            first: Page size (default 30, max 50).
             after: Cursor from a previous page's ``page_info.endCursor``.
         """
-        variables: dict[str, Any] = {
-            "organizationId": organization_id,
-            "period": period,
-            "first": first,
-        }
-        if automation_ids is not None:
-            variables["automationIds"] = automation_ids
-        if repo_id is not None:
-            variables["repoId"] = repo_id
-        if after is not None:
-            variables["after"] = after
+        variables = _build_execution_metrics_variables(
+            organization_id,
+            automation_ids,
+            repo_id=repo_id,
+            period=period,
+            first=first,
+            after=after,
+        )
         result = await self._executor.execute_query_allow_partial(
             GET_AUTOMATION_EXECUTION_METRICS_QUERY, variables
         )

--- a/packages/sdk/src/pipefy_sdk/services/observability_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/observability_service.py
@@ -166,8 +166,9 @@ def _partial_error(err: dict[str, Any]) -> dict[str, Any]:
 def _normalize_execution_metrics_result(result: PartialQueryResult) -> dict[str, Any]:
     """Split a partial ``automations.executionMetrics`` response into nodes and errors.
 
-    A null ``automations`` connection means the lookup itself failed (bad org, no
-    org access), so it raises ``ValueError``; an empty ``edges`` list (every
+    The sole failure decision for this query: a missing or null ``automations``
+    connection means the lookup itself failed (bad org, no org access, or a fully
+    null response), so it raises ``ValueError``. An empty ``edges`` list (every
     requested automation denied) stays a partial success. ``page_info`` carries
     the connection's ``pageInfo`` for cursor paging.
     """

--- a/packages/sdk/tests/_shared/mock_clients.py
+++ b/packages/sdk/tests/_shared/mock_clients.py
@@ -8,16 +8,31 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-from pipefy_sdk.graphql_executor import GraphQLExecutor
+from pipefy_sdk.graphql_executor import GraphQLExecutor, PartialQueryResult
 
 
-def mock_executor(return_value: dict | None = None, *, side_effect=None) -> MagicMock:
+def mock_executor(
+    return_value: dict | None = None,
+    *,
+    side_effect=None,
+    partial_result: PartialQueryResult | None = None,
+    partial_side_effect=None,
+) -> MagicMock:
     """A MagicMock standing in for a :class:`GraphQLExecutor`.
 
     Pass ``return_value`` to set what ``execute_query`` resolves to, or
     ``side_effect`` for the error-path tests. Assert on the returned mock's
     ``execute_query`` to verify the query and variables a service sent.
+
+    The partial-tolerant seam is stubbed too: ``partial_result`` sets what
+    ``execute_query_allow_partial`` resolves to, and ``partial_side_effect``
+    drives its error paths. Without them the spec'd mock would auto-create the
+    method as an AsyncMock resolving to a bare MagicMock, so a service reading
+    ``result.data``/``result.errors`` gets silent garbage instead of a failure.
     """
     mock = MagicMock(spec=GraphQLExecutor)
     mock.execute_query = AsyncMock(return_value=return_value, side_effect=side_effect)
+    mock.execute_query_allow_partial = AsyncMock(
+        return_value=partial_result, side_effect=partial_side_effect
+    )
     return mock

--- a/packages/sdk/tests/_shared/mock_clients.py
+++ b/packages/sdk/tests/_shared/mock_clients.py
@@ -20,19 +20,12 @@ def mock_executor(
 ) -> MagicMock:
     """A MagicMock standing in for a :class:`PartialGraphQLExecutor`.
 
-    Spec'd on the wide protocol so the one fake serves every service, including
-    the partial-tolerant consumers; services that only need the narrow
-    :class:`GraphQLExecutor` see a structural superset.
-
-    Pass ``return_value`` to set what ``execute_query`` resolves to, or
-    ``side_effect`` for the error-path tests. Assert on the returned mock's
-    ``execute_query`` to verify the query and variables a service sent.
-
-    The partial-tolerant seam is stubbed too: ``partial_result`` sets what
-    ``execute_query_allow_partial`` resolves to, and ``partial_side_effect``
-    drives its error paths. Without them the spec'd mock would auto-create the
-    method as an AsyncMock resolving to a bare MagicMock, so a service reading
-    ``result.data``/``result.errors`` gets silent garbage instead of a failure.
+    Spec'd on the wide protocol so one fake serves every service.
+    ``return_value``/``side_effect`` drive ``execute_query``;
+    ``partial_result``/``partial_side_effect`` drive
+    ``execute_query_allow_partial``. Both are stubbed explicitly: an
+    auto-created method would resolve to a bare MagicMock and feed services
+    silent garbage instead of a failure.
     """
     mock = MagicMock(spec=PartialGraphQLExecutor)
     mock.execute_query = AsyncMock(return_value=return_value, side_effect=side_effect)

--- a/packages/sdk/tests/_shared/mock_clients.py
+++ b/packages/sdk/tests/_shared/mock_clients.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-from pipefy_sdk.graphql_executor import GraphQLExecutor, PartialQueryResult
+from pipefy_sdk.graphql_executor import PartialGraphQLExecutor, PartialQueryResult
 
 
 def mock_executor(
@@ -18,7 +18,11 @@ def mock_executor(
     partial_result: PartialQueryResult | None = None,
     partial_side_effect=None,
 ) -> MagicMock:
-    """A MagicMock standing in for a :class:`GraphQLExecutor`.
+    """A MagicMock standing in for a :class:`PartialGraphQLExecutor`.
+
+    Spec'd on the wide protocol so the one fake serves every service, including
+    the partial-tolerant consumers; services that only need the narrow
+    :class:`GraphQLExecutor` see a structural superset.
 
     Pass ``return_value`` to set what ``execute_query`` resolves to, or
     ``side_effect`` for the error-path tests. Assert on the returned mock's
@@ -30,7 +34,7 @@ def mock_executor(
     method as an AsyncMock resolving to a bare MagicMock, so a service reading
     ``result.data``/``result.errors`` gets silent garbage instead of a failure.
     """
-    mock = MagicMock(spec=GraphQLExecutor)
+    mock = MagicMock(spec=PartialGraphQLExecutor)
     mock.execute_query = AsyncMock(return_value=return_value, side_effect=side_effect)
     mock.execute_query_allow_partial = AsyncMock(
         return_value=partial_result, side_effect=partial_side_effect

--- a/packages/sdk/tests/services/pipefy/test_observability_service.py
+++ b/packages/sdk/tests/services/pipefy/test_observability_service.py
@@ -662,6 +662,17 @@ async def test_get_automation_execution_metrics_null_connection_raises():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_get_automation_execution_metrics_null_connection_without_errors_raises():
+    """A null connection raises even when the response carries no error to quote."""
+    partial_result = PartialQueryResult(data={"automations": None}, errors=[])
+    service, _ = _make_partial_service(partial_result)
+
+    with pytest.raises(ValueError, match="Query failed."):
+        await service.get_automation_execution_metrics("999", ["25"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_get_automation_execution_metrics_without_ids_omits_filter():
     """Omitting automation_ids drops the automationIds variable so the query returns all."""
     partial_result = PartialQueryResult(

--- a/packages/sdk/tests/services/pipefy/test_observability_service.py
+++ b/packages/sdk/tests/services/pipefy/test_observability_service.py
@@ -585,7 +585,7 @@ async def test_get_automation_execution_metrics_all_permitted():
         "automationIds": ["25", "107"],
         "period": "TWENTY_FOUR_HOURS",
         "repoId": "16",
-        "first": 30,
+        "first": 50,
     }
     assert [a["id"] for a in result["automations"]] == ["25", "107"]
     assert result["automations"][0]["executionMetrics"]["totalRuns"] == 3
@@ -620,7 +620,6 @@ async def test_get_automation_execution_metrics_partial_permission_denied():
             "correlation_id": "c86ccfa6",
         },
     ]
-    # repo_id omitted → not sent as a variable
     _, variables = executor.execute_query_allow_partial.call_args[0]
     assert "repoId" not in variables
 
@@ -692,7 +691,7 @@ async def test_get_automation_execution_metrics_without_ids_omits_filter():
 
     _, variables = executor.execute_query_allow_partial.call_args[0]
     assert "automationIds" not in variables
-    assert variables == {"organizationId": "3", "period": "SIXTY_MINUTES", "first": 30}
+    assert variables == {"organizationId": "3", "period": "SIXTY_MINUTES", "first": 50}
     assert [a["id"] for a in result["automations"]] == ["25", "107"]
 
 

--- a/packages/sdk/tests/services/pipefy/test_observability_service.py
+++ b/packages/sdk/tests/services/pipefy/test_observability_service.py
@@ -8,9 +8,9 @@ import pytest
 from _shared.fixture_ids import EXAMPLE_NUMERIC_ORG_ID, EXAMPLE_ORG_UUID
 from _shared.mock_clients import mock_executor
 from gql.transport.exceptions import TransportQueryError
-from graphql import ExecutionResult, GraphQLError
 from openpyxl import Workbook
 
+from pipefy_sdk.graphql_executor import PartialQueryResult
 from pipefy_sdk.queries.observability_queries import (
     CREATE_AUTOMATION_JOBS_EXPORT_MUTATION,
     GET_AGENTS_USAGE_QUERY,
@@ -33,9 +33,8 @@ def _make_service(return_value):
     return service, executor
 
 
-def _make_partial_service(execution_result):
-    executor = mock_executor()
-    executor.execute_query_allow_partial = AsyncMock(return_value=execution_result)
+def _make_partial_service(partial_result):
+    executor = mock_executor(partial_result=partial_result)
     service = ObservabilityService(executor=executor)
     return service, executor
 
@@ -545,11 +544,22 @@ async def test_get_automations_usage_resolves_numeric_organization_id():
     assert result["automationsUsage"]["totalExecutions"] == 42
 
 
+def _denied_error(automation_id: str) -> dict:
+    return {
+        "message": "Permission denied",
+        "extensions": {
+            "code": "PERMISSION_DENIED",
+            "automation_id": automation_id,
+            "correlation_id": "c86ccfa6",
+        },
+    }
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_all_permitted():
     """Full success: all requested automations return metrics, no partial errors."""
-    execution_result = ExecutionResult(
+    partial_result = PartialQueryResult(
         data={
             "automations": {
                 "edges": [
@@ -558,9 +568,9 @@ async def test_get_automation_execution_metrics_all_permitted():
                 ]
             }
         },
-        errors=None,
+        errors=[],
     )
-    service, executor = _make_partial_service(execution_result)
+    service, executor = _make_partial_service(partial_result)
 
     result = await service.get_automation_execution_metrics(
         "3", ["25", "107"], repo_id="16", period="TWENTY_FOUR_HOURS"
@@ -584,28 +594,11 @@ async def test_get_automation_execution_metrics_all_permitted():
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_partial_permission_denied():
     """Partial success: permitted nodes returned, denied ids surfaced in partial_errors."""
-    execution_result = ExecutionResult(
+    partial_result = PartialQueryResult(
         data={"automations": {"edges": [{"node": _metrics_node("25", total_runs=3)}]}},
-        errors=[
-            GraphQLError(
-                "Permission denied",
-                extensions={
-                    "code": "PERMISSION_DENIED",
-                    "automation_id": "124",
-                    "correlation_id": "c86ccfa6",
-                },
-            ),
-            GraphQLError(
-                "Permission denied",
-                extensions={
-                    "code": "PERMISSION_DENIED",
-                    "automation_id": "65",
-                    "correlation_id": "c86ccfa6",
-                },
-            ),
-        ],
+        errors=[_denied_error("124"), _denied_error("65")],
     )
-    service, executor = _make_partial_service(execution_result)
+    service, executor = _make_partial_service(partial_result)
 
     result = await service.get_automation_execution_metrics("3", ["25", "124", "65"])
 
@@ -631,26 +624,44 @@ async def test_get_automation_execution_metrics_partial_permission_denied():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_automation_execution_metrics_null_data():
-    """Defensive: null data (total failure shape) yields empty automations list."""
-    execution_result = ExecutionResult(
-        data=None,
-        errors=[GraphQLError("boom", extensions={"code": "INTERNAL"})],
+async def test_get_automation_execution_metrics_all_denied_stays_partial():
+    """Every requested id denied but the connection is present: empty list, not a raise."""
+    partial_result = PartialQueryResult(
+        data={"automations": {"edges": []}},
+        errors=[_denied_error("124"), _denied_error("65")],
     )
-    service, _ = _make_partial_service(execution_result)
+    service, _ = _make_partial_service(partial_result)
 
-    result = await service.get_automation_execution_metrics("3", ["25"])
+    result = await service.get_automation_execution_metrics("3", ["124", "65"])
 
     assert result["automations"] == []
-    assert result["partial_errors"][0]["code"] == "INTERNAL"
-    assert result["partial_errors"][0]["automation_id"] is None
+    assert [e["automation_id"] for e in result["partial_errors"]] == ["124", "65"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automation_execution_metrics_null_connection_raises():
+    """A null automations connection (lookup failed) is a total failure, not empty success."""
+    partial_result = PartialQueryResult(
+        data={"automations": None},
+        errors=[
+            {
+                "message": "Couldn't find Organization with 'id'=999",
+                "extensions": {"code": "NOT_FOUND"},
+            }
+        ],
+    )
+    service, _ = _make_partial_service(partial_result)
+
+    with pytest.raises(ValueError, match="Couldn't find Organization"):
+        await service.get_automation_execution_metrics("999", ["25"])
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_without_ids_omits_filter():
     """Omitting automation_ids drops the automationIds variable so the query returns all."""
-    execution_result = ExecutionResult(
+    partial_result = PartialQueryResult(
         data={
             "automations": {
                 "edges": [
@@ -659,9 +670,9 @@ async def test_get_automation_execution_metrics_without_ids_omits_filter():
                 ]
             }
         },
-        errors=None,
+        errors=[],
     )
-    service, executor = _make_partial_service(execution_result)
+    service, executor = _make_partial_service(partial_result)
 
     result = await service.get_automation_execution_metrics("3")
 

--- a/packages/sdk/tests/services/pipefy/test_observability_service.py
+++ b/packages/sdk/tests/services/pipefy/test_observability_service.py
@@ -562,10 +562,11 @@ async def test_get_automation_execution_metrics_all_permitted():
     partial_result = PartialQueryResult(
         data={
             "automations": {
+                "pageInfo": {"hasNextPage": False, "endCursor": "cur-2"},
                 "edges": [
                     {"node": _metrics_node("25", total_runs=3)},
                     {"node": _metrics_node("107", total_runs=0)},
-                ]
+                ],
             }
         },
         errors=[],
@@ -584,10 +585,12 @@ async def test_get_automation_execution_metrics_all_permitted():
         "automationIds": ["25", "107"],
         "period": "TWENTY_FOUR_HOURS",
         "repoId": "16",
+        "first": 30,
     }
     assert [a["id"] for a in result["automations"]] == ["25", "107"]
     assert result["automations"][0]["executionMetrics"]["totalRuns"] == 3
     assert result["partial_errors"] == []
+    assert result["page_info"] == {"hasNextPage": False, "endCursor": "cur-2"}
 
 
 @pytest.mark.unit
@@ -678,5 +681,30 @@ async def test_get_automation_execution_metrics_without_ids_omits_filter():
 
     _, variables = executor.execute_query_allow_partial.call_args[0]
     assert "automationIds" not in variables
-    assert variables == {"organizationId": "3", "period": "SIXTY_MINUTES"}
+    assert variables == {"organizationId": "3", "period": "SIXTY_MINUTES", "first": 30}
     assert [a["id"] for a in result["automations"]] == ["25", "107"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automation_execution_metrics_paginates_with_first_and_after():
+    """first and after are forwarded; after is omitted when not supplied."""
+    partial_result = PartialQueryResult(
+        data={
+            "automations": {
+                "pageInfo": {"hasNextPage": True, "endCursor": "cur-1"},
+                "edges": [{"node": _metrics_node("25", total_runs=3)}],
+            }
+        },
+        errors=[],
+    )
+    service, executor = _make_partial_service(partial_result)
+
+    result = await service.get_automation_execution_metrics(
+        "3", first=50, after="cur-0"
+    )
+
+    _, variables = executor.execute_query_allow_partial.call_args[0]
+    assert variables["first"] == 50
+    assert variables["after"] == "cur-0"
+    assert result["page_info"] == {"hasNextPage": True, "endCursor": "cur-1"}

--- a/packages/sdk/tests/services/pipefy/test_observability_service.py
+++ b/packages/sdk/tests/services/pipefy/test_observability_service.py
@@ -718,3 +718,64 @@ async def test_get_automation_execution_metrics_paginates_with_first_and_after()
     assert variables["first"] == 50
     assert variables["after"] == "cur-0"
     assert result["page_info"] == {"hasNextPage": True, "endCursor": "cur-1"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automation_execution_metrics_forwards_all_filters():
+    """search, active, event_id, action_ids, and sort_by/order map onto the variables."""
+    partial_result = PartialQueryResult(
+        data={"automations": {"edges": [{"node": _metrics_node("25", total_runs=3)}]}},
+        errors=[],
+    )
+    service, executor = _make_partial_service(partial_result)
+
+    await service.get_automation_execution_metrics(
+        "3",
+        action_ids=["9", "10"],
+        event_id="card_moved",
+        active=True,
+        search="welcome",
+        sort_by="name",
+        sort_order="asc",
+    )
+
+    _, variables = executor.execute_query_allow_partial.call_args[0]
+    assert variables["actionIds"] == ["9", "10"]
+    assert variables["eventId"] == "card_moved"
+    assert variables["active"] is True
+    assert variables["search"] == "welcome"
+    assert variables["sort"] == {"by": "name", "order": "asc"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automation_execution_metrics_omits_unset_filters():
+    """Unset optional filters are absent from the variables (never sent as nulls)."""
+    partial_result = PartialQueryResult(
+        data={"automations": {"edges": []}},
+        errors=[],
+    )
+    service, executor = _make_partial_service(partial_result)
+
+    await service.get_automation_execution_metrics("3")
+
+    _, variables = executor.execute_query_allow_partial.call_args[0]
+    for absent in ("actionIds", "eventId", "active", "search", "sort"):
+        assert absent not in variables
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automation_execution_metrics_partial_sort_criteria():
+    """sort_by alone yields a sort input with only the `by` field set."""
+    partial_result = PartialQueryResult(
+        data={"automations": {"edges": []}},
+        errors=[],
+    )
+    service, executor = _make_partial_service(partial_result)
+
+    await service.get_automation_execution_metrics("3", sort_by="created_at")
+
+    _, variables = executor.execute_query_allow_partial.call_args[0]
+    assert variables["sort"] == {"by": "created_at"}

--- a/packages/sdk/tests/services/pipefy/test_observability_service.py
+++ b/packages/sdk/tests/services/pipefy/test_observability_service.py
@@ -8,6 +8,7 @@ import pytest
 from _shared.fixture_ids import EXAMPLE_NUMERIC_ORG_ID, EXAMPLE_ORG_UUID
 from _shared.mock_clients import mock_executor
 from gql.transport.exceptions import TransportQueryError
+from graphql import ExecutionResult, GraphQLError
 from openpyxl import Workbook
 
 from pipefy_sdk.queries.observability_queries import (
@@ -16,6 +17,7 @@ from pipefy_sdk.queries.observability_queries import (
     GET_AI_AGENT_LOG_DETAILS_QUERY,
     GET_AI_AGENT_LOGS_QUERY,
     GET_AI_CREDIT_USAGE_QUERY,
+    GET_AUTOMATION_EXECUTION_METRICS_QUERY,
     GET_AUTOMATION_JOBS_EXPORT_QUERY,
     GET_AUTOMATION_LOGS_BY_REPO_QUERY,
     GET_AUTOMATION_LOGS_QUERY,
@@ -29,6 +31,30 @@ def _make_service(return_value):
     executor = mock_executor(return_value)
     service = ObservabilityService(executor=executor)
     return service, executor
+
+
+def _make_partial_service(execution_result):
+    executor = mock_executor()
+    executor.execute_query_allow_partial = AsyncMock(return_value=execution_result)
+    service = ObservabilityService(executor=executor)
+    return service, executor
+
+
+def _metrics_node(automation_id: str, *, total_runs: int) -> dict:
+    return {
+        "id": automation_id,
+        "name": f"Automation {automation_id}",
+        "event_id": "card_moved",
+        "action_id": "update_card_field",
+        "event_repo": {"id": "16", "name": "Execution Metrics 16"},
+        "executionMetrics": {
+            "lastRun": None,
+            "failureRate": 0.0,
+            "successRate": 0.0,
+            "averageDuration": None,
+            "totalRuns": total_runs,
+        },
+    }
 
 
 @pytest.mark.unit
@@ -517,3 +543,129 @@ async def test_get_automations_usage_resolves_numeric_organization_id():
     assert calls[1][0][0] is GET_AUTOMATIONS_USAGE_QUERY
     assert calls[1][0][1]["organizationUuid"] == EXAMPLE_ORG_UUID
     assert result["automationsUsage"]["totalExecutions"] == 42
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automation_execution_metrics_all_permitted():
+    """Full success: all requested automations return metrics, no partial errors."""
+    execution_result = ExecutionResult(
+        data={
+            "automations": {
+                "edges": [
+                    {"node": _metrics_node("25", total_runs=3)},
+                    {"node": _metrics_node("107", total_runs=0)},
+                ]
+            }
+        },
+        errors=None,
+    )
+    service, executor = _make_partial_service(execution_result)
+
+    result = await service.get_automation_execution_metrics(
+        "3", ["25", "107"], repo_id="16", period="TWENTY_FOUR_HOURS"
+    )
+
+    executor.execute_query_allow_partial.assert_awaited_once()
+    query, variables = executor.execute_query_allow_partial.call_args[0]
+    assert query is GET_AUTOMATION_EXECUTION_METRICS_QUERY
+    assert variables == {
+        "organizationId": "3",
+        "automationIds": ["25", "107"],
+        "period": "TWENTY_FOUR_HOURS",
+        "repoId": "16",
+    }
+    assert [a["id"] for a in result["automations"]] == ["25", "107"]
+    assert result["automations"][0]["executionMetrics"]["totalRuns"] == 3
+    assert result["partial_errors"] == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automation_execution_metrics_partial_permission_denied():
+    """Partial success: permitted nodes returned, denied ids surfaced in partial_errors."""
+    execution_result = ExecutionResult(
+        data={"automations": {"edges": [{"node": _metrics_node("25", total_runs=3)}]}},
+        errors=[
+            GraphQLError(
+                "Permission denied",
+                extensions={
+                    "code": "PERMISSION_DENIED",
+                    "automation_id": "124",
+                    "correlation_id": "c86ccfa6",
+                },
+            ),
+            GraphQLError(
+                "Permission denied",
+                extensions={
+                    "code": "PERMISSION_DENIED",
+                    "automation_id": "65",
+                    "correlation_id": "c86ccfa6",
+                },
+            ),
+        ],
+    )
+    service, executor = _make_partial_service(execution_result)
+
+    result = await service.get_automation_execution_metrics("3", ["25", "124", "65"])
+
+    assert [a["id"] for a in result["automations"]] == ["25"]
+    assert result["partial_errors"] == [
+        {
+            "automation_id": "124",
+            "code": "PERMISSION_DENIED",
+            "message": "Permission denied",
+            "correlation_id": "c86ccfa6",
+        },
+        {
+            "automation_id": "65",
+            "code": "PERMISSION_DENIED",
+            "message": "Permission denied",
+            "correlation_id": "c86ccfa6",
+        },
+    ]
+    # repo_id omitted → not sent as a variable
+    _, variables = executor.execute_query_allow_partial.call_args[0]
+    assert "repoId" not in variables
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automation_execution_metrics_null_data():
+    """Defensive: null data (total failure shape) yields empty automations list."""
+    execution_result = ExecutionResult(
+        data=None,
+        errors=[GraphQLError("boom", extensions={"code": "INTERNAL"})],
+    )
+    service, _ = _make_partial_service(execution_result)
+
+    result = await service.get_automation_execution_metrics("3", ["25"])
+
+    assert result["automations"] == []
+    assert result["partial_errors"][0]["code"] == "INTERNAL"
+    assert result["partial_errors"][0]["automation_id"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_automation_execution_metrics_without_ids_omits_filter():
+    """Omitting automation_ids drops the automationIds variable so the query returns all."""
+    execution_result = ExecutionResult(
+        data={
+            "automations": {
+                "edges": [
+                    {"node": _metrics_node("25", total_runs=3)},
+                    {"node": _metrics_node("107", total_runs=0)},
+                ]
+            }
+        },
+        errors=None,
+    )
+    service, executor = _make_partial_service(execution_result)
+
+    result = await service.get_automation_execution_metrics("3")
+
+    _, variables = executor.execute_query_allow_partial.call_args[0]
+    assert "automationIds" not in variables
+    assert variables == {"organizationId": "3", "period": "SIXTY_MINUTES"}
+    assert [a["id"] for a in result["automations"]] == ["25", "107"]

--- a/packages/sdk/tests/services/pipefy/test_observability_service.py
+++ b/packages/sdk/tests/services/pipefy/test_observability_service.py
@@ -672,6 +672,20 @@ async def test_get_automation_execution_metrics_null_connection_without_errors_r
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_get_automation_execution_metrics_empty_data_raises():
+    """A fully null response (executor hands back empty data) fails through the same decision."""
+    partial_result = PartialQueryResult(
+        data={},
+        errors=[{"message": "Couldn't find Organization with 'id'=999"}],
+    )
+    service, _ = _make_partial_service(partial_result)
+
+    with pytest.raises(ValueError, match="Couldn't find Organization"):
+        await service.get_automation_execution_metrics("999", ["25"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_get_automation_execution_metrics_without_ids_omits_filter():
     """Omitting automation_ids drops the automationIds variable so the query returns all."""
     partial_result = PartialQueryResult(

--- a/packages/sdk/tests/services/test_httpx_graphql_executor.py
+++ b/packages/sdk/tests/services/test_httpx_graphql_executor.py
@@ -1,11 +1,12 @@
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 from gql import gql
 from gql.graphql_request import GraphQLRequest
+from gql.transport.exceptions import TransportQueryError
 from gql.transport.httpx import HTTPXAsyncTransport
-from graphql import ExecutionResult, GraphQLError
 from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk import __version__
@@ -17,6 +18,24 @@ GRAPHQL_URL = "https://api.pipefy.com/graphql"
 
 def _bearer() -> StaticBearerAuth:
     return StaticBearerAuth("test-token")
+
+
+@contextmanager
+def _patched_transport(handler):
+    """Route the executor's gql transport through an ``httpx.MockTransport``.
+
+    Runs the real gql Client and httpx stack, swapping only the network so the
+    executor's actual raise-on-errors behavior is exercised, not a mock's.
+    """
+
+    def transport_factory(**kwargs):
+        kwargs.pop("verify", None)
+        return HTTPXAsyncTransport(**kwargs, transport=httpx.MockTransport(handler))
+
+    with patch(
+        "pipefy_sdk.graphql_executor.HTTPXAsyncTransport", side_effect=transport_factory
+    ):
+        yield
 
 
 def _sample_query() -> GraphQLRequest:
@@ -155,47 +174,68 @@ async def test_execute_query_bubbles_up_execute_errors_unchanged():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_execute_query_forwards_get_execution_result_false():
-    """Default path asks gql for the data dict (raise-on-errors semantics)."""
-    query = _sample_query()
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value={"ok": True})
+async def test_execute_query_allow_partial_returns_data_and_errors_together():
+    """A response mixing data and per-node errors becomes a PartialQueryResult.
 
-    with patch("pipefy_sdk.graphql_executor.Client") as mock_client_cls:
-        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+    gql 4 raises ``TransportQueryError`` whenever the response carries any errors,
+    even for a partial success; the executor rebuilds the partial ``data`` and the
+    raw error dicts from the exception rather than dropping them.
+    """
+    partial_body = {
+        "data": {"automations": {"edges": [{"node": {"id": "25"}}]}},
+        "errors": [
+            {
+                "message": "Permission denied",
+                "extensions": {"code": "PERMISSION_DENIED", "automation_id": "124"},
+            }
+        ],
+    }
 
-        base = HttpxGraphQLExecutor(url=GRAPHQL_URL, auth=_bearer())
-        await base.execute_query(query, {})
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=partial_body)
 
-    assert mock_session.execute.call_args.kwargs["get_execution_result"] is False
+    with _patched_transport(handler):
+        executor = HttpxGraphQLExecutor(url=GRAPHQL_URL, auth=_bearer())
+        result = await executor.execute_query_allow_partial(_sample_query(), {})
+
+    assert result.data == {"automations": {"edges": [{"node": {"id": "25"}}]}}
+    assert result.errors[0]["extensions"]["automation_id"] == "124"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_execute_query_allow_partial_returns_execution_result_without_raising():
-    """Partial path forwards get_execution_result=True and returns the result as-is.
+async def test_execute_query_allow_partial_success_carries_no_errors():
+    """An error-free response yields a PartialQueryResult with an empty error list."""
 
-    gql does not raise on GraphQL ``errors`` in this mode, so per-node failures
-    arrive on ``result.errors`` next to the partial ``result.data``.
-    """
-    query = _sample_query()
-    sentinel = ExecutionResult(
-        data={"automations": {"edges": []}},
-        errors=[GraphQLError("Permission denied", extensions={"code": "X"})],
-    )
-    mock_session = AsyncMock()
-    mock_session.execute = AsyncMock(return_value=sentinel)
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": {"automations": {"edges": []}}})
 
-    with patch("pipefy_sdk.graphql_executor.Client") as mock_client_cls:
-        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
-        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+    with _patched_transport(handler):
+        executor = HttpxGraphQLExecutor(url=GRAPHQL_URL, auth=_bearer())
+        result = await executor.execute_query_allow_partial(_sample_query(), {})
 
-        base = HttpxGraphQLExecutor(url=GRAPHQL_URL, auth=_bearer())
-        result = await base.execute_query_allow_partial(query, {"x": 1})
+    assert result.data == {"automations": {"edges": []}}
+    assert result.errors == []
 
-    assert result is sentinel
-    assert mock_session.execute.call_args.kwargs["get_execution_result"] is True
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_query_allow_partial_raises_when_no_data():
+    """A response with null data (the lookup failed outright) reraises, not a partial."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": None,
+                "errors": [{"message": "Couldn't find Organization with 'id'=999"}],
+            },
+        )
+
+    with _patched_transport(handler):
+        executor = HttpxGraphQLExecutor(url=GRAPHQL_URL, auth=_bearer())
+        with pytest.raises(TransportQueryError):
+            await executor.execute_query_allow_partial(_sample_query(), {})
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/test_httpx_graphql_executor.py
+++ b/packages/sdk/tests/services/test_httpx_graphql_executor.py
@@ -175,12 +175,7 @@ async def test_execute_query_bubbles_up_execute_errors_unchanged():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_query_allow_partial_returns_data_and_errors_together():
-    """A response mixing data and per-node errors becomes a PartialQueryResult.
-
-    gql 4 raises ``TransportQueryError`` whenever the response carries any errors,
-    even for a partial success; the executor rebuilds the partial ``data`` and the
-    raw error dicts from the exception rather than dropping them.
-    """
+    """A response mixing data and per-node errors becomes a PartialQueryResult."""
     partial_body = {
         "data": {"automations": {"edges": [{"node": {"id": "25"}}]}},
         "errors": [

--- a/packages/sdk/tests/services/test_httpx_graphql_executor.py
+++ b/packages/sdk/tests/services/test_httpx_graphql_executor.py
@@ -5,7 +5,6 @@ import httpx
 import pytest
 from gql import gql
 from gql.graphql_request import GraphQLRequest
-from gql.transport.exceptions import TransportQueryError
 from gql.transport.httpx import HTTPXAsyncTransport
 from pipefy_auth import StaticBearerAuth
 
@@ -215,8 +214,8 @@ async def test_execute_query_allow_partial_success_carries_no_errors():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_execute_query_allow_partial_raises_when_no_data():
-    """A response with null data (the lookup failed outright) reraises, not a partial."""
+async def test_execute_query_allow_partial_null_data_yields_empty_result():
+    """A fully null response yields empty data with errors kept; classifying it is the caller's job."""
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -229,8 +228,10 @@ async def test_execute_query_allow_partial_raises_when_no_data():
 
     with _patched_transport(handler):
         executor = HttpxGraphQLExecutor(url=GRAPHQL_URL, auth=_bearer())
-        with pytest.raises(TransportQueryError):
-            await executor.execute_query_allow_partial(_sample_query(), {})
+        result = await executor.execute_query_allow_partial(_sample_query(), {})
+
+    assert result.data == {}
+    assert result.errors[0]["message"] == "Couldn't find Organization with 'id'=999"
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/test_httpx_graphql_executor.py
+++ b/packages/sdk/tests/services/test_httpx_graphql_executor.py
@@ -5,6 +5,7 @@ import pytest
 from gql import gql
 from gql.graphql_request import GraphQLRequest
 from gql.transport.httpx import HTTPXAsyncTransport
+from graphql import ExecutionResult, GraphQLError
 from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk import __version__
@@ -150,6 +151,51 @@ async def test_execute_query_bubbles_up_execute_errors_unchanged():
             await base.execute_query(query, variables)
 
     assert exc.value is expected_error
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_query_forwards_get_execution_result_false():
+    """Default path asks gql for the data dict (raise-on-errors semantics)."""
+    query = _sample_query()
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value={"ok": True})
+
+    with patch("pipefy_sdk.graphql_executor.Client") as mock_client_cls:
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        base = HttpxGraphQLExecutor(url=GRAPHQL_URL, auth=_bearer())
+        await base.execute_query(query, {})
+
+    assert mock_session.execute.call_args.kwargs["get_execution_result"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_query_allow_partial_returns_execution_result_without_raising():
+    """Partial path forwards get_execution_result=True and returns the result as-is.
+
+    gql does not raise on GraphQL ``errors`` in this mode, so per-node failures
+    arrive on ``result.errors`` next to the partial ``result.data``.
+    """
+    query = _sample_query()
+    sentinel = ExecutionResult(
+        data={"automations": {"edges": []}},
+        errors=[GraphQLError("Permission denied", extensions={"code": "X"})],
+    )
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=sentinel)
+
+    with patch("pipefy_sdk.graphql_executor.Client") as mock_client_cls:
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        base = HttpxGraphQLExecutor(url=GRAPHQL_URL, auth=_bearer())
+        result = await base.execute_query_allow_partial(query, {"x": 1})
+
+    assert result is sentinel
+    assert mock_session.execute.call_args.kwargs["get_execution_result"] is True
 
 
 @pytest.mark.unit

--- a/skills/observability/pipefy-observability/SKILL.md
+++ b/skills/observability/pipefy-observability/SKILL.md
@@ -3,13 +3,13 @@ name: pipefy-observability
 description: >
   Use this skill when the user wants to check AI agent logs, automation
   execution logs, org-level usage stats, AI credit consumption, or export
-  automation job history. Covers 10 MCP tools.
+  automation job history. Covers 11 MCP tools.
 tags: [pipefy, observability, logs, usage, credits, exports]
 ---
 
 # Observability
 
-Monitor AI agent and automation execution, usage stats, credit consumption, and export job history. **10 MCP tools.**
+Monitor AI agent and automation execution, usage stats, credit consumption, and export job history. **11 MCP tools.**
 
 **CLI status (v0.1):** use MCP tools below. Observability Typer commands are planned for v0.3+.
 

--- a/skills/observability/pipefy-observability/SKILL.md
+++ b/skills/observability/pipefy-observability/SKILL.md
@@ -35,6 +35,7 @@ Monitor AI agent and automation execution, usage stats, credit consumption, and 
 | `get_automation_logs_by_repo` | — (CLI v0.3+) | Yes | Automation logs filtered by pipe UUID. |
 | `get_agents_usage` | — (CLI v0.3+) | Yes | Org-level AI agent execution count and trends. |
 | `get_automations_usage` | — (CLI v0.3+) | Yes | Org-level automation execution stats. |
+| `get_automation_execution_metrics` | `pipefy usage execution-metrics` | Yes | Per-automation execution metrics (totalRuns, success/failure rate, avg duration, lastRun) over a rolling window; partial success returns `partial_errors` for denied ids. |
 | `get_ai_credit_usage` | — (CLI v0.3+) | Yes | AI credit consumption and remaining balance. |
 | `export_automation_jobs` | — (CLI v0.3+) | Yes | Trigger async export of automation job history. |
 | `get_automation_jobs_export` | — (CLI v0.3+) | Yes | Poll export job status (after `export_automation_jobs`). |


### PR DESCRIPTION
## Summary

Adds an automation execution metrics capability across the SDK, MCP, and CLI. It reports per-automation metrics (`totalRuns`, `successRate`, `failureRate`, `averageDuration`, `lastRun`) over a rolling window (`FIFTEEN_MINUTES`, `SIXTY_MINUTES`, `TWELVE_HOURS`, `TWENTY_FOUR_HOURS`), backed by the `automations.executionMetrics` GraphQL field.

The `automations` query returns partial results: it can carry metrics for the automations a token may read alongside per-automation errors (for example `PERMISSION_DENIED`) for those it may not, in one response. The capability surfaces this as a partial success, returning a normalized `{automations, partial_errors, page_info}` payload rather than failing outright, so one denied automation in a batch does not drop the rest. A response with no readable data at all is treated as a failure, not an empty success.

## What's included

Capability parity across all three surfaces (per the "Adding a New Capability" checklist in AGENTS.md):

- **SDK**: `GET_AUTOMATION_EXECUTION_METRICS_QUERY`, `ObservabilityService.get_automation_execution_metrics`, and the `PipefyClient` passthrough.
- **MCP**: a read-only `get_automation_execution_metrics` tool, validating the organization id, the optional automation id list, the optional repo id, the period, and the page size.
- **CLI**: `pipefy usage execution-metrics`.
- **Docs and skills**: the `docs/parity.md` row and the observability `SKILL.md` entry.

## Partial-execution handling

Supporting the partial path required a fix in the GraphQL executor. gql 4 raises `TransportQueryError` whenever a response carries GraphQL errors, even for a partial success, so an approach relying on `get_execution_result=True` never returned partial data. `execute_query_allow_partial` now reconstructs the partial data and the raw error dicts from the exception into an owned `PartialQueryResult`, which keeps gql and graphql-core types out of the service layer.

Two smaller cleanups came with it: the period values are single-sourced from one SDK constant that the MCP validation set and the CLI help both derive from, and a shared `validate_optional_tool_id_list` helper replaces a hand-rolled list-of-ids validation loop.

## Pagination

The server caps the `automations` connection at 50 per page, so an unbounded query silently dropped everything past the first 50 automations. The query, service, client, MCP tool, and CLI now take `first` and `after` (the tool bounds `first` at the server's 50-per-page cap), and the normalized payload carries `page_info` (`hasNextPage`, `endCursor`) so callers page through the rest with `after`.

## Testing performed

- `uv run ruff check` and `uv run ruff format --check`: clean.
- `uv run pytest`: full suite green, including the SDK executor and observability service tests, the MCP tool tests, the CLI help golden, and the tool-parity drift guards.
- MCP surface through an in-memory session with a fake client: happy path, partial success (the payload carries `partial_errors` with `automation_id`), total failure (an error payload, not an empty success), pagination (`first`/`after` forwarded, `page_info` returned), and input validation for period, empty id list, empty organization id, and out-of-range page size.
- Real API through `pipefy usage execution-metrics`:
  - A mixed list (one readable automation plus one denied id) returned the readable automation's metrics alongside `partial_errors: [{automation_id, code: PERMISSION_DENIED, correlation_id}]`.
  - An unknown organization returned an error rather than an empty success.
  - Pagination: `--first 1` returned one automation with `page_info.hasNextPage: true`; paging with `--after <endCursor>` advanced to the next automation. `--first 51` came back with 50 and `hasNextPage: true`, confirming the server's page cap.
