### PR TITLE
fix(mcp): restore automation error fallback after marker sanitization

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/automation_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/automation_tool_helpers.py
@@ -171,6 +171,8 @@ async def handle_automation_tool_graphql_error(
     msgs = extract_error_strings(exc)
     base = "; ".join(msgs) if msgs else "Automation request failed."
     base = strip_internal_api_diagnostic_markers(base)
+    if not base.strip():
+        base = "Automation request failed."
     base = with_debug_suffix(base, debug=debug, codes=codes, correlation_id=cid)
     return build_automation_error_payload(message=base, code=first_code)
 

--- a/packages/mcp/src/pipefy_mcp/tools/automation_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/automation_tool_helpers.py
@@ -55,6 +55,9 @@ class AutomationToolErrorPayload(TypedDict):
     error: ToolErrorDetail
 
 
+_AUTOMATION_REQUEST_FAILED = "Automation request failed."
+
+
 def build_automation_mutation_success_payload(
     automation: dict[str, Any],
     action: str,
@@ -169,10 +172,10 @@ async def handle_automation_tool_graphql_error(
         return build_automation_error_payload(message=message, code=code)
 
     msgs = extract_error_strings(exc)
-    base = "; ".join(msgs) if msgs else "Automation request failed."
+    base = "; ".join(msgs) if msgs else _AUTOMATION_REQUEST_FAILED
     base = strip_internal_api_diagnostic_markers(base)
     if not base.strip():
-        base = "Automation request failed."
+        base = _AUTOMATION_REQUEST_FAILED
     base = with_debug_suffix(base, debug=debug, codes=codes, correlation_id=cid)
     return build_automation_error_payload(message=base, code=first_code)
 

--- a/packages/mcp/tests/tools/test_automation_tools.py
+++ b/packages/mcp/tests/tools/test_automation_tools.py
@@ -602,6 +602,34 @@ async def test_create_automation_error_only_diagnostic_markers_uses_fallback(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("automation_session", [None], indirect=True)
+async def test_create_automation_error_only_markers_with_debug_keeps_fallback(
+    automation_session, mock_automation_client, extract_payload
+):
+    mock_automation_client.create_automation.side_effect = TransportQueryError(
+        " [code=X] [correlation_id=Y]",
+        errors=[{"message": " [code=X] [correlation_id=Y]"}],
+    )
+
+    async with automation_session as session:
+        result = await session.call_tool(
+            "create_automation",
+            {
+                "pipe_id": "p1",
+                "name": "N",
+                "trigger_id": "e",
+                "action_id": "a",
+                "debug": True,
+            },
+        )
+
+    msg = tool_error_message(extract_payload(result))
+    assert msg.startswith("Automation request failed.")
+    assert "(debug:" in msg and "codes=X" in msg
+    assert "[code=" not in msg and "[correlation_id=" not in msg
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("automation_session", [None], indirect=True)
 async def test_update_automation_success(
     automation_session, mock_automation_client, extract_payload
 ):

--- a/packages/mcp/tests/tools/test_automation_tools.py
+++ b/packages/mcp/tests/tools/test_automation_tools.py
@@ -574,6 +574,34 @@ async def test_create_automation_error(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("automation_session", [None], indirect=True)
+async def test_create_automation_error_only_diagnostic_markers_uses_fallback(
+    automation_session, mock_automation_client, extract_payload
+):
+    mock_automation_client.create_automation.side_effect = TransportQueryError(
+        " [code=X] [correlation_id=Y]",
+        errors=[{"message": " [code=X] [correlation_id=Y]"}],
+    )
+
+    async with automation_session as session:
+        result = await session.call_tool(
+            "create_automation",
+            {
+                "pipe_id": "p1",
+                "name": "N",
+                "trigger_id": "e",
+                "action_id": "a",
+            },
+        )
+
+    payload = extract_payload(result)
+    msg = tool_error_message(payload)
+    assert payload["success"] is False
+    assert msg == "Automation request failed."
+    assert "[code=" not in msg and "[correlation_id=" not in msg
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("automation_session", [None], indirect=True)
 async def test_update_automation_success(
     automation_session, mock_automation_client, extract_payload
 ):


### PR DESCRIPTION
## Problem
When `create_ai_automation` / `update_ai_automation` route failures through `handle_automation_tool_graphql_error`, an error whose text is only diagnostic
markers (`[code=…]` / `[correlation_id=…]`) ends up empty: `extract_error_strings`
returns a non-empty string, so the `else` fallback never fires, and
`strip_internal_api_diagnostic_markers` then blanks the message. The user sees an
empty error.

## Fix
Add a floor after sanitization: if `base` is empty, fall back to
`_AUTOMATION_REQUEST_FAILED`. This mirrors `enrich_behavior_error` in
`ai_tool_helpers.py`. The guard runs before `with_debug_suffix`, so in debug mode
the suffix attaches to the fallback text rather than an empty string. Same block
exists on `dev` and `main`; landing on `dev` propagates to `main` on the next release.

Also extracted the repeated `"Automation request failed."` literal into the
`_AUTOMATION_REQUEST_FAILED` module constant so the two sites cannot drift.

## Tests
- `test_create_automation_error_only_diagnostic_markers_uses_fallback` (debug off)
- `test_create_automation_error_only_markers_with_debug_keeps_fallback` (debug on)

Both fail without the guard (empty / suffix-only message) and pass with it.

Closes #288