### PR TITLE
ci(release): publish to PyPI on every tag and bump to 0.3.0-alpha.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,6 @@ jobs:
           files: dist/*.whl
           body_path: CHANGELOG_RELEASE_BODY.md
       - name: Stage PyPI wheels (SDK + CLI + MCP + Auth + Infra)
-        if: startsWith(github.ref_name, 'v1.') && !contains(github.ref_name, '-')
         run: |
           mkdir -p dist-pypi
           shopt -s nullglob
@@ -105,7 +104,6 @@ jobs:
           fi
           cp "${sdk[0]}" "${cli[0]}" "${mcp[0]}" "${auth[0]}" "${infra[0]}" dist-pypi/
       - name: Smoke install staged wheels (clean venv)
-        if: startsWith(github.ref_name, 'v1.') && !contains(github.ref_name, '-')
         run: |
           python -m venv .venv-pypi-smoke
           .venv-pypi-smoke/bin/python -m pip install --upgrade pip
@@ -113,7 +111,6 @@ jobs:
           .venv-pypi-smoke/bin/pipefy --help
           .venv-pypi-smoke/bin/pipefy-mcp-server --help
       - name: Upload to PyPI
-        if: startsWith(github.ref_name, 'v1.') && !contains(github.ref_name, '-')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist-pypi/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,13 +2,13 @@
 
 Workspace distributions (`pipefy`, `pipefy-mcp-server`, `pipefy-cli`, `pipefy-auth`, `pipefy-infra`) share a single **lockstep** version string in each package's `__init__.py`. CI fails if those values diverge.
 
-## Pre-launch (v0.x): GitHub Release only
+## Cutting a release
 
-PyPI publishing is **disabled** for tags that do not start with `v1.`. Pre-release installs use git references (for example `uvx --from git+https://github.com/<owner>/<repo>.git@vX.Y.Z --refresh pipefy-cli`).
+The Release workflow publishes to PyPI on **every `v*` tag**: it builds and uploads all five workspace wheels via Trusted Publishing, whatever the version. A pre-release tag (`aN` / `bN` / `rcN`, or the dashed `-alpha.N` / `-beta.N` forms) uploads to PyPI as a pre-release, so `pip` / `uv` install it only with `--pre`, while a stable `vX.Y.Z` tag is what a plain install resolves. Git-reference installs stay available too (for example `uvx --from git+https://github.com/<owner>/<repo>.git@vX.Y.Z --refresh pipefy-cli`).
 
 ### Public beta line (`v0.2.0-beta.*`)
 
-The next **GitHub pre-release** after the standalone repo’s [`v0.1.0-beta.1`](https://github.com/pipefy/ai-toolkit/releases/tag/v0.1.0-beta.1) is the **`v0.2.0-beta.*`** series on this monorepo (first cut: **`v0.2.0-beta.1`** unless you intentionally reuse another suffix). Same mechanics as any other **v0.x** tag: attach wheels to the GitHub Release; **no PyPI** until **`v1.`**.
+The next **GitHub pre-release** after the standalone repo’s [`v0.1.0-beta.1`](https://github.com/pipefy/ai-toolkit/releases/tag/v0.1.0-beta.1) is the **`v0.2.0-beta.*`** series on this monorepo (first cut: **`v0.2.0-beta.1`** unless you intentionally reuse another suffix). Same mechanics as any other tag: wheels attach to the GitHub Release and upload to PyPI as a pre-release (installable with `--pre`).
 
 The Release workflow requires the git tag (without leading `v`) to **exactly match** `__version__` in `packages/sdk/src/pipefy_sdk/__init__.py` (and the MCP/CLI/Auth/Infra copies). For example tag **`v0.2.0-beta.1`** implies **`__version__ = "0.2.0-beta.1"`** in all five packages before you push the tag (set via step 2 below using `version=0.2.0-beta.1`, or edit the five `__init__.py` files together).
 
@@ -72,13 +72,13 @@ uvx --from "git+https://github.com/pipefy/ai-toolkit.git@vX.Y.Z" --refresh pipef
 # Expected: help text (server may block in stdio mode — Ctrl-C after banner)
 ```
 
-## v1.0 and later: GitHub Release + PyPI
+## v1.0 and later: stable PyPI installs
 
-Same steps as above. For tags whose name starts with **`v1.`** (for example `v1.0.0` or `v1.0.0rc1`), the release workflow also runs **Trusted Publishing** to upload the **`pipefy-cli`** and **`pipefy-mcp-server`** wheels to PyPI via `pypa/gh-action-pypi-publish` (the `pipefy` wheel is built for the GitHub Release but is **not** uploaded to PyPI until maintainers enable it in the workflow; see **Repository setup** below).
+Same steps as above. PyPI publishing already runs on every tag; a **`v1.`** tag with no pre-release suffix (for example `v1.0.0`) is simply what a plain `pip install` / `uv tool install` resolves without `--pre`. The workflow uploads all five workspace wheels to PyPI via `pypa/gh-action-pypi-publish` on every tag.
 
 **Repository setup (maintainers):**
 
-- Configure [Trusted Publishers](https://docs.pypi.org/trusted-publishers/using-a-publisher/) on PyPI for **`pipefy-cli`** and **`pipefy-mcp-server`** (and `pipefy` later if you enable it in the workflow).
+- Configure [Trusted Publishers](https://docs.pypi.org/trusted-publishers/using-a-publisher/) on PyPI for **all five** workspace distributions. Uploads fail until each project has a matching trusted publisher; use PyPI's pending-publisher flow for the first upload of a new name.
 - No long-lived PyPI token is required when using OIDC; the workflow requests `id-token: write`.
 
 **After a v1.x tag:**
@@ -96,4 +96,4 @@ Same steps as above. For tags whose name starts with **`v1.`** (for example `v1.
 | --- | --- |
 | `scripts/bump_version.py` | Reads the SDK `__version__`, applies the bump, writes the same value to SDK, MCP, CLI, Auth, and Infra `__init__.py` plus the root `pyproject.toml`'s `[project].version`, then runs `uv lock` to refresh `uv.lock`. Also exposes a `verify` mode that asserts every version-bearing file agrees. |
 | `.github/workflows/ci.yml` | Invokes `scripts/bump_version.py verify` to assert the five `__version__` strings and root `pyproject.toml` `[project].version` all match. |
-| `.github/workflows/release.yml` | On `v*` tags: asserts the tag matches SDK `__version__`, extracts the matching `CHANGELOG.md` section as the GitHub Release body, builds wheels and sdists with `uv build --all-packages -o dist --wheel --sdist`, attaches wheels to the GitHub Release, and publishes CLI + MCP wheels to PyPI only when `github.ref_name` starts with `v1.`. |
+| `.github/workflows/release.yml` | On `v*` tags: asserts the tag matches SDK `__version__`, extracts the matching `CHANGELOG.md` section as the GitHub Release body, builds wheels and sdists with `uv build --all-packages -o dist --wheel --sdist`, attaches wheels to the GitHub Release, and uploads all five wheels to PyPI via Trusted Publishing on every `v*` tag. |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,6 +42,8 @@ The Release workflow requires the git tag (without leading `v`) to **exactly mat
    git tag -f latest vX.Y.Z && git push --force-with-lease origin latest
    ```
 
+   **Skip this step for a pre-release tag** (`aN` / `bN` / `rcN` or the dashed `-alpha.N` / `-beta.N` forms). `latest` drives default installs, so it must track the newest stable release, not a pre-release.
+
 7. Wait for the **Release** workflow (`.github/workflows/release.yml`) to finish.
 8. Confirm the GitHub Release lists the built wheels (`pipefy_cli-*.whl`, `pipefy_mcp_server-*.whl`, `pipefy-*.whl`, `pipefy_auth-*.whl`, and `pipefy_infra-*.whl`). Optionally verify install from the tag, for example:
 

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -9,7 +9,7 @@ artifacts surfaced here to the SDK.
 
 from __future__ import annotations
 
-__version__ = "0.2.0-beta.4"
+__version__ = "0.3.0-alpha.1"
 
 from pipefy_auth.bearer import (
     RefreshableBearerAuth,

--- a/packages/cli/src/pipefy_cli/__init__.py
+++ b/packages/cli/src/pipefy_cli/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.2.0-beta.4"
+__version__ = "0.3.0-alpha.1"
 
 __all__ = ["__version__"]

--- a/packages/infra/src/pipefy_infra/__init__.py
+++ b/packages/infra/src/pipefy_infra/__init__.py
@@ -13,6 +13,6 @@ package sits at the bottom of the workspace dependency graph: stdlib +
 
 from __future__ import annotations
 
-__version__ = "0.2.0-beta.4"
+__version__ = "0.3.0-alpha.1"
 
 __all__ = ["__version__"]

--- a/packages/mcp/src/pipefy_mcp/__init__.py
+++ b/packages/mcp/src/pipefy_mcp/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-__version__ = "0.2.0-beta.4"
+__version__ = "0.3.0-alpha.1"
 version = __version__
 
 m = re.match(r"^(\d+)\.(\d+)\.(\d+)", __version__)

--- a/packages/sdk/src/pipefy_sdk/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.2.0-beta.4"
+__version__ = "0.3.0-alpha.1"
 
 from pipefy_sdk.client import PipefyClient
 from pipefy_sdk.exceptions import PipefyAPIError, PipefyError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipefy-workspace"
-version = "0.2.0-beta.4"
+version = "0.3.0-alpha.1"
 description = "Development workspace for Pipefy MCP server, SDK, and CLI (not published as a single distribution)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1021,7 +1021,7 @@ dev = [
 
 [[package]]
 name = "pipefy-workspace"
-version = "0.2.0b4"
+version = "0.3.0a1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

Enable an alpha release off `dev` that publishes to PyPI:

- **`ci(release)`**: drop the `startsWith(github.ref_name, 'v1.') && !contains(github.ref_name, '-')` gate from the three PyPI steps (Stage / Smoke install / Upload). The workflow now uploads all five workspace wheels via Trusted Publishing on every `v*` tag, including 0.x and pre-release tags. Pre-release versions upload as pre-releases (installable only with `--pre`).
- **`chore(release)`**: bump the lockstep version `0.2.0-beta.4` -> `0.3.0-alpha.1` (minor bump for the breaking changes under `[Unreleased]`, first alpha of the 0.3.0 line).
- **`RELEASE.md`**: document the every-tag publishing policy and the trusted-publisher setup for all five distributions.

## Why

The previous gate published to PyPI only for `v1.` tags with no pre-release suffix, so a 0.x alpha cut off `dev` produced a GitHub Release but never reached PyPI. Relaxing the gate lets us exercise the full PyPI pipeline from the alpha line.

## Stacking

This branch is stacked on `refactor/rename-sdk-dist-to-pipefy` (#361), so it carries none of that PR's diff here and cannot conflict with it. #361 must land first (its wheel-name globs are what make the `pipefy-*.whl` SDK upload match). When #361 merges, GitHub auto-retargets this PR's base to `dev`.

## Before tagging a release

- Configure PyPI Trusted Publishers for all five distributions (`pipefy`, `pipefy-cli`, `pipefy-mcp-server`, `pipefy-auth`, `pipefy-infra`); use the pending-publisher flow for first upload of a new name.
- Rename the `CHANGELOG.md` `## [Unreleased]` heading to `## [0.3.0-alpha.1] - <date>` at tag time (the release-notes step needs the matching heading).
- Do not roll the `latest` moving tag for a pre-release; `latest` drives default installs.
