### PR TITLE
chore(release): post-0.3.0-alpha.1 housekeeping (skip-existing + reopen Unreleased)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,3 +114,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist-pypi/
+          # Idempotent re-runs: a re-pushed tag at an already-published version
+          # skips files already on PyPI instead of failing on PyPI's 400.
+          skip-existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Releases are versioned in lockstep across workspace members (`pipefy`, `pipefy-m
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
 ## [0.3.0-alpha.1] - 2026-07-04
 
 ### Added


### PR DESCRIPTION
## What

Two post-release cleanups after cutting `v0.3.0-alpha.1`:

- **`ci(release)`**: add `skip-existing: true` to the Upload-to-PyPI step. A re-pushed tag at an already-published version otherwise fails the whole release on PyPI's 400 for a duplicate file. This is the exact failure mode we hit during the alpha upload (`pipefy` published, then a later file 400'd), which needed manual recovery.
- **`docs(changelog)`**: reopen an empty `## [Unreleased]` section. Cutting the alpha renamed the old `[Unreleased]` heading into `## [0.3.0-alpha.1]`, leaving new entries nowhere to land.

## Why

Both are follow-ups to the `0.3.0-alpha.1` release (#365). `skip-existing` makes re-running a release idempotent; reopening `[Unreleased]` restores the changelog's working section for the next change.

## Test

No behavior change to build or version logic; `release.yml` still uploads the same staged wheels, only now tolerant of files already on PyPI.
