### PR TITLE
feat(plugin): install the MCP server from PyPI

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,12 +3,8 @@
     "pipefy": {
       "command": "uvx",
       "args": [
-        "--with",
-        "pipefy @ git+https://github.com/pipefy/ai-toolkit@latest#subdirectory=packages/sdk",
-        "--with",
-        "pipefy-auth @ git+https://github.com/pipefy/ai-toolkit@latest#subdirectory=packages/auth",
-        "--from",
-        "git+https://github.com/pipefy/ai-toolkit@latest#subdirectory=packages/mcp",
+        "--prerelease",
+        "allow",
         "pipefy-mcp-server"
       ]
     }

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,8 +3,6 @@
     "pipefy": {
       "command": "uvx",
       "args": [
-        "--prerelease",
-        "allow",
         "pipefy-mcp-server"
       ]
     }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -5,10 +5,10 @@ MCP server for Pipefy — **152 tools** for AI agents (Cursor, Claude Desktop, C
 ## Install
 
 ```sh
-uvx --prerelease allow pipefy-mcp-server
+uvx pipefy-mcp-server
 ```
 
-`pipefy-mcp-server` and its workspace dependencies (`pipefy`, `pipefy-auth`, `pipefy-infra`) are published to PyPI, so `uvx` resolves the whole set from there. `--prerelease allow` is required while the toolkit ships pre-release versions (the 0.x line); once a stable release exists, `uvx pipefy-mcp-server` resolves it without the flag.
+`pipefy-mcp-server` and its workspace dependencies (`pipefy`, `pipefy-auth`, `pipefy-infra`) are published to PyPI, so `uvx` resolves the whole set from there. While the toolkit ships only pre-release versions (the 0.x line), `uvx` resolves the latest pre-release automatically; once a stable release exists it resolves that instead. Do not pass a global `--prerelease allow`: it also lets transitive dependencies jump to their own pre-releases, which can pull a broken build.
 
 For per-client wiring (Claude Code / Cursor / Claude Desktop / Codex), see [root `README.md#installation`](../../README.md#installation).
 
@@ -40,7 +40,7 @@ Useful when you want to wire the server without editing `~/.claude.json` by hand
 
 ```bash
 claude mcp add --scope project pipefy \
-  -- uvx --prerelease allow pipefy-mcp-server
+  -- uvx pipefy-mcp-server
 ```
 
 Then (repeat for each key you need):

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,17 +2,13 @@
 
 MCP server for Pipefy — **152 tools** for AI agents (Cursor, Claude Desktop, Claude Code, Codex, and any MCP-compatible client). Depends on [`pipefy`](../sdk/README.md) for all GraphQL and API logic.
 
-## Install (pre-launch, v0.1 → v0.5)
+## Install
 
 ```sh
-uvx \
-  --with "pipefy @ git+https://github.com/pipefy/ai-toolkit@latest#subdirectory=packages/sdk" \
-  --with "pipefy-auth @ git+https://github.com/pipefy/ai-toolkit@latest#subdirectory=packages/auth" \
-  --from "git+https://github.com/pipefy/ai-toolkit@latest#subdirectory=packages/mcp" \
-  --refresh pipefy-mcp-server
+uvx --prerelease allow pipefy-mcp-server
 ```
 
-The `--with pipefy` / `pipefy-auth` flags are required pre-1.0 because the workspace members are not yet on PyPI. At v1.0 this collapses to `uvx pipefy-mcp-server`.
+`pipefy-mcp-server` and its workspace dependencies (`pipefy`, `pipefy-auth`, `pipefy-infra`) are published to PyPI, so `uvx` resolves the whole set from there. `--prerelease allow` is required while the toolkit ships pre-release versions (the 0.x line); once a stable release exists, `uvx pipefy-mcp-server` resolves it without the flag.
 
 For per-client wiring (Claude Code / Cursor / Claude Desktop / Codex), see [root `README.md#installation`](../../README.md#installation).
 
@@ -44,11 +40,7 @@ Useful when you want to wire the server without editing `~/.claude.json` by hand
 
 ```bash
 claude mcp add --scope project pipefy \
-  -- uvx \
-       --with "pipefy @ git+https://github.com/pipefy/ai-toolkit@latest#subdirectory=packages/sdk" \
-       --with "pipefy-auth @ git+https://github.com/pipefy/ai-toolkit@latest#subdirectory=packages/auth" \
-       --from "git+https://github.com/pipefy/ai-toolkit@latest#subdirectory=packages/mcp" \
-       pipefy-mcp-server
+  -- uvx --prerelease allow pipefy-mcp-server
 ```
 
 Then (repeat for each key you need):


### PR DESCRIPTION
## What

Switch the bundled plugin `.mcp.json` (and the MCP package README's launch snippets) from `uvx --from git+...#subdirectory=...` to a plain PyPI install: `uvx --prerelease allow pipefy-mcp-server`.

## Why

The bundled config launched the server from git subdirectory refs, so every `/plugin install` and `--refresh` cloned the repo and built four workspace members (`pipefy`, `pipefy-auth`, `pipefy-infra`, `pipefy-mcp-server`) from source. All five packages now publish to PyPI on every tag (#365), so `uvx` resolves `pipefy-mcp-server` and its dependency closure straight from the index, with no clone or build.

`--prerelease allow` is required while the 0.x line ships only pre-release versions (a plain `uvx pipefy-mcp-server` finds nothing installable when only pre-releases exist). It drops once a stable release is published; the README documents that.

## Scope

- `.mcp.json`: the zero-config default the plugin ships.
- `packages/mcp/README.md`: the install block and the `claude mcp add` snippet, to match.

Left for a separate follow-up (a broader docs pass, not the programmatic install path):
- The root `README.md` CLI install blocks (`uvx --from git+...packages/cli`) and its pre-1.0 "not yet on PyPI" policy prose.
- `commands/install.md` (the CLI installer command).

## Context

This is the surviving, still-relevant piece of the old #260 (install via release wheel URLs). #260's Release-wheel-URL approach is superseded now that PyPI publishing is live: PyPI is simpler and also removes the clone/build. #260 can be closed.

## Test

- `.mcp.json` parses as valid JSON.
- All five distributions are live on PyPI at the current pre-release (`0.3.0a1`), so `uvx --prerelease allow pipefy-mcp-server` resolves the full closure from the index.
