### PR TITLE
feat(install): register the Claude Code MCP server at user scope

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,17 @@
   "author": { "name": "Pipefy", "url": "https://github.com/pipefy" },
   "homepage": "https://github.com/pipefy/ai-toolkit",
   "repository": "https://github.com/pipefy/ai-toolkit",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/check-server-version.sh\""
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/hooks/check-server-version.sh
+++ b/hooks/check-server-version.sh
@@ -3,7 +3,9 @@
 # server (the persistent pipefy-mcp-server binary, which shadows the plugin's
 # bundled uvx entry), plugin auto-updates no longer reach that running server.
 # This compares the installed binary's version against the plugin's declared
-# version and, on drift, asks the user to re-run /pipefy:install.
+# version and, on drift, tells the user to re-run install.sh (the path that
+# actually reinstalls the binary and re-registers the user-scope server;
+# /pipefy:install only installs the CLI).
 #
 # No-op for users on the pure plugin/uvx path: they have no installed binary,
 # so there is nothing shadowing the plugin and nothing to update.
@@ -24,6 +26,6 @@ installed=$(pipefy-mcp-server --version 2>/dev/null | tr -d '[:space:]')
 [ -n "$installed" ] || exit 0
 
 if [ "$installed" != "$plugin" ]; then
-    echo "Pipefy: the installed MCP server ($installed) differs from this plugin ($plugin); re-run /pipefy:install to sync."
+    echo "Pipefy: the installed MCP server ($installed) differs from this plugin ($plugin). Re-run the installer to sync: curl -fsSL https://raw.githubusercontent.com/pipefy/ai-toolkit/main/install.sh | sh -s -- --client claude-code"
 fi
 exit 0

--- a/hooks/check-server-version.sh
+++ b/hooks/check-server-version.sh
@@ -20,7 +20,7 @@ manifest="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"
 plugin=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest" | head -n1)
 [ -n "$plugin" ] || exit 0
 
-installed=$(pipefy-mcp-server --version 2>/dev/null | tr -d '[:space:]') || exit 0
+installed=$(pipefy-mcp-server --version 2>/dev/null | tr -d '[:space:]')
 [ -n "$installed" ] || exit 0
 
 if [ "$installed" != "$plugin" ]; then

--- a/hooks/check-server-version.sh
+++ b/hooks/check-server-version.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# SessionStart nudge: when install.sh has registered a user-scope `pipefy`
+# server (the persistent pipefy-mcp-server binary, which shadows the plugin's
+# bundled uvx entry), plugin auto-updates no longer reach that running server.
+# This compares the installed binary's version against the plugin's declared
+# version and, on drift, asks the user to re-run /pipefy:install.
+#
+# No-op for users on the pure plugin/uvx path: they have no installed binary,
+# so there is nothing shadowing the plugin and nothing to update.
+set -eu
+
+# No installed binary means nothing shadows the plugin, so there is no
+# user-scope override that could drift -> nothing to nudge about.
+command -v pipefy-mcp-server >/dev/null 2>&1 || exit 0
+
+# Cheap checks first; only spawn the binary (Python cold start) once we have a
+# plugin version to compare against.
+manifest="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"
+[ -f "$manifest" ] || exit 0
+plugin=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest" | head -n1)
+[ -n "$plugin" ] || exit 0
+
+installed=$(pipefy-mcp-server --version 2>/dev/null | tr -d '[:space:]') || exit 0
+[ -n "$installed" ] || exit 0
+
+if [ "$installed" != "$plugin" ]; then
+    echo "Pipefy: the installed MCP server ($installed) differs from this plugin ($plugin); re-run /pipefy:install to sync."
+fi
+exit 0

--- a/hooks/check-server-version.sh
+++ b/hooks/check-server-version.sh
@@ -7,13 +7,33 @@
 # actually reinstalls the binary and re-registers the user-scope server;
 # /pipefy:install only installs the CLI).
 #
-# No-op for users on the pure plugin/uvx path: they have no installed binary,
-# so there is nothing shadowing the plugin and nothing to update.
+# No-op unless that user-scope override is registered: users on the pure
+# plugin/uvx path have no installed binary, and users who installed the binary
+# only for another client (e.g. --client cursor) still run the plugin's uvx
+# server here, so there is nothing shadowing the plugin to nudge about.
 set -eu
 
-# No installed binary means nothing shadows the plugin, so there is no
-# user-scope override that could drift -> nothing to nudge about.
+# Cheap pre-filter: no installed binary means nothing could shadow the plugin.
 command -v pipefy-mcp-server >/dev/null 2>&1 || exit 0
+
+# The precise trigger is a user-scope `pipefy` server whose command is that
+# binary. `command -v` alone is not enough: --client cursor also puts the
+# binary on PATH without registering a Claude Code override, so the plugin's
+# uvx server still runs here and there is nothing to sync. Fall through to no
+# nudge if python3 is missing or the config cannot be read.
+python3 - <<'PY' || exit 0
+import json
+import os
+import sys
+
+try:
+    servers = json.load(open(os.path.expanduser("~/.claude.json"))).get("mcpServers", {})
+except (OSError, ValueError):
+    sys.exit(1)
+entry = servers.get("pipefy") if isinstance(servers, dict) else None
+command = entry.get("command") if isinstance(entry, dict) else None
+sys.exit(0 if command == "pipefy-mcp-server" else 1)
+PY
 
 # Cheap checks first; only spawn the binary (Python cold start) once we have a
 # plugin version to compare against.

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,8 @@
 # Resolves the latest GitHub Release tag (or a tag passed via --version),
 # discovers its wheel assets, installs the CLI and MCP server via
 # `uv tool install`, optionally installs skills via `npx skills add`, and
-# writes the MCP server registration into the chosen client's config.
+# registers the MCP server with the chosen client (a config-file write for
+# most clients; `claude mcp add` at user scope for Claude Code).
 
 set -eu
 
@@ -71,8 +72,11 @@ and register the MCP server with an MCP client.
 Options:
   --yes, -y           Skip all confirmation prompts.
   --no-skills         Skip the skills installation step.
-  --client <id>       Register MCP server in this client's config.
+  --client <id>       Register the MCP server for this client.
                       One of: claude-code, claude-desktop, cursor, codex, none.
+                      claude-code registers via 'claude mcp add' at user scope
+                      (overrides the plugin's bundled server); the others write
+                      the client's own config file.
                       Defaults to 'none' (prints snippet to paste).
   --version <tag>     Install a specific GitHub Release tag (e.g. v0.2.0-beta.2).
                       Defaults to the most recent release (incl. prereleases).
@@ -314,6 +318,28 @@ require_python3() {
     fi
 }
 
+require_claude() {
+    if ! command -v claude >/dev/null 2>&1; then
+        err "the 'claude' CLI is required to register the MCP server in Claude Code, but was not found. Install Claude Code (https://claude.com/claude-code), or re-run with --client none and paste the snippet manually."
+    fi
+}
+
+claude_code_register_pipefy() {
+    # Register at USER scope: Claude Code resolves same-named servers
+    # local > project > user > plugin, so a user-scope `pipefy` shadows the
+    # plugin's bundled entry and only the binary installed above spawns. The
+    # bare binary (not a uvx command) keeps the server on the system Python it
+    # was installed with, without baking an interpreter path into user config.
+    if [ "$DRY_RUN" -eq 0 ]; then
+        require_claude
+        # `claude mcp add` errors on a duplicate name; drop any prior user-scope
+        # entry first to keep re-runs idempotent.
+        claude mcp remove pipefy --scope user >/dev/null 2>&1 || true
+    fi
+    run claude mcp add pipefy --scope user -- pipefy-mcp-server
+    [ "$DRY_RUN" -eq 1 ] || say "Registered 'pipefy' at user scope (overrides the plugin's bundled server)."
+}
+
 json_merge_pipefy() {
     path="$1"
     if [ "$DRY_RUN" -eq 1 ]; then
@@ -404,6 +430,8 @@ EOF
 }
 
 write_client_config() {
+    # cursor/claude-desktop/codex write the client's own config file; claude-code
+    # instead registers via `claude mcp add` (user scope) to override the plugin.
     case "$CLIENT" in
         cursor)
             json_merge_pipefy "$HOME/.cursor/mcp.json"
@@ -415,11 +443,7 @@ write_client_config() {
             codex_append_pipefy "$HOME/.codex/config.toml"
             ;;
         claude-code)
-            cat <<EOF
-To install in Claude Code, run these slash commands:
-  /plugin marketplace add $REPO
-  /plugin install pipefy@pipefy
-EOF
+            claude_code_register_pipefy
             ;;
         ""|none)
             print_manual_snippet
@@ -449,6 +473,13 @@ print_next_steps() {
         say "    For future shells, uv typically updates your shell rc (~/.bashrc,"
         say "    ~/.zshrc, ~/.config/fish/conf.d/uv.fish). If a new terminal still"
         say "    can't find 'pipefy', add \$HOME/.local/bin to PATH manually."
+    fi
+    if [ "$CLIENT" = "claude-code" ]; then
+        say ""
+        say "==> Pipefy MCP server registered at user scope (overrides the plugin's"
+        say "    bundled server). Reload or restart Claude Code for it to take effect."
+        say "    For skills and slash commands, also install the plugin:"
+        say "        /plugin marketplace add $REPO && /plugin install pipefy@pipefy"
     fi
     say ""
     say "Next: authenticate with Pipefy."


### PR DESCRIPTION
> Draft. This is the deferred design piece from #270, ported onto current `dev` and stacked on #368. It is not ready to merge as-is: see the open questions below.

## What

On the Claude Code path, `install.sh` currently leaves the plugin's bundled uvx `.mcp.json` entry as the running server while also `uv tool install`ing `pipefy-mcp-server`, so a plugin user who runs `/pipefy:install` ends up with two materializations (the uvx-cached env plus an unused tool venv).

This makes the installer the single owner of the Claude Code registration:

- **`install.sh`**: `--client claude-code` registers via `claude mcp add pipefy --scope user -- pipefy-mcp-server` (idempotent: removes any prior user-scope entry first; `require_claude` errors cleanly if the `claude` CLI is absent). By Claude Code's name precedence (`local > project > user > plugin`) the user-scope entry shadows the plugin's bundled server, so only the installed binary spawns, on the system Python the CLI is pinned to.
- **`.claude-plugin/plugin.json` + `hooks/check-server-version.sh`**: a `SessionStart` hook that nudges the user to re-run `/pipefy:install` when the installed server's `--version` drifts from the plugin manifest version. It no-ops for users on the pure plugin/uvx path (no installed binary).

## Why user scope, not editing the plugin

There is no supported way to disable a single plugin's bundled MCP server. Name-shadowing at a higher scope is the only lever, and it is deterministic per the documented precedence. The committed `.mcp.json` stays the zero-config default (`/plugin install pipefy@pipefy` still works with no prior step); the override only takes effect once a user runs the installer with `--client claude-code`.

## Why the drift hook

Shadowing means plugin auto-updates no longer reach the running (installed) server. The hook is the mitigation for that staleness. It reads the plugin version (cheap `sed` on `plugin.json`) before spawning `pipefy-mcp-server --version`, so the Python cold start only happens for users who actually have the override installed.

The compare is a raw string, and it holds because `--version` is argparse `action="version"` echoing `__version__` verbatim (the dashed form, e.g. `0.3.0-alpha.1`), and the manifest now tracks that same value in lockstep (via the plugin.json lockstep added in #367). So a user on the current release is not nudged. **This depends on #367 landing** (before it, the manifest was stuck at `0.2.0-beta.1` and every session would nudge).

## Stacking

Stacked on #368 (`chore/mcp-json-pypi-install`); GitHub retargets the base to `dev` when #368 merges. The two do not overlap in files, but #368 settles the `.mcp.json` shape this feature coexists with, and #367 provides the manifest-lockstep the hook relies on, so this should land after both.

## Open questions (why this is a draft)

1. **Slash-command wiring is not included.** #270 also switched `/pipefy:install` (`commands/install.md`) from `--client none` to `--client claude-code`. On current `dev` that command no longer uses the curl installer at all: it runs a direct git-based `uv tool install` and never calls `install.sh`. Wiring the slash command to trigger user-scope registration is a separate decision, tangled with the pending CLI-install PyPI migration, so I left `commands/install.md` out. Without it, user-scope registration is reachable only by running `install.sh --client claude-code` directly.
2. **Is shadowing the desired UX?** It is deterministic, but it means a plugin user who runs the installer silently stops receiving plugin auto-updates for the server (the hook is the only feedback). Worth confirming this is the intended model before shipping.
3. **`--version` format coupling.** The hook's raw-string compare is correct only as long as `--version` keeps emitting the dashed `__version__` and the manifest stays in lockstep with it. If either changes to the PEP 440-normalized form (`0.3.0a1`), the compare needs canonicalization on both sides.
4. **Is the manifest version the right anchor for the hook?** (Surfaced by a `/simplify` altitude pass.) The hook diffs the installed binary's `--version` against `plugin.json`'s manifest version, but that manifest version is not what the plugin actually *runs*: `.mcp.json` is an unpinned `uvx --prerelease allow pipefy-mcp-server`, i.e. latest PyPI pre-release. The truthful "is my shadowing binary stale?" comparison is installed-vs-what-the-plugin-would-run, so the options are: pin the bundled server in `.mcp.json` and read that pin, compare installed-vs-latest-PyPI (adds a network call to a session-start hook), or keep the manifest anchor and accept it as a proxy that is exact only at release time. Note #367 makes the manifest track the package version in lockstep, which removes today's `0.2.0-beta.1` vs `0.3.0-alpha.1` skew but does not by itself make the manifest equal the running server's resolved version.
5. **Session-start cost.** (Surfaced by a `/simplify` efficiency pass.) The hook spawns `pipefy-mcp-server --version` on every SessionStart for anyone who ran `install.sh --client claude-code`; measured at ~0.58s wall (Python cold start). Guards correctly defer the spawn (no binary -> instant exit), but it is the steady-state cost for the target population. If kept, the cheap mitigation is an mtime-keyed cache (stat the resolved binary, cache `<mtime> <version>`, re-spawn only when it changes) so the cost collapses to roughly once per install. Deferred as a design call rather than optimized in place, since question 2 may drop the hook entirely.

## Test

- A `/simplify` pass ran over this diff: applied one cleanup (removed a dead `|| exit 0` guard in the hook), and surfaced open questions 4 and 5 above; reuse/altitude otherwise judged the shell + hook at the right altitude.
- `sh -n install.sh` and `sh -n hooks/check-server-version.sh` pass.
- `.claude-plugin/plugin.json` parses as valid JSON.
- `install.sh --dry-run --client claude-code` previews `claude mcp add pipefy --scope user -- pipefy-mcp-server` and the user-scope next-steps message.
- Not yet exercised on a real Claude Code machine (the `claude mcp add` + reload + `claude mcp list` shadowing check).

