### PR TITLE
refactor(sdk): unify the GraphQL execution seam (one protocol, one result type) [#354 Rung 2]

### DIFF
--- a/packages/sdk/src/pipefy_sdk/graphql_executor.py
+++ b/packages/sdk/src/pipefy_sdk/graphql_executor.py
@@ -14,11 +14,13 @@ from httpx import Auth, Timeout
 
 
 @dataclass(frozen=True)
-class PartialQueryResult:
+class GraphQLResult:
     """GraphQL ``data`` plus the raw per-node error dicts from one response.
 
-    Owned by the executor so services and their tests never touch gql objects.
-    ``data`` is always a dict; a fully null response yields an empty one.
+    A GraphQL response can carry readable ``data`` and per-node ``errors`` at the
+    same time, so the primitive hands both back together. Owned by the executor
+    so services and their tests never touch gql objects. ``data`` is always a
+    dict; a fully null response yields an empty one.
     """
 
     data: dict[str, Any]
@@ -28,28 +30,30 @@ class PartialQueryResult:
 class GraphQLExecutor(Protocol):
     """The GraphQL execution seam services depend on.
 
-    Narrow by design: it exposes only the operation services need and leaks
-    nothing about the httpx/gql transport. Services receive an implementation
-    through their constructor and call ``execute_query``; tests inject a fake.
+    Narrow by design: it exposes only what services need. Its return types are
+    owned (:class:`GraphQLResult` and a plain ``dict``); the one gql type it
+    surfaces is the ``TransportQueryError`` a formatter-less :meth:`execute_query`
+    raises. Services receive an implementation through their constructor and call
+    one of two methods; tests inject a fake.
+
+    :meth:`execute` is the primitive: it performs the request and returns
+    ``data`` and ``errors`` together, deciding nothing about what the errors
+    mean. :meth:`execute_query` is the raise-on-error convenience layered over
+    it, for the callers that want data or an exception and nothing in between. A
+    service that needs partial-success handling calls :meth:`execute` and hands
+    the errors to its own classifier.
+
     ``query`` is a parsed ``DocumentNode``: callers build one with ``gql()`` (the
     raw ``execute_graphql`` passthrough parses its string before reaching here).
     """
 
+    async def execute(
+        self, query: DocumentNode, variables: dict[str, Any]
+    ) -> GraphQLResult: ...
+
     async def execute_query(
         self, query: DocumentNode, variables: dict[str, Any]
     ) -> dict: ...
-
-
-class PartialGraphQLExecutor(GraphQLExecutor, Protocol):
-    """:class:`GraphQLExecutor` plus a partial-tolerant execute path.
-
-    For services whose queries mix ``data`` with per-node ``errors`` in one
-    response; everything else depends on the narrower protocol.
-    """
-
-    async def execute_query_allow_partial(
-        self, query: DocumentNode, variables: dict[str, Any]
-    ) -> PartialQueryResult: ...
 
 
 def _graphql_request_with_variables(
@@ -87,10 +91,11 @@ class GraphQLEndpoint:
         self._graphql_url = url
         self._cache_schema = cache_schema
         self._headers = headers
-        # When set, ``TransportQueryError`` is converted to ``ValueError`` using the
-        # formatter's output. Used by the Internal API endpoint to surface its
-        # ``[code=…] [correlation_id=…]`` envelope; ``None`` leaves gql exceptions
-        # untouched (the public endpoint's behaviour).
+        # How execute_query surfaces GraphQL errors. When set, it raises a
+        # ValueError carrying the formatter's output; used by the Internal API
+        # endpoint for its [code=…] [correlation_id=…] envelope. When None it
+        # re-raises the gql TransportQueryError shape (the public endpoint's
+        # behaviour). The primitive execute never applies it.
         self._on_graphql_error = on_graphql_error
         # Caches the introspected schema so it is fetched once, not per Client.
         self._fetched_gql_schema: GraphQLSchema | None = None
@@ -146,64 +151,66 @@ class GraphQLEndpoint:
         ) as session:
             return await session.execute(request)
 
-    def _reraise_graphql_error(self, exc: TransportQueryError) -> NoReturn:
-        if self._on_graphql_error is None:
-            raise exc
-        raise ValueError(self._on_graphql_error(exc.errors or [])) from exc
-
     async def execute(
         self, query: DocumentNode, variables: dict[str, Any], *, auth: Auth
-    ) -> dict:
-        """Execute a GraphQL query/mutation with variables under ``auth``.
+    ) -> GraphQLResult:
+        """Execute a query and return its ``data`` and raw ``errors`` together.
 
-        All-or-nothing: any GraphQL ``errors`` raise and partial ``data`` is
-        discarded; for responses that mix both, use :meth:`execute_allow_partial`.
-        """
-        try:
-            return await self._execute_request(query, variables, auth=auth)
-        except TransportQueryError as exc:
-            self._reraise_graphql_error(exc)
-
-    async def execute_allow_partial(
-        self, query: DocumentNode, variables: dict[str, Any], *, auth: Auth
-    ) -> PartialQueryResult:
-        """Execute a query preserving partial ``data`` alongside GraphQL ``errors``.
-
-        gql raises on any ``errors`` but attaches the partial ``data`` and the raw
-        error dicts to the exception; this rebuilds them into a
-        :class:`PartialQueryResult`. A fully null response yields ``data={}`` with
-        its errors preserved: whether an empty result is a failure is the caller's
-        decision, not the transport's.
+        The primitive: it performs the effect and decides nothing about what the
+        errors mean. gql raises on any ``errors`` but attaches the partial ``data``
+        and the raw error dicts to the exception; this rebuilds them into a
+        :class:`GraphQLResult`. A fully null response yields ``data={}`` with its
+        errors preserved. Genuine transport/network failures (timeouts, non-2xx)
+        still raise.
         """
         try:
             data = await self._execute_request(query, variables, auth=auth)
         except TransportQueryError as exc:
-            return PartialQueryResult(
-                data=exc.data or {}, errors=list(exc.errors or [])
-            )
-        return PartialQueryResult(data=data, errors=[])
+            return GraphQLResult(data=exc.data or {}, errors=list(exc.errors or []))
+        return GraphQLResult(data=data, errors=[])
+
+    async def execute_query(
+        self, query: DocumentNode, variables: dict[str, Any], *, auth: Auth
+    ) -> dict:
+        """Run :meth:`execute` and return ``data``, raising if the response held errors.
+
+        The raise-on-error convenience the query/mutation tools use: they want
+        ``data`` or an exception, not partial success. On GraphQL ``errors`` the
+        error formatter decides the exception (see :meth:`_raise_for_errors`).
+        """
+        result = await self.execute(query, variables, auth=auth)
+        if result.errors:
+            self._raise_for_errors(result.errors, data=result.data)
+        return result.data
+
+    def _raise_for_errors(
+        self, errors: list[dict[str, Any]], *, data: dict[str, Any]
+    ) -> NoReturn:
+        if self._on_graphql_error is not None:
+            raise ValueError(self._on_graphql_error(errors))
+        # Without a formatter, re-raise gql's error shape so callers that read the
+        # structured ``errors`` list off the exception keep working unchanged.
+        raise TransportQueryError(str(errors[0]), errors=errors, data=data)
 
 
 @dataclass(frozen=True)
 class AuthenticatedExecutor:
     """A :class:`GraphQLEndpoint` bound to one identity's ``auth``.
 
-    The cheap per-session executor: it implements :class:`PartialGraphQLExecutor`
-    by delegating to the shared endpoint with its own ``auth``. Cheap to build one
+    The cheap per-session executor: it implements :class:`GraphQLExecutor` by
+    delegating to the shared endpoint with its own ``auth``. Cheap to build one
     per request; the endpoint (and its schema cache) is reused across all of them.
     """
 
     endpoint: GraphQLEndpoint
     auth: Auth
 
+    async def execute(
+        self, query: DocumentNode, variables: dict[str, Any]
+    ) -> GraphQLResult:
+        return await self.endpoint.execute(query, variables, auth=self.auth)
+
     async def execute_query(
         self, query: DocumentNode, variables: dict[str, Any]
     ) -> dict:
-        return await self.endpoint.execute(query, variables, auth=self.auth)
-
-    async def execute_query_allow_partial(
-        self, query: DocumentNode, variables: dict[str, Any]
-    ) -> PartialQueryResult:
-        return await self.endpoint.execute_allow_partial(
-            query, variables, auth=self.auth
-        )
+        return await self.endpoint.execute_query(query, variables, auth=self.auth)

--- a/packages/sdk/src/pipefy_sdk/services/observability_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/observability_service.py
@@ -8,7 +8,7 @@ from zipfile import BadZipFile
 import httpx
 from openpyxl.utils.exceptions import InvalidFileException
 
-from pipefy_sdk.graphql_executor import PartialGraphQLExecutor, PartialQueryResult
+from pipefy_sdk.graphql_executor import GraphQLExecutor, GraphQLResult
 from pipefy_sdk.queries.observability_queries import (
     CREATE_AUTOMATION_JOBS_EXPORT_MUTATION,
     GET_AGENTS_USAGE_QUERY,
@@ -163,7 +163,7 @@ def _partial_error(err: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _normalize_execution_metrics_result(result: PartialQueryResult) -> dict[str, Any]:
+def _normalize_execution_metrics_result(result: GraphQLResult) -> dict[str, Any]:
     """Split a partial ``automations.executionMetrics`` response into nodes and errors.
 
     The sole failure decision for this query: a missing or null ``automations``
@@ -189,7 +189,7 @@ def _normalize_execution_metrics_result(result: PartialQueryResult) -> dict[str,
 class ObservabilityService:
     """Reads for AI agent logs, automation logs, usage stats, and credit dashboard."""
 
-    def __init__(self, *, executor: PartialGraphQLExecutor) -> None:
+    def __init__(self, *, executor: GraphQLExecutor) -> None:
         self._executor = executor
 
     async def get_automation_execution_metrics(
@@ -245,7 +245,7 @@ class ObservabilityService:
             sort_by=sort_by,
             sort_order=sort_order,
         )
-        result = await self._executor.execute_query_allow_partial(
+        result = await self._executor.execute(
             GET_AUTOMATION_EXECUTION_METRICS_QUERY, variables
         )
         return _normalize_execution_metrics_result(result)

--- a/packages/sdk/tests/_shared/mock_clients.py
+++ b/packages/sdk/tests/_shared/mock_clients.py
@@ -8,28 +8,27 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-from pipefy_sdk.graphql_executor import PartialGraphQLExecutor, PartialQueryResult
+from pipefy_sdk.graphql_executor import GraphQLExecutor, GraphQLResult
 
 
 def mock_executor(
     return_value: dict | None = None,
     *,
     side_effect=None,
-    partial_result: PartialQueryResult | None = None,
-    partial_side_effect=None,
+    execute_result: GraphQLResult | None = None,
+    execute_side_effect=None,
 ) -> MagicMock:
-    """A MagicMock standing in for a :class:`PartialGraphQLExecutor`.
+    """A MagicMock standing in for a :class:`GraphQLExecutor`.
 
-    Spec'd on the wide protocol so one fake serves every service.
-    ``return_value``/``side_effect`` drive ``execute_query``;
-    ``partial_result``/``partial_side_effect`` drive
-    ``execute_query_allow_partial``. Both are stubbed explicitly: an
-    auto-created method would resolve to a bare MagicMock and feed services
-    silent garbage instead of a failure.
+    ``return_value``/``side_effect`` drive ``execute_query``, the raise-on-error
+    convenience most services call. ``execute_result``/``execute_side_effect``
+    drive ``execute``, the primitive that hands back data and errors together.
+    Both are stubbed explicitly: an auto-created method would resolve to a bare
+    MagicMock and feed services silent garbage instead of a failure.
     """
-    mock = MagicMock(spec=PartialGraphQLExecutor)
+    mock = MagicMock(spec=GraphQLExecutor)
     mock.execute_query = AsyncMock(return_value=return_value, side_effect=side_effect)
-    mock.execute_query_allow_partial = AsyncMock(
-        return_value=partial_result, side_effect=partial_side_effect
+    mock.execute = AsyncMock(
+        return_value=execute_result, side_effect=execute_side_effect
     )
     return mock

--- a/packages/sdk/tests/services/pipefy/test_observability_service.py
+++ b/packages/sdk/tests/services/pipefy/test_observability_service.py
@@ -10,7 +10,7 @@ from _shared.mock_clients import mock_executor
 from gql.transport.exceptions import TransportQueryError
 from openpyxl import Workbook
 
-from pipefy_sdk.graphql_executor import PartialQueryResult
+from pipefy_sdk.graphql_executor import GraphQLResult
 from pipefy_sdk.queries.observability_queries import (
     CREATE_AUTOMATION_JOBS_EXPORT_MUTATION,
     GET_AGENTS_USAGE_QUERY,
@@ -34,7 +34,7 @@ def _make_service(return_value):
 
 
 def _make_partial_service(partial_result):
-    executor = mock_executor(partial_result=partial_result)
+    executor = mock_executor(execute_result=partial_result)
     service = ObservabilityService(executor=executor)
     return service, executor
 
@@ -559,7 +559,7 @@ def _denied_error(automation_id: str) -> dict:
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_all_permitted():
     """Full success: all requested automations return metrics, no partial errors."""
-    partial_result = PartialQueryResult(
+    partial_result = GraphQLResult(
         data={
             "automations": {
                 "pageInfo": {"hasNextPage": False, "endCursor": "cur-2"},
@@ -577,8 +577,8 @@ async def test_get_automation_execution_metrics_all_permitted():
         "3", ["25", "107"], repo_id="16", period="TWENTY_FOUR_HOURS"
     )
 
-    executor.execute_query_allow_partial.assert_awaited_once()
-    query, variables = executor.execute_query_allow_partial.call_args[0]
+    executor.execute.assert_awaited_once()
+    query, variables = executor.execute.call_args[0]
     assert query is GET_AUTOMATION_EXECUTION_METRICS_QUERY
     assert variables == {
         "organizationId": "3",
@@ -597,7 +597,7 @@ async def test_get_automation_execution_metrics_all_permitted():
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_partial_permission_denied():
     """Partial success: permitted nodes returned, denied ids surfaced in partial_errors."""
-    partial_result = PartialQueryResult(
+    partial_result = GraphQLResult(
         data={"automations": {"edges": [{"node": _metrics_node("25", total_runs=3)}]}},
         errors=[_denied_error("124"), _denied_error("65")],
     )
@@ -620,7 +620,7 @@ async def test_get_automation_execution_metrics_partial_permission_denied():
             "correlation_id": "c86ccfa6",
         },
     ]
-    _, variables = executor.execute_query_allow_partial.call_args[0]
+    _, variables = executor.execute.call_args[0]
     assert "repoId" not in variables
 
 
@@ -628,7 +628,7 @@ async def test_get_automation_execution_metrics_partial_permission_denied():
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_all_denied_stays_partial():
     """Every requested id denied but the connection is present: empty list, not a raise."""
-    partial_result = PartialQueryResult(
+    partial_result = GraphQLResult(
         data={"automations": {"edges": []}},
         errors=[_denied_error("124"), _denied_error("65")],
     )
@@ -644,7 +644,7 @@ async def test_get_automation_execution_metrics_all_denied_stays_partial():
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_null_connection_raises():
     """A null automations connection (lookup failed) is a total failure, not empty success."""
-    partial_result = PartialQueryResult(
+    partial_result = GraphQLResult(
         data={"automations": None},
         errors=[
             {
@@ -663,7 +663,7 @@ async def test_get_automation_execution_metrics_null_connection_raises():
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_null_connection_without_errors_raises():
     """A null connection raises even when the response carries no error to quote."""
-    partial_result = PartialQueryResult(data={"automations": None}, errors=[])
+    partial_result = GraphQLResult(data={"automations": None}, errors=[])
     service, _ = _make_partial_service(partial_result)
 
     with pytest.raises(ValueError, match="Query failed."):
@@ -674,7 +674,7 @@ async def test_get_automation_execution_metrics_null_connection_without_errors_r
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_empty_data_raises():
     """A fully null response (executor hands back empty data) fails through the same decision."""
-    partial_result = PartialQueryResult(
+    partial_result = GraphQLResult(
         data={},
         errors=[{"message": "Couldn't find Organization with 'id'=999"}],
     )
@@ -688,7 +688,7 @@ async def test_get_automation_execution_metrics_empty_data_raises():
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_without_ids_omits_filter():
     """Omitting automation_ids drops the automationIds variable so the query returns all."""
-    partial_result = PartialQueryResult(
+    partial_result = GraphQLResult(
         data={
             "automations": {
                 "edges": [
@@ -703,7 +703,7 @@ async def test_get_automation_execution_metrics_without_ids_omits_filter():
 
     result = await service.get_automation_execution_metrics("3")
 
-    _, variables = executor.execute_query_allow_partial.call_args[0]
+    _, variables = executor.execute.call_args[0]
     assert "automationIds" not in variables
     assert variables == {"organizationId": "3", "period": "SIXTY_MINUTES", "first": 50}
     assert [a["id"] for a in result["automations"]] == ["25", "107"]
@@ -713,7 +713,7 @@ async def test_get_automation_execution_metrics_without_ids_omits_filter():
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_paginates_with_first_and_after():
     """first and after are forwarded; after is omitted when not supplied."""
-    partial_result = PartialQueryResult(
+    partial_result = GraphQLResult(
         data={
             "automations": {
                 "pageInfo": {"hasNextPage": True, "endCursor": "cur-1"},
@@ -728,7 +728,7 @@ async def test_get_automation_execution_metrics_paginates_with_first_and_after()
         "3", first=50, after="cur-0"
     )
 
-    _, variables = executor.execute_query_allow_partial.call_args[0]
+    _, variables = executor.execute.call_args[0]
     assert variables["first"] == 50
     assert variables["after"] == "cur-0"
     assert result["page_info"] == {"hasNextPage": True, "endCursor": "cur-1"}
@@ -738,7 +738,7 @@ async def test_get_automation_execution_metrics_paginates_with_first_and_after()
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_forwards_all_filters():
     """search, active, event_id, action_ids, and sort_by/order map onto the variables."""
-    partial_result = PartialQueryResult(
+    partial_result = GraphQLResult(
         data={"automations": {"edges": [{"node": _metrics_node("25", total_runs=3)}]}},
         errors=[],
     )
@@ -754,7 +754,7 @@ async def test_get_automation_execution_metrics_forwards_all_filters():
         sort_order="asc",
     )
 
-    _, variables = executor.execute_query_allow_partial.call_args[0]
+    _, variables = executor.execute.call_args[0]
     assert variables["actionIds"] == ["9", "10"]
     assert variables["eventId"] == "card_moved"
     assert variables["active"] is True
@@ -766,7 +766,7 @@ async def test_get_automation_execution_metrics_forwards_all_filters():
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_omits_unset_filters():
     """Unset optional filters are absent from the variables (never sent as nulls)."""
-    partial_result = PartialQueryResult(
+    partial_result = GraphQLResult(
         data={"automations": {"edges": []}},
         errors=[],
     )
@@ -774,7 +774,7 @@ async def test_get_automation_execution_metrics_omits_unset_filters():
 
     await service.get_automation_execution_metrics("3")
 
-    _, variables = executor.execute_query_allow_partial.call_args[0]
+    _, variables = executor.execute.call_args[0]
     for absent in ("actionIds", "eventId", "active", "search", "sort"):
         assert absent not in variables
 
@@ -783,7 +783,7 @@ async def test_get_automation_execution_metrics_omits_unset_filters():
 @pytest.mark.asyncio
 async def test_get_automation_execution_metrics_partial_sort_criteria():
     """sort_by alone yields a sort input with only the `by` field set."""
-    partial_result = PartialQueryResult(
+    partial_result = GraphQLResult(
         data={"automations": {"edges": []}},
         errors=[],
     )
@@ -791,5 +791,5 @@ async def test_get_automation_execution_metrics_partial_sort_criteria():
 
     await service.get_automation_execution_metrics("3", sort_by="created_at")
 
-    _, variables = executor.execute_query_allow_partial.call_args[0]
+    _, variables = executor.execute.call_args[0]
     assert variables["sort"] == {"by": "created_at"}

--- a/packages/sdk/tests/services/test_graphql_endpoint.py
+++ b/packages/sdk/tests/services/test_graphql_endpoint.py
@@ -5,6 +5,7 @@ import httpx
 import pytest
 from gql import gql
 from gql.graphql_request import GraphQLRequest
+from gql.transport.exceptions import TransportQueryError
 from gql.transport.httpx import HTTPXAsyncTransport
 from pipefy_auth import StaticBearerAuth
 
@@ -108,7 +109,7 @@ async def test_execute_passes_variables_to_session():
     request = mock_session.execute.call_args[0][0]
     assert isinstance(request, GraphQLRequest)
     assert request.variable_values == variables
-    assert result == {"ok": True}
+    assert result.data == {"ok": True}
     assert mock_client_cls.call_args.kwargs["fetch_schema_from_transport"] is False
     assert "schema" not in mock_client_cls.call_args.kwargs
 
@@ -158,8 +159,10 @@ async def test_execute_reuse_fetches_once_then_passes_cached_schema():
         mock_client_cls.side_effect = [first, second]
 
         endpoint = GraphQLEndpoint(url=GRAPHQL_URL, cache_schema=True)
-        assert await endpoint.execute(query, variables, auth=_bearer()) == {"one": 1}
-        assert await endpoint.execute(query, variables, auth=_bearer()) == {"two": 2}
+        first_result = await endpoint.execute(query, variables, auth=_bearer())
+        second_result = await endpoint.execute(query, variables, auth=_bearer())
+        assert first_result.data == {"one": 1}
+        assert second_result.data == {"two": 2}
 
     assert mock_client_cls.call_count == 2
     assert (
@@ -196,8 +199,8 @@ async def test_execute_bubbles_up_execute_errors_unchanged():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_execute_query_allow_partial_returns_data_and_errors_together():
-    """A response mixing data and per-node errors becomes a PartialQueryResult."""
+async def test_execute_returns_data_and_errors_together():
+    """A response mixing data and per-node errors becomes a GraphQLResult."""
     partial_body = {
         "data": {"automations": {"edges": [{"node": {"id": "25"}}]}},
         "errors": [
@@ -213,9 +216,7 @@ async def test_execute_query_allow_partial_returns_data_and_errors_together():
 
     with _patched_transport(handler):
         endpoint = GraphQLEndpoint(url=GRAPHQL_URL)
-        result = await endpoint.execute_allow_partial(
-            _sample_query(), {}, auth=_bearer()
-        )
+        result = await endpoint.execute(_sample_query(), {}, auth=_bearer())
 
     assert result.data == {"automations": {"edges": [{"node": {"id": "25"}}]}}
     assert result.errors[0]["extensions"]["automation_id"] == "124"
@@ -223,17 +224,15 @@ async def test_execute_query_allow_partial_returns_data_and_errors_together():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_execute_query_allow_partial_success_carries_no_errors():
-    """An error-free response yields a PartialQueryResult with an empty error list."""
+async def test_execute_success_carries_no_errors():
+    """An error-free response yields a GraphQLResult with an empty error list."""
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"data": {"automations": {"edges": []}}})
 
     with _patched_transport(handler):
         endpoint = GraphQLEndpoint(url=GRAPHQL_URL)
-        result = await endpoint.execute_allow_partial(
-            _sample_query(), {}, auth=_bearer()
-        )
+        result = await endpoint.execute(_sample_query(), {}, auth=_bearer())
 
     assert result.data == {"automations": {"edges": []}}
     assert result.errors == []
@@ -241,7 +240,7 @@ async def test_execute_query_allow_partial_success_carries_no_errors():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_execute_query_allow_partial_null_data_yields_empty_result():
+async def test_execute_null_data_yields_empty_result():
     """A fully null response yields empty data with errors kept; classifying it is the caller's job."""
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -255,12 +254,74 @@ async def test_execute_query_allow_partial_null_data_yields_empty_result():
 
     with _patched_transport(handler):
         endpoint = GraphQLEndpoint(url=GRAPHQL_URL)
-        result = await endpoint.execute_allow_partial(
-            _sample_query(), {}, auth=_bearer()
-        )
+        result = await endpoint.execute(_sample_query(), {}, auth=_bearer())
 
     assert result.data == {}
     assert result.errors[0]["message"] == "Couldn't find Organization with 'id'=999"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_query_returns_data_on_success():
+    """The raise-on-error convenience unwraps a clean response to its ``data`` dict."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": {"__typename": "Query"}})
+
+    with _patched_transport(handler):
+        endpoint = GraphQLEndpoint(url=GRAPHQL_URL)
+        result = await endpoint.execute_query(_sample_query(), {}, auth=_bearer())
+
+    assert result == {"__typename": "Query"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_query_raises_transport_query_error_with_structured_errors():
+    """Without an error formatter, ``execute_query`` raises a ``TransportQueryError``
+    that still carries the structured ``errors`` list the tool layer reads."""
+    error_body = {
+        "data": {"automations": {"edges": [{"node": {"id": "25"}}]}},
+        "errors": [
+            {
+                "message": "Permission denied",
+                "extensions": {"code": "PERMISSION_DENIED", "automation_id": "124"},
+            }
+        ],
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=error_body)
+
+    with _patched_transport(handler):
+        endpoint = GraphQLEndpoint(url=GRAPHQL_URL)
+        with pytest.raises(TransportQueryError) as excinfo:
+            await endpoint.execute_query(_sample_query(), {}, auth=_bearer())
+
+    assert excinfo.value.errors[0]["message"] == "Permission denied"
+    assert excinfo.value.errors[0]["extensions"]["code"] == "PERMISSION_DENIED"
+    # The tool layer's correlation-id and part of its code extraction regex only
+    # str(exc), so pin that the reconstructed message still carries the code.
+    assert "PERMISSION_DENIED" in str(excinfo.value)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_query_applies_error_formatter_when_configured():
+    """With an error formatter, ``execute_query`` raises the formatter's message as a ValueError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"errors": [{"message": "boom", "extensions": {"code": "X"}}]}
+        )
+
+    with _patched_transport(handler):
+        endpoint = GraphQLEndpoint(
+            url=GRAPHQL_URL,
+            on_graphql_error=lambda errs: "; ".join(e["message"] for e in errs),
+        )
+        with pytest.raises(ValueError, match=r"^boom$"):
+            await endpoint.execute_query(_sample_query(), {}, auth=_bearer())
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/test_graphql_endpoint.py
+++ b/packages/sdk/tests/services/test_graphql_endpoint.py
@@ -325,6 +325,33 @@ async def test_execute_query_applies_error_formatter_when_configured():
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_ignores_error_formatter_when_configured():
+    """The primitive never applies ``on_graphql_error``; that policy is ``execute_query``'s.
+
+    On a formatter-configured endpoint, ``execute`` still returns a ``GraphQLResult``
+    carrying the raw errors rather than raising the formatter's ``ValueError``. This
+    pins the one semantic that separates the primitive from the convenience layer.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"errors": [{"message": "boom", "extensions": {"code": "X"}}]}
+        )
+
+    with _patched_transport(handler):
+        endpoint = GraphQLEndpoint(
+            url=GRAPHQL_URL,
+            on_graphql_error=lambda errs: "; ".join(e["message"] for e in errs),
+        )
+        result = await endpoint.execute(_sample_query(), {}, auth=_bearer())
+
+    assert result.data == {}
+    assert result.errors[0]["message"] == "boom"
+    assert result.errors[0]["extensions"]["code"] == "X"
+
+
+@pytest.mark.unit
 def test_init_connects_to_given_url():
     """The endpoint connects to exactly the URL it is handed, no derivation."""
     url = "https://api.pipefy.com/graphql/interfaces"

--- a/packages/sdk/tests/services/test_pipefy_facade.py
+++ b/packages/sdk/tests/services/test_pipefy_facade.py
@@ -5,6 +5,7 @@ from pipefy_auth import StaticBearerAuth
 
 from pipefy_sdk import __version__
 from pipefy_sdk.client import PipefyClient, build_executors
+from pipefy_sdk.graphql_executor import GraphQLResult
 from pipefy_sdk.services.ai_agent_service import AiAgentService
 from pipefy_sdk.services.attachment_service import AttachmentService
 from pipefy_sdk.services.automation_service import AutomationService
@@ -790,7 +791,9 @@ async def test_delete_card_relation_delegates_to_internal_api_client(mock_settin
     # delegates to its shared endpoint; swap that endpoint's network seam.
     internal = client._internal_executor
     internal.endpoint.execute = AsyncMock(
-        return_value={"deleteCardRelation": {"success": True}}
+        return_value=GraphQLResult(
+            data={"deleteCardRelation": {"success": True}}, errors=[]
+        )
     )
 
     # Pin the snake_case input keys that the Internal API expects
@@ -818,7 +821,9 @@ async def test_sub_portal_mutation_routes_through_internal_api_client(mock_setti
     # PortalService and the facade share the one internal executor and its endpoint.
     internal = client._internal_executor
     internal.endpoint.execute = AsyncMock(
-        return_value={"updateSubPortalElement": {"success": True}}
+        return_value=GraphQLResult(
+            data={"updateSubPortalElement": {"success": True}}, errors=[]
+        )
     )
 
     result = await client.publish_sub_portal("portal-1", "element-2", "sub-3")


### PR DESCRIPTION
## What

Rung 2 of #354: collapse the GraphQL execution seam to one protocol and one result type.

Before, partial-success handling was modelled as a second transport capability: a `PartialGraphQLExecutor` protocol (extending `GraphQLExecutor`) added an `execute_query_allow_partial` verb returning a partial-specific `PartialQueryResult`. Any query that needed partial handling had to widen its service to the fatter protocol and reach for the second verb.

This makes partial handling the default shape of one primitive:

- `PartialQueryResult` becomes `GraphQLResult`; `PartialGraphQLExecutor` is deleted.
- `GraphQLExecutor` exposes `execute` (the primitive that returns `data` and `errors` together and decides nothing about what the errors mean) and `execute_query` (the raise-on-error convenience the query/mutation tools use, reimplemented as a thin wrapper over `execute`). Genuine transport/network failures still raise.
- `ObservabilityService` depends on the one protocol, calls `execute`, and hands the errors to its own pure classifier (`_normalize_execution_metrics_result`), unchanged from a caller's view.

## Behavior preservation

- The ~152 `execute_query` callers are unchanged. On GraphQL errors, formatter-less endpoints (public, interfaces) re-raise a `TransportQueryError` carrying the structured `errors` the MCP tool layer reads; the message is byte-identical to gql's (`str(errors[0])`).
- `_on_graphql_error` is preserved: the internal endpoint's `execute_query` still raises a `ValueError` with the `[code=...] [correlation_id=...]` envelope.

## Acceptance criteria (from #354)

- [x] one execution protocol; `PartialGraphQLExecutor` removed
- [x] one primitive returning data + errors; `execute_query` reimplemented over it, external behavior unchanged
- [x] `_on_graphql_error` behavior preserved for the Internal API endpoint
- [x] observability partial-success path unchanged from a caller's view; full SDK + MCP suites green

## Testing

- Full suite green: `uv run pytest packages -m "not integration"` -> 3067 passed, 5 skipped. Ruff clean.
- Added an endpoint-level test that `execute_query` on a formatter-less endpoint raises a `TransportQueryError` carrying structured `.errors` (and that `str(exc)` still carries the code the tool layer's regex reads).
- E2E against a live org exercised all four paths: `execute_query` happy path, the `execute` primitive plus the observability classifier (real automations + pagination), the `execute_query` error path (reconstructed `TransportQueryError` with `PERMISSION_DENIED` intact), and the classifier's null-connection `ValueError`.

## Follow-up

Rung 3 (separate PR, also tracked under #354) relocates error policy out of the transport seam: the protocol shrinks to the single `execute` method, an owned `PipefyGraphQLError` carries the structured errors, and the `[code=...]` string envelope plus its parsers are deleted.
