### PR TITLE
docs: sync MCP tool docs, counts, and skill cross-refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Tool descriptions and `Args:` blocks come from Python docstrings (what MCP clien
 | **Relations** | 8 | Pipe and card relations. | [docs](docs/mcp/tools/relations.md) |
 | **Reports** | 17 | Pipe and organization reports, async exports. | [docs](docs/mcp/tools/reports.md) |
 | **Automations & AI** | 23 | Automations, AI automations, AI agents, validators. | [docs](docs/mcp/tools/automations-and-ai.md) |
-| **Observability** | 10 | Logs, usage, credits, job exports. | [docs](docs/mcp/tools/observability.md) |
+| **Observability** | 11 | Logs, usage, credits, execution metrics, job exports. | [docs](docs/mcp/tools/observability.md) |
 | **Members, email & webhooks** | 11 | Membership, inbox email, webhooks. | [docs](docs/mcp/tools/members-email-webhooks.md) |
 | **Organization** | 1 | Organization metadata. | [docs](docs/mcp/tools/organization.md) |
 | **Portals** | 20 | Portal read/CRUD, pages, elements, sub-portals (publish/unpublish). | [docs](docs/mcp/tools/portal.md) |

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -6,7 +6,17 @@ Material in this tree describes **`pipefy-mcp-server`**: the MCP process, tool b
 
 | Path | Description |
 |------|-------------|
-| [`tools/`](tools/cross-cutting.md) | Per-domain MCP tool reference (parameters, edge cases, cross-cutting behavior) |
+| [`tools/cross-cutting.md`](tools/cross-cutting.md) | Shared conventions: pagination, IDs, `debug`, destructive deletes, permissions, errors |
+| [`tools/pipes-and-cards.md`](tools/pipes-and-cards.md) | Pipes, phases, fields, labels, cards, field conditions, card attachments |
+| [`tools/database-tables.md`](tools/database-tables.md) | Tables, records, table fields, table-record attachments |
+| [`tools/relations.md`](tools/relations.md) | Pipe and card relations |
+| [`tools/reports.md`](tools/reports.md) | Pipe and organization reports, async exports |
+| [`tools/automations-and-ai.md`](tools/automations-and-ai.md) | Traditional automations, AI automations, AI agents, validators |
+| [`tools/observability.md`](tools/observability.md) | Logs, usage, credits, execution metrics, job exports |
+| [`tools/members-email-webhooks.md`](tools/members-email-webhooks.md) | Membership, inbox email, webhooks |
+| [`tools/organization.md`](tools/organization.md) | Organization metadata |
+| [`tools/portal.md`](tools/portal.md) | Portals, pages, elements, sub-portals |
+| [`tools/introspection.md`](tools/introspection.md) | Schema discovery and raw GraphQL |
 
 Start with [`tools/cross-cutting.md`](tools/cross-cutting.md) for pagination, IDs, `debug`, permissions, and error shape — then open the domain guide you need.
 

--- a/docs/mcp/tools/cross-cutting.md
+++ b/docs/mcp/tools/cross-cutting.md
@@ -1,6 +1,6 @@
 # Cross-cutting tool behavior
 
-Conventions shared across many MCP tools. Per-area details (parameters, edge cases) stay in the guides linked from the [main README](../../../README.md#mcp-tools).
+Conventions shared across many MCP tools. Per-area details (parameters, edge cases) stay in the guides linked from the [main README](../../../README.md#mcp-server).
 
 ## Pagination
 
@@ -36,7 +36,7 @@ Pipefy often returns **`PERMISSION_DENIED`** for `card(id: …)` when the card w
 
 ## Pre-flight validation for AI features
 
-Before creating/updating AI automations or AI agents, call [`validate_ai_automation_prompt`](automations-and-ai.md#ai-automations) and [`validate_ai_agent_behaviors`](automations-and-ai.md#ai-agent-read--delete) to catch prompt, field, and event errors and membership gaps without round-tripping the write mutation.
+Before creating/updating AI automations or AI agents, call [`validate_ai_automation_prompt`](automations-and-ai.md#ai-automations) and [`validate_ai_agent_behaviors`](automations-and-ai.md#ai-agent-read-delete) to catch prompt, field, and event errors and membership gaps without round-tripping the write mutation.
 
 ## Introspection
 

--- a/docs/mcp/tools/database-tables.md
+++ b/docs/mcp/tools/database-tables.md
@@ -12,7 +12,7 @@ Tables, records (rows), and schema columns (table fields) for org Database Table
 
 | Domain | Tools | Notes |
 |--------|-------|-------|
-| **Read** | `get_table`, `get_tables`, `get_table_records`, `get_table_record`, `find_records` | |
+| **Read** | `search_tables`, `get_table`, `get_tables`, `get_table_records`, `get_table_record`, `find_records` | |
 | **Table CRUD** | `create_table`, `update_table`, `delete_table` | `delete_table` uses preview + `confirm=true` (like `delete_pipe`). |
 | **Record CRUD** | `create_table_record`, `update_table_record`, `delete_table_record`, `set_table_record_field_value`, `upload_attachment_to_table_record` | `upload_attachment_to_table_record` runs presigned URL + S3 PUT + `setTableRecordFieldValue` for attachment columns. **One file per call**: to attach multiple files, call the tool once per file. Same inputs as card upload: `file_path` is the local filesystem path the MCP server reads (supports `~` expansion); `file_name` is inferred from the path's basename when omitted. Files larger than **100 MiB** are rejected locally before any network call. **`field_id` must be the field slug**, not the uuid. |
 | **Field CRUD** | `create_table_field`, `update_table_field`, `delete_table_field` | Schema columns; `delete_table_field` is destructive (confirm with the user). |

--- a/docs/mcp/tools/observability.md
+++ b/docs/mcp/tools/observability.md
@@ -1,6 +1,6 @@
 # Observability
 
-Monitor AI agent and automation execution, usage stats, credit consumption, and export job history. **10 tools.**
+Monitor AI agent and automation execution, usage stats, credit consumption, and export job history. **11 tools.**
 
 Read-only observability tools use `readOnlyHint=True`. The async export mutation (`export_automation_jobs`) does not.
 
@@ -15,6 +15,7 @@ Read-only observability tools use `readOnlyHint=True`. The async export mutation
 | **Single automation logs** | `automation_id` — **not** the pipe id | `get_automations` with `pipe_id` lists rules and their `id` values. |
 | **Organization for usage queries** | `organization_uuid` — org **UUID** | `get_organization(organization_id)` returns the `uuid` directly. Alternatively: `execute_graphql` with `pipe(id: $id) { organization { uuid } }`. |
 | **Organization for credit dashboard** | `organization_uuid` in the tool | **UUID** or **numeric org id** (string); numeric ids are resolved server-side before calling the API. |
+| **Organization for execution metrics** | `organization_id` on `get_automation_execution_metrics` | Numeric org id (same as URLs / exports); optional `automation_ids` from `get_automations`. |
 | **Organization for export** | `organization_id` on `export_automation_jobs` | Numeric org id (as used in URLs / exports); differs from the usage tools’ UUID parameter name. |
 
 Empty lists (`totalCount: 0`) are valid: the pipe or automation may have no recent executions in what the API returns.
@@ -38,6 +39,12 @@ Empty lists (`totalCount: 0`) are valid: the pipe or automation may have no rece
 1. `get_agents_usage` and `get_automations_usage` need the org **UUID** and ISO8601 `filter_date_from` / `filter_date_to` values.  
 2. `get_ai_credit_usage` accepts org UUID **or** numeric org id; `period` is `current_month`, `last_month`, or `last_3_months`.  
 3. **`get_automations_usage` `usage`** is an **execution count** (runs), not AI credits. **`get_agents_usage` `usage`** aligns with AI credit consumption for agents — compare with `get_ai_credit_usage` for the dashboard view, not with automation run totals.
+
+**Per-automation execution metrics (rolling window)**  
+1. Call `get_automation_execution_metrics(organization_id=…)` with the numeric org id. Omit `automation_ids` to fetch every automation in the org (optionally narrowed by `repo_id`, `action_ids`, `event_id`, `active`, `search`).  
+2. `period` is one of `FIFTEEN_MINUTES`, `SIXTY_MINUTES` (default), `TWELVE_HOURS`, `TWENTY_FOUR_HOURS`.  
+3. A page holds at most 50 automations; pass `page_info.endCursor` back as `after` for the next page.  
+4. Partial success is normal: metrics for permitted automations plus `partial_errors` for denied ids — not a hard failure.
 
 **Automation jobs export (async file)**  
 1. `export_automation_jobs(organization_id, period)` → read `result.createAutomationJobsExport.automationJobsExport.id`.  
@@ -68,6 +75,7 @@ Empty lists (`totalCount: 0`) are valid: the pipe or automation may have no rece
 | `get_agents_usage` | Yes | AI agent usage stats for an org within a date range. `filter_date_from` / `filter_date_to` (ISO8601). Optional `filters`, `search`, `sort`. Returns total **AI credits** consumed and per-agent breakdown. Requires org **UUID** (see Identifiers). |
 | `get_automations_usage` | Yes | Automation usage stats for an org. Same date-range and filter inputs as `get_agents_usage`. Returns total **execution count** and per-automation breakdown (not the same unit as AI credits). Requires org **UUID**. |
 | `get_ai_credit_usage` | Yes | AI credit dashboard for an org: credit limit, total consumption, per-resource breakdown (AI Agents vs Assistants), addon status. `organization_uuid` may be the org UUID or the **numeric organization id** (string). `period`: `current_month`, `last_month`, or `last_3_months`. |
+| `get_automation_execution_metrics` | Yes | Per-automation rolling-window metrics (`totalRuns`, `successRate`, `failureRate`, `averageDuration`, `lastRun`). Uses numeric `organization_id`; optional `automation_ids` / filters / sort; paginated (`first` ≤ 50, `after`). Partial success returns `partial_errors` for denied ids. |
 
 ## Automation export tools
 

--- a/docs/mcp/tools/pipes-and-cards.md
+++ b/docs/mcp/tools/pipes-and-cards.md
@@ -1,6 +1,6 @@
 # Pipes & Cards
 
-Read, create, update, and delete pipes, phases, phase fields, labels, cards, and field conditions. **37 tools.** (Card-to-card relation tools `get_card_relations` / `delete_card_relation` / `create_card_relation` are documented in [Connections & Relations](relations.md).)
+Read, create, update, and delete pipes, phases, phase fields, labels, cards, and field conditions. **40 tools.** (Card-to-card relation tools `get_card_relations` / `delete_card_relation` / `create_card_relation` are documented in [Connections & Relations](relations.md).)
 
 ## Cross-cutting patterns
 

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -190,6 +190,6 @@ for n in m.body:
             print(len(v.args[0].elts))"
 ```
 
-Expect **152** tool names in `PIPEFY_TOOL_NAMES` and **152** data rows in the parity table (excluding the header rows).
+Expect **153** tool names in `PIPEFY_TOOL_NAMES` and **153** data rows in the parity table (excluding the header rows).
 
 When adding or removing an MCP tool, update **this file** and `PIPEFY_TOOL_NAMES` in the same change set.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # pipefy-mcp-server
 
-MCP server for Pipefy — **152 tools** for AI agents (Cursor, Claude Desktop, Claude Code, Codex, and any MCP-compatible client). Depends on [`pipefy`](../sdk/README.md) for all GraphQL and API logic.
+MCP server for Pipefy — **153 tools** for AI agents (Cursor, Claude Desktop, Claude Code, Codex, and any MCP-compatible client). Depends on [`pipefy`](../sdk/README.md) for all GraphQL and API logic.
 
 ## Install
 
@@ -104,7 +104,7 @@ This form also works as a per-project `.mcp.json` if your team shares a clone. C
 
 ## Tools
 
-**152 tools** across ten domains (including **Portals**) — see the root [`README.md`](../../README.md#mcp-server) for the full table with per-area links. Deep reference: [`docs/mcp/tools/`](../../docs/mcp/tools/cross-cutting.md) (start with [`cross-cutting.md`](../../docs/mcp/tools/cross-cutting.md)); portals: [`portal.md`](../../docs/mcp/tools/portal.md).
+**153 tools** across ten domains (including **Portals**) — see the root [`README.md`](../../README.md#mcp-server) for the full table with per-area links. Deep reference: [`docs/mcp/tools/`](../../docs/mcp/tools/cross-cutting.md) (start with [`cross-cutting.md`](../../docs/mcp/tools/cross-cutting.md)); portals: [`portal.md`](../../docs/mcp/tools/portal.md).
 
 ## Development
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -34,7 +34,7 @@ git clone https://github.com/pipefy/ai-toolkit.git
 | **Reports** | [pipefy-reports](reports/pipefy-reports/SKILL.md) | Pipe and organization reports, async exports. 17 MCP tools. |
 | **Automations** | [pipefy-automations](automations/pipefy-automations/SKILL.md) | Traditional and AI automations, simulation. 15 MCP tools. |
 | **AI Agents** | [pipefy-ai-agents](ai-agents/pipefy-ai-agents/SKILL.md) | Conversational AI agents and behaviors. 7 MCP tools. |
-| **Observability** | [pipefy-observability](observability/pipefy-observability/SKILL.md) | Logs, usage, credits, job exports. 10 MCP tools. |
+| **Observability** | [pipefy-observability](observability/pipefy-observability/SKILL.md) | Logs, usage, credits, execution metrics, job exports. 11 MCP tools. |
 | **Members, Email & Webhooks** | [pipefy-members-email-webhooks](members-email-webhooks/pipefy-members-email-webhooks/SKILL.md) | Membership, email, webhooks. 11 MCP tools. |
 | **Portal setup** | [pipefy-portal-setup](portal-setup/pipefy-portal-setup/SKILL.md) | Main portal, pages, elements, sub-portals (publish/unpublish). 20 MCP tools. |
 | **Introspection** | [pipefy-introspection](introspection/pipefy-introspection/SKILL.md) | Schema discovery and GraphQL fallback. 6 MCP tools. |

--- a/skills/README.md
+++ b/skills/README.md
@@ -32,7 +32,7 @@ git clone https://github.com/pipefy/ai-toolkit.git
 | **Database Tables** | [pipefy-database-tables](database-tables/pipefy-database-tables/SKILL.md) | Tables, records, schema, attachments. 17 MCP tools. |
 | **Relations** | [pipefy-relations](relations/pipefy-relations/SKILL.md) | Pipe and card relations. 8 MCP tools. |
 | **Reports** | [pipefy-reports](reports/pipefy-reports/SKILL.md) | Pipe and organization reports, async exports. 17 MCP tools. |
-| **Automations** | [pipefy-automations](automations/pipefy-automations/SKILL.md) | Traditional and AI automations, simulation. 15 MCP tools. |
+| **Automations** | [pipefy-automations](automations/pipefy-automations/SKILL.md) | Traditional and AI automations, simulation. 16 MCP tools. |
 | **AI Agents** | [pipefy-ai-agents](ai-agents/pipefy-ai-agents/SKILL.md) | Conversational AI agents and behaviors. 7 MCP tools. |
 | **Observability** | [pipefy-observability](observability/pipefy-observability/SKILL.md) | Logs, usage, credits, execution metrics, job exports. 11 MCP tools. |
 | **Members, Email & Webhooks** | [pipefy-members-email-webhooks](members-email-webhooks/pipefy-members-email-webhooks/SKILL.md) | Membership, email, webhooks. 11 MCP tools. |

--- a/skills/automations/pipefy-automations/SKILL.md
+++ b/skills/automations/pipefy-automations/SKILL.md
@@ -25,16 +25,12 @@ For AI agents (conversational agents with behaviors), see [skills/ai-agents/pipe
 | `update_automation` | `pipefy automation update` | Patch a rule via `extra_input` (`UpdateAutomationInput` fields). |
 | `delete_automation` | `pipefy automation delete` | **(Two-step destructive)** |
 | `simulate_automation` | `pipefy automation simulate` | **AI-only** dry-run (`generate_with_ai` action). |
-| `get_automation_logs` | `pipefy automation logs` | Execution history for one automation. |
-| `get_automation_logs_by_repo` | `pipefy automation logs --repo` | Logs across all automations in a pipe. |
 | `get_automation_events` | `pipefy automation events list` | Available trigger events. |
 | `get_automation_event_attributes` | `pipefy automation event-attributes` | Official `field_map.value` event-attribute tokens. |
 | `get_automation_actions` | `pipefy automation actions list` | Available action types for a pipe. |
 | `create_send_task_automation` | `pipefy automation send-task create` | Shortcut for send-a-task rules. |
-| `get_automations_usage` | `pipefy automation usage` / `pipefy usage automations` | Org usage stats (execution counts). |
-| `export_automation_jobs` | `pipefy automation export jobs` / `pipefy export automation-jobs` | Start async jobs export. |
-| `get_automation_jobs_export` | `pipefy automation export status` | Poll export status / URL. |
-| `get_automation_jobs_export_csv` | `pipefy automation export csv` / `pipefy export automation-jobs-csv` | Fetch CSV text when export is finished. |
+
+Logs, usage, and job exports for automations live in [skills/observability/pipefy-observability/SKILL.md](../../observability/pipefy-observability/SKILL.md) (`get_automation_logs`, `get_automation_logs_by_repo`, `get_automations_usage`, `export_automation_jobs`, and related tools).
 
 ---
 

--- a/skills/database-tables/pipefy-database-tables/SKILL.md
+++ b/skills/database-tables/pipefy-database-tables/SKILL.md
@@ -122,5 +122,5 @@ Never delete in a single call.
 
 ## See also
 
-- [skills/relations/pipefy-relations/SKILL.md](skills/relations/pipefy-relations/SKILL.md) — connect tables to pipes (and the table-relation ID namespace gotcha).
-- [skills/introspection/pipefy-introspection/SKILL.md](skills/introspection/pipefy-introspection/SKILL.md) — discover field input schemas.
+- [skills/relations/pipefy-relations/SKILL.md](../../relations/pipefy-relations/SKILL.md) — connect tables to pipes (and the table-relation ID namespace gotcha).
+- [skills/introspection/pipefy-introspection/SKILL.md](../../introspection/pipefy-introspection/SKILL.md) — discover field input schemas.

--- a/skills/members-email-webhooks/pipefy-members-email-webhooks/SKILL.md
+++ b/skills/members-email-webhooks/pipefy-members-email-webhooks/SKILL.md
@@ -16,10 +16,11 @@ Manage pipe membership, send emails from card inboxes, read inbox replies, and m
 
 | Tool (MCP) | CLI | Read-only | Purpose |
 |------------|-----|-----------|---------|
-| `get_pipe_members` | `pipefy member list --pipe <id>` | Yes | List all members of a pipe. |
 | `invite_members` | `pipefy member invite` | No | Invite one or more users by email + role. |
 | `remove_member_from_pipe` | `pipefy member remove` | No | **Two-step destructive.** Warns on external emails. |
 | `set_role` | `pipefy member set-role` | No | Change a member's pipe role. |
+
+List existing members with `get_pipe_members` from [skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md](../../pipes-and-cards/pipefy-pipes-and-cards/SKILL.md).
 
 ### Steps — invite members
 

--- a/skills/observability/pipefy-observability/SKILL.md
+++ b/skills/observability/pipefy-observability/SKILL.md
@@ -11,8 +11,6 @@ tags: [pipefy, observability, logs, usage, credits, exports]
 
 Monitor AI agent and automation execution, usage stats, credit consumption, and export job history. **11 MCP tools.**
 
-**CLI status (v0.1):** use MCP tools below. Observability Typer commands are planned for v0.3+.
-
 ---
 
 ## Identifiers reference
@@ -29,17 +27,17 @@ Monitor AI agent and automation execution, usage stats, credit consumption, and 
 
 | Tool (MCP) | CLI | Read-only | Purpose |
 |------------|-----|-----------|---------|
-| `get_ai_agent_logs` | — (CLI v0.3+) | Yes | Execution history for a specific AI agent. |
-| `get_ai_agent_log_details` | — (CLI v0.3+) | Yes | Single execution detail for an AI agent log entry. |
-| `get_automation_logs` | — (CLI v0.3+) | Yes | Execution history for an automation (by automation ID or pipe). |
-| `get_automation_logs_by_repo` | — (CLI v0.3+) | Yes | Automation logs filtered by pipe UUID. |
-| `get_agents_usage` | — (CLI v0.3+) | Yes | Org-level AI agent execution count and trends. |
-| `get_automations_usage` | — (CLI v0.3+) | Yes | Org-level automation execution stats. |
+| `get_ai_agent_logs` | `pipefy agent logs list` | Yes | Execution history for a specific AI agent. |
+| `get_ai_agent_log_details` | `pipefy agent logs get` | Yes | Single execution detail for an AI agent log entry. |
+| `get_automation_logs` | `pipefy automation logs --automation` | Yes | Execution history for an automation (by automation ID). |
+| `get_automation_logs_by_repo` | `pipefy automation logs --repo` | Yes | Automation logs filtered by pipe. |
+| `get_agents_usage` | `pipefy usage agents` | Yes | Org-level AI agent execution count and trends. |
+| `get_automations_usage` | `pipefy usage automations` | Yes | Org-level automation execution stats. |
 | `get_automation_execution_metrics` | `pipefy usage execution-metrics` | Yes | Per-automation execution metrics (totalRuns, success/failure rate, avg duration, lastRun) over a rolling window; partial success returns `partial_errors` for denied ids. |
-| `get_ai_credit_usage` | — (CLI v0.3+) | Yes | AI credit consumption and remaining balance. |
-| `export_automation_jobs` | — (CLI v0.3+) | Yes | Trigger async export of automation job history. |
-| `get_automation_jobs_export` | — (CLI v0.3+) | Yes | Poll export job status (after `export_automation_jobs`). |
-| `get_automation_jobs_export_csv` | — (CLI v0.3+) | Yes | Download finished automation-jobs export as CSV text. |
+| `get_ai_credit_usage` | `pipefy usage credits` | Yes | AI credit consumption and remaining balance. |
+| `export_automation_jobs` | `pipefy export automation-jobs` | Yes | Trigger async export of automation job history. |
+| `get_automation_jobs_export` | `pipefy automation export status` | Yes | Poll export job status (after `export_automation_jobs`). |
+| `get_automation_jobs_export_csv` | `pipefy export automation-jobs-csv` | Yes | Download finished automation-jobs export as CSV text. |
 
 ---
 

--- a/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
+++ b/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
@@ -32,6 +32,7 @@ Read, create, update, and delete pipes, phases, phase fields, labels, cards, att
 | `update_pipe` | `pipefy pipe update <id>` | No | Rename or change pipe settings. |
 | `delete_pipe` | `pipefy pipe delete <id>` | No | **Two-step destructive.** |
 | `clone_pipe` | `pipefy pipe clone <id>` | No | Clone an existing pipe. |
+| `get_pipe_members` | `pipefy member list --pipe <id>` | Yes | List members of a pipe. |
 
 ### Steps — create a pipe with phases
 
@@ -152,9 +153,13 @@ This returns valid `type` enum values and their descriptions.
 | `create_card` | `pipefy card create <pipe_id>` | No | Default: start form. Optional `--phase-id` / `phase_id` creates in that phase; interactive clients may elicit start-form fields unless `skip_elicitation=true`. |
 | `fill_card_phase_fields` | `pipefy card fill <id> --phase <id>` | No | Fill phase fields non-interactively; filters to editable IDs. Uses `--fields` JSON object; for ad-hoc updates use `card update --field-updates` (JSON array). |
 | `update_card` | `pipefy card update <id>` | No | Update title, assignee, due date, fields. |
+| `update_card_field` | `pipefy card update <id> --field-updates` | No | Single-field update (`updateCardField`); for several fields prefer `update_card` + `field_updates`. |
 | `move_card_to_phase` | `pipefy card move <id> --phase <id>` | No | Call `get_phase_allowed_move_targets` on the source phase first. |
 | `delete_card` | `pipefy card delete <id>` | No | **Two-step destructive.** |
 | `add_card_comment` | `pipefy card comment add <id>` | No | Add a text comment to a card. |
+| `update_comment` | `pipefy card comment update` | No | Update an existing card comment. |
+| `delete_comment` | `pipefy card comment delete` | No | **Two-step destructive.** |
+| `upload_attachment_to_card` | `pipefy attachment upload --card` | No | Upload a local file to an attachment field (`field_id` must be the field slug). |
 
 ### Steps — create a card
 
@@ -203,10 +208,11 @@ Read `pageInfo.hasNextPage` and `pageInfo.endCursor` from the response; pass `af
 
 | Tool (MCP) | CLI | Purpose |
 |------------|-----|---------|
-| `get_field_conditions` | — | List all field conditions on a phase. |
-| `create_field_condition` | — | Create show/hide rule. |
-| `update_field_condition` | — | Update condition action or rule. |
-| `delete_field_condition` | — | **Two-step destructive.** |
+| `get_field_conditions` | `pipefy field-condition list --phase <id>` | List all field conditions on a phase. |
+| `get_field_condition` | `pipefy field-condition get` | Load one field condition by ID. |
+| `create_field_condition` | `pipefy field-condition create` | Create show/hide rule. |
+| `update_field_condition` | `pipefy field-condition update` | Update condition action or rule. |
+| `delete_field_condition` | `pipefy field-condition delete` | **Two-step destructive.** |
 
 ---
 

--- a/skills/reports/pipefy-reports/SKILL.md
+++ b/skills/reports/pipefy-reports/SKILL.md
@@ -11,8 +11,6 @@ tags: [pipefy, reports, exports, pipe-reports, organization-reports]
 
 Pipe reports and organization reports: discovery, CRUD, and async exports. **17 MCP tools.**
 
-**CLI status (v0.1):** use MCP tools below. Report-specific Typer commands are planned for v0.3+.
-
 ---
 
 ## Cross-cutting patterns
@@ -27,33 +25,33 @@ Pipe reports and organization reports: discovery, CRUD, and async exports. **17 
 
 | Tool (MCP) | CLI | Read-only | Purpose |
 |------------|-----|-----------|---------|
-| `get_pipe_reports` | — (CLI v0.3+) | Yes | List all reports for a pipe. |
-| `get_pipe_report` | — (CLI v0.3+) | Yes | Single report data. |
-| `get_pipe_report_columns` | — (CLI v0.3+) | Yes | Discover available columns for a report filter. |
-| `get_pipe_report_filterable_fields` | — (CLI v0.3+) | Yes | Discover filterable fields for a report. |
-| `create_pipe_report` | — (CLI v0.3+) | No | Create a new pipe report. |
-| `update_pipe_report` | — (CLI v0.3+) | No | Update report name or filters. |
-| `delete_pipe_report` | — (CLI v0.3+) | No | **Two-step destructive.** |
-| `export_pipe_report` | — (CLI v0.3+) | No | Trigger async export. |
+| `get_pipe_reports` | `pipefy report-pipe list` | Yes | List all reports for a pipe. |
+| `get_pipe_report` | `pipefy report-pipe get` | Yes | Single report data. |
+| `get_pipe_report_columns` | `pipefy report-pipe columns` | Yes | Discover available columns for a report filter. |
+| `get_pipe_report_filterable_fields` | `pipefy report-pipe filterable-fields` | Yes | Discover filterable fields for a report. |
+| `create_pipe_report` | `pipefy report-pipe create` | No | Create a new pipe report. |
+| `update_pipe_report` | `pipefy report-pipe update` | No | Update report name or filters. |
+| `delete_pipe_report` | `pipefy report-pipe delete` | No | **Two-step destructive.** |
+| `export_pipe_report` | `pipefy report-pipe export` | No | Trigger async export. |
 
 ## Organization report tools
 
 | Tool (MCP) | CLI | Read-only | Purpose |
 |------------|-----|-----------|---------|
-| `get_organization_reports` | — (CLI v0.3+) | Yes | List all org-level reports. |
-| `get_organization_report` | — (CLI v0.3+) | Yes | Single org report data. |
-| `create_organization_report` | — (CLI v0.3+) | No | Create an org-wide report. |
-| `update_organization_report` | — (CLI v0.3+) | No | Update report config. |
-| `delete_organization_report` | — (CLI v0.3+) | No | **Two-step destructive.** |
-| `export_organization_report` | — (CLI v0.3+) | No | Trigger async export. |
+| `get_organization_reports` | `pipefy report-org list` | Yes | List all org-level reports. |
+| `get_organization_report` | `pipefy report-org get` | Yes | Single org report data. |
+| `create_organization_report` | `pipefy report-org create` | No | Create an org-wide report. |
+| `update_organization_report` | `pipefy report-org update` | No | Update report config. |
+| `delete_organization_report` | `pipefy report-org delete` | No | **Two-step destructive.** |
+| `export_organization_report` | `pipefy report-org export` | No | Trigger async export. |
 
 ## Export status & download
 
 | Tool (MCP) | CLI | Purpose |
 |------------|-----|---------|
-| `get_pipe_report_export` | — (CLI v0.3+) | Poll pipe report export status (after `export_pipe_report`). |
-| `get_organization_report_export` | — (CLI v0.3+) | Poll org report export status (after `export_organization_report`). |
-| `export_pipe_audit_logs` | — (CLI v0.3+) | Export pipe audit logs (separate from card report exports). |
+| `get_pipe_report_export` | poll via `pipefy report-pipe export --format json` | Poll pipe report export status (after `export_pipe_report`). |
+| `get_organization_report_export` | poll via `pipefy report-org export --format json` | Poll org report export status (after `export_organization_report`). |
+| `export_pipe_audit_logs` | `pipefy audit export` | Export pipe audit logs (separate from card report exports). |
 
 ---
 


### PR DESCRIPTION
## Summary
- Document `get_automation_execution_metrics` in `docs/mcp/tools/observability.md` and align Observability counts (10 → 11) across README / packages / skills.
- Fix related inventory drift: `docs/parity.md` expect 153, pipes-and-cards lead 40, `search_tables` in database-tables, `docs/mcp/README.md` domain index, and broken anchors in `cross-cutting.md`.
- Skills cleanup: add 6 missing pipes tools; move observability tools out of automations inventory; keep members at 11 (`get_pipe_members` lives in pipes); fix database-tables See also links; replace stale `CLI v0.3+` notes with shipped commands from `docs/parity.md`.

## Why
Capability PRs updated `parity` + totals, but per-area MCP references, skill inventories, and cross-links drifted. This PR is docs/skills only.

## Test plan
- [x] `docs/mcp/tools/observability.md` lists `get_automation_execution_metrics` and says 11 tools
- [x] README Observability = 11; domain table sums to 153; parity footer Expect **153**
- [x] `docs/mcp/README.md` links all 10 domain guides + cross-cutting
- [x] `cross-cutting.md` links resolve (`#mcp-server`, `#ai-agent-read-delete`)
- [x] pipes skill tables list 40 tools including comments / `update_card_field` / `get_field_condition` / `get_pipe_members` / `upload_attachment_to_card`
- [x] automations skill tables list 16 tools (no logs/usage/export bleed)
- [x] observability + reports skills show shipped CLI commands (no `v0.3+` placeholders)
- [x] No code/test changes in this PR