### PR TITLE
docs: fix pipefy-login AUTH_URL note and document local-checkout plugin testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ Skills are Markdown-only — no Python, no `uv`, no test infrastructure required
 5. Open a PR. CI validates frontmatter, MCP tool names, and `pipefy` CLI
    subcommands referenced in each `SKILL.md`.
 
+> **Try your skill in Claude Code before opening the PR.** Point the plugin marketplace at your local clone so your branch loads live — see [Test the Claude Code plugin from a local checkout](README.md#test-the-claude-code-plugin-from-a-local-checkout).
+
 ### Frontmatter requirements
 
 Every `SKILL.md` must have valid YAML frontmatter with:

--- a/README.md
+++ b/README.md
@@ -219,6 +219,19 @@ npx @modelcontextprotocol/inspector uv --directory . run pipefy-mcp-server
 
 **Adding an MCP tool:** implement under `packages/mcp/src/pipefy_mcp/tools/`, register in `ToolRegistry`, add the name to `PIPEFY_TOOL_NAMES`, and ship the matching CLI command (or document a deferral in `docs/parity.md`). See [`AGENTS.md`](AGENTS.md) for the full TDD workflow.
 
+### Test the Claude Code plugin from a local checkout
+
+The [Claude Code install](#claude-code) adds the marketplace from the `pipefy/ai-toolkit` GitHub repo, which tracks `main`. To run **your local branch** (e.g. `dev`) as the plugin instead, point the marketplace at your clone:
+
+```text
+/plugin marketplace add /absolute/path/to/ai-toolkit
+/plugin install pipefy@pipefy
+```
+
+Whatever is checked out in that clone — any branch — is what loads. Use the `plugin@marketplace` form (`pipefy@pipefy`) since the marketplace and the plugin share the name `pipefy`. After editing plugin files (skills, commands), run `/reload-plugins` to pick up changes without restarting.
+
+> **Already installed the GitHub version?** A marketplace named `pipefy` can be registered only once, and a marketplace declared in `~/.claude/settings.json` under `extraKnownMarketplaces` is locked — `/plugin marketplace add` becomes a no-op (`already on disk — declared in user settings`) and keeps pointing at GitHub. Run `/plugin marketplace remove pipefy` first (or delete that `extraKnownMarketplaces` entry), **then** add the local path.
+
 ---
 
 ## Contributing

--- a/commands/pipefy-login.md
+++ b/commands/pipefy-login.md
@@ -13,4 +13,4 @@ Otherwise prompt the user to confirm running:
 pipefy auth login $ARGUMENTS
 ```
 
-Requires `PIPEFY_AUTH_URL` set in the shell environment (the OIDC issuer URL).
+This targets Pipefy production by default. Only set `PIPEFY_AUTH_URL` (the OIDC issuer URL) in the shell environment when logging in to a non-prod IdP; it defaults to `https://signin.pipefy.com/realms/pipefy`.


### PR DESCRIPTION
## What

Two documentation changes.

### 1. `/pipefy:pipefy-login` command — drop the false `PIPEFY_AUTH_URL` requirement
`commands/pipefy-login.md` claimed `PIPEFY_AUTH_URL` must be set in the shell. It isn't required — it defaults to the prod OIDC issuer (`https://signin.pipefy.com/realms/pipefy`). Only non-prod IdPs need it. Reworded to say so.

### 2. Document testing the plugin from a local checkout
Adds a README section on pointing the plugin marketplace at a local clone (so a working branch loads live), including the `/reload-plugins` step and the `extraKnownMarketplaces` lock gotcha. Linked from CONTRIBUTING's skill quick-start so contributors can try skills before opening a PR.

## Dropped from this PR

An earlier revision also rewrote the macOS keychain troubleshooting entry in `docs/cli/auth.md`. That's been removed — #265 already owns that section (with CLI code, and closes #235), so the keychain guidance is deferred there to avoid a competing narrative. See the review thread for the `-25244` constant details.

## Scope

Docs and command text only. No code or behavior changes.