### PR TITLE
Invoke iPaaS (Advanced Automations) tools via call_ipaas_tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Open-source toolkit for **Pipefy** developers: a Model Context Protocol (MCP) se
 
 | Component | Package / path | Purpose |
 |-----------|----------------|---------|
-| **MCP server** | `pipefy-mcp-server` | Exposes **154** tools to MCP clients (Cursor, Claude Desktop, Claude Code, and others). |
+| **MCP server** | `pipefy-mcp-server` | Exposes **155** tools to MCP clients (Cursor, Claude Desktop, Claude Code, and others). |
 | **CLI** | `pipefy-cli` | Terminal commands aligned with MCP capabilities; see [`docs/parity.md`](docs/parity.md). |
 | **SDK** | `pipefy` | Vendor GraphQL client, services, and models shared by MCP and CLI. |
 | **Skills** | [`skills/`](skills/) | Markdown playbooks (Anthropic Skills format) for common Pipefy workflows. |
@@ -141,7 +141,7 @@ Deprecation and semver (post-1.0): [`docs/DEPRECATION.md`](docs/DEPRECATION.md).
 
 ## MCP server
 
-The server registers **154 tools** across eleven domains. Canonical names: `PIPEFY_TOOL_NAMES` in [`packages/mcp/src/pipefy_mcp/tools/registry.py`](packages/mcp/src/pipefy_mcp/tools/registry.py).
+The server registers **155 tools** across eleven domains. Canonical names: `PIPEFY_TOOL_NAMES` in [`packages/mcp/src/pipefy_mcp/tools/registry.py`](packages/mcp/src/pipefy_mcp/tools/registry.py).
 
 Tool descriptions and `Args:` blocks come from Python docstrings (what MCP clients show to models). Per-area reference docs cover parameters, edge cases, and cross-cutting behavior.
 

--- a/docs/ipaas.md
+++ b/docs/ipaas.md
@@ -1,7 +1,7 @@
 # iPaaS (Advanced Automations) tools
 
-How the MCP server exposes Pipefy's iPaaS (Advanced Automations) capabilities to agents,
-starting with the `get_ipaas_tools` meta tool.
+How the MCP server exposes Pipefy's iPaaS (Advanced Automations) capabilities to agents:
+`get_ipaas_tools` for discovery and `call_ipaas_tool` for invocation.
 
 ## The meta-tool pattern
 
@@ -9,7 +9,10 @@ iPaaS offers a large tool surface. Loading it into every agent session would cro
 context, so the server exposes it lazily: `get_ipaas_tools(pipe_id)` returns a compact
 `name + description` catalog, and `get_ipaas_tools(pipe_id, tool_name=...)` drills into a
 single tool's full input schema on demand. Agents pay for the catalog only when they need
-it, and for a schema only when they are about to use that tool.
+it, and for a schema only when they are about to use that tool — then invoke it with
+`call_ipaas_tool(pipe_id, tool_name=..., arguments={...})`, which relays the result in
+full. The iPaaS host validates the arguments against its own schema, so its error
+messages come back verbatim.
 
 ## Flow
 
@@ -27,13 +30,15 @@ sequenceDiagram
     Pipefy-->>MCP: short-lived, pipe-scoped credential
     MCP->>iPaaS: authenticate to the pipe's iPaaS workspace
     iPaaS-->>MCP: session-scoped access
-    MCP->>iPaaS: list available tools
-    iPaaS-->>MCP: tool catalog
-    MCP-->>Agent: compact list<br/>(or one tool's schema via tool_name)
+    MCP->>iPaaS: list available tools · or invoke one (call_ipaas_tool)
+    iPaaS-->>MCP: tool catalog · or the tool's result
+    MCP-->>Agent: compact list, one tool's schema,<br/>or the invoked tool's full output
 ```
 
 Every call is stateless: credentials are minted per request and nothing is cached, so any
-server replica can serve any call.
+server replica can serve any call — invocation included. Invocation gets a longer
+network budget than discovery, since a called tool may execute a real flow; executions
+that outlive it are inspected through the catalog's own run-listing tools.
 
 ## Configuration
 
@@ -58,7 +63,11 @@ workspace.
 **Authorization** — acting on a pipe's iPaaS workspace requires the caller to be allowed
 to create automations on that pipe (a pipe-admin ability), evaluated against the identity
 the server resolves for the request. iPaaS-side activity is attributed per pipe.
+Invocation exposes the full catalog — including destructive operations — because the
+same caller already has that full surface in the product's Advanced Automations UI; the
+MCP path grants nothing beyond it, and `call_ipaas_tool` is annotated destructive so
+agent clients apply their approval flows.
 
 **Meta tool** — a tool whose job is to expose a catalog of *other* tools on demand (lazy
 discovery), so agents load large tool surfaces only when needed. `get_ipaas_tools` is the
-first one.
+first one; `call_ipaas_tool` is its invocation counterpart.

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -16,7 +16,7 @@ Material in this tree describes **`pipefy-mcp-server`**: the MCP process, tool b
 | [`tools/members-email-webhooks.md`](tools/members-email-webhooks.md) | Membership, inbox email, webhooks |
 | [`tools/organization.md`](tools/organization.md) | Organization metadata |
 | [`tools/portal.md`](tools/portal.md) | Portals, pages, elements, sub-portals |
-| [`tools/ipaas.md`](tools/ipaas.md) | iPaaS (Advanced Automations) tool discovery |
+| [`tools/ipaas.md`](tools/ipaas.md) | iPaaS (Advanced Automations) tool discovery and invocation |
 | [`tools/introspection.md`](tools/introspection.md) | Schema discovery and raw GraphQL |
 
 Start with [`tools/cross-cutting.md`](tools/cross-cutting.md) for pagination, IDs, `debug`, permissions, and error shape — then open the domain guide you need.

--- a/docs/mcp/tools/ipaas.md
+++ b/docs/mcp/tools/ipaas.md
@@ -1,12 +1,13 @@
 # iPaaS (Advanced Automations)
 
-Discover the iPaaS tool catalog available to a pipe's workspace. **1 tool.**
+Discover and invoke the iPaaS tools available to a pipe's workspace. **2 tools.**
 
 ---
 
 | Tool | Read-only | Role |
 |------|-----------|------|
 | `get_ipaas_tools` | Yes | Lists the iPaaS (Advanced Automations) tools available for a pipe; with `tool_name`, expands one tool's full description and input schema. |
+| `call_ipaas_tool` | No | Invokes one iPaaS tool by name with `arguments` matching its input schema, relaying the result in full. The catalog includes destructive operations (deleting flows, tables, records) — reserve those for explicit user intent. |
 
 **`pipe_id`** matches GraphQL: use a **string** (unquoted JSON integers are coerced). See [Pipefy IDs in pipes & cards](pipes-and-cards.md#pipefy-ids-type-safety).
 
@@ -14,14 +15,19 @@ Discover the iPaaS tool catalog available to a pipe's workspace. **1 tool.**
 
 iPaaS exposes a large catalog (flow building, testing, tables, runs — dozens of
 tools, some with very large input schemas). Loading everything into an agent's
-context would crowd it out, so discovery is two-step:
+context would crowd it out, so the surface is discover → expand → call:
 
 1. `get_ipaas_tools(pipe_id)` — compact catalog: each tool's `name` and the
    first line of its description.
 2. `get_ipaas_tools(pipe_id, tool_name="...")` — one tool's full description
    and `inputSchema`, fetched right before you need it.
+3. `call_ipaas_tool(pipe_id, tool_name="...", arguments={...})` — invokes the
+   tool. Arguments are forwarded verbatim; the iPaaS host validates them
+   against its own schema and its error messages are relayed back.
 
-Never expand more than the tool you are about to use. See
+Never expand more than the tool you are about to use. Long-running executions
+(flow tests, retries) may still be in flight when the call returns — inspect
+progress with the catalog's run-listing tools instead of re-invoking. See
 [`docs/ipaas.md`](../../ipaas.md) for the flow overview and vocabulary.
 
 ## Requirements
@@ -32,7 +38,7 @@ Never expand more than the tool you are about to use. See
   to Pipefy's canonical public OAuth client (see
   [`docs/config.md`](../../config.md)). Staging/single-tenant hosts override
   `PIPEFY_IPAAS_URL` + `PIPEFY_IPAAS_OAUTH_CLIENT_ID`; a blank client id
-  disables the tool, which then answers with a clear "disabled" error.
+  disables both tools, which then answer with a clear "disabled" error.
 
 ## Scoping
 

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -2,7 +2,7 @@
 
 This matrix is the source of truth for **MCP tool ↔ `pipefy` CLI** coverage. Update it whenever MCP tools or CLI commands are added, renamed, or removed.
 
-**Registry source:** `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` (must stay in sync with this table: **154** tools).
+**Registry source:** `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` (must stay in sync with this table: **155** tools).
 
 **Later CLI coverage:** areas such as attachments, field conditions, email, audit export, traditional automations, exports/usage, introspection, and raw GraphQL appear as **shipped** below when the matching Typer commands exist in `packages/cli`.
 
@@ -26,6 +26,7 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | MCP tool name | CLI command (or target) | Status | Notes |
 | --- | --- | --- | --- |
 | `add_card_comment` | `pipefy card comment add` | shipped | — |
+| `call_ipaas_tool` | — | deferred | iPaaS (Advanced Automations) tool invocation; MCP-first surface, CLI twin considered once agent usage settles. |
 | `clone_pipe` | `pipefy pipe clone` | shipped | optional `--org`. |
 | `create_ai_agent` | `pipefy agent create` | shipped | AI Agents domain; post-v0.1 CLI unless explicitly rescoped. |
 | `create_ai_automation` | `pipefy ai-automation create` | shipped | AI Automations domain; post-v0.1 CLI unless explicitly rescoped. |
@@ -107,7 +108,7 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | `get_email_templates` | `pipefy email template list` | shipped | (`--repo`). |
 | `get_field_condition` | `pipefy field-condition get` | shipped | — |
 | `get_field_conditions` | `pipefy field-condition list` | shipped | (`--phase`). |
-| `get_ipaas_tools` | — | deferred | iPaaS (Advanced Automations) tool discovery; MCP-first surface, CLI twin considered after the invocation phase ships. |
+| `get_ipaas_tools` | — | deferred | iPaaS (Advanced Automations) tool discovery; MCP-first surface, CLI twin considered alongside invocation's. |
 | `get_labels` | `pipefy label list` | shipped | — |
 | `get_organization` | `pipefy org get` | shipped | Organization-level read; out of v0.1 parity per spec. |
 | `get_organization_report` | `pipefy report-org get` | shipped | Organization reports. |
@@ -191,6 +192,6 @@ for n in m.body:
             print(len(v.args[0].elts))"
 ```
 
-Expect **154** tool names in `PIPEFY_TOOL_NAMES` and **154** data rows in the parity table (excluding the header rows).
+Expect **155** tool names in `PIPEFY_TOOL_NAMES` and **155** data rows in the parity table (excluding the header rows).
 
 When adding or removing an MCP tool, update **this file** and `PIPEFY_TOOL_NAMES` in the same change set.

--- a/packages/mcp/src/pipefy_mcp/core/ipaas_gateway.py
+++ b/packages/mcp/src/pipefy_mcp/core/ipaas_gateway.py
@@ -294,7 +294,13 @@ class IpaasGateway:
             raise IpaasGatewayError(
                 f"iPaaS {method} returned a response with no result."
             )
-        return payload["result"]
+        result = payload["result"]
+        # A JSON-RPC success with an explicit null (or non-object) result is a
+        # protocol violation: every MCP result the callers read is an object.
+        # Reject it here so callers never dereference a None result.
+        if not isinstance(result, dict):
+            raise IpaasGatewayError(f"iPaaS {method} returned a non-object result.")
+        return result
 
 
 def _query_param(url: str, name: str) -> str | None:

--- a/packages/mcp/src/pipefy_mcp/core/ipaas_gateway.py
+++ b/packages/mcp/src/pipefy_mcp/core/ipaas_gateway.py
@@ -9,7 +9,8 @@ authenticated ``tools/list`` against the pipe's iPaaS workspace:
    pre-registered client — the authorize redirect is parsed, never followed,
    and the approve step is a plain authenticated POST — yielding a short-lived
    access token.
-3. Call the iPaaS MCP endpoint (JSON-RPC ``initialize`` + ``tools/list``).
+3. Call the iPaaS MCP endpoint (JSON-RPC ``initialize`` + ``tools/list`` or
+   ``tools/call``).
 
 Every call is self-contained: no token, session, or client state is retained,
 so any server replica can serve any call. The construction values come from
@@ -28,6 +29,9 @@ import httpx
 from pipefy_auth.pkce import challenge_from_verifier, generate_verifier
 
 REQUEST_TIMEOUT_SECONDS = 30
+# The invocation hop only: a called tool may execute a real flow (test runs,
+# retries), which can legitimately outlast the 30s handshake budget.
+CALL_TIMEOUT_SECONDS = 120
 _MCP_PROTOCOL_VERSION = "2025-03-26"
 _ERROR_BODY_PREVIEW_CHARS = 300
 
@@ -66,16 +70,72 @@ class IpaasGateway:
             IpaasGatewayError: When any step of the chain is refused by the
                 iPaaS host; the message names the step.
         """
+        result = await self._authed_mcp_request(
+            advanced_automations_token, "tools/list", params={}
+        )
+        return result["tools"]
+
+    async def call_tool(
+        self,
+        advanced_automations_token: str,
+        tool_name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Invoke one tool in the pipe's iPaaS workspace and return its raw result.
+
+        The return value is the wire-format ``tools/call`` result
+        (``content`` list plus ``isError``); interpreting or reshaping it is
+        the caller's concern. Like :meth:`list_tools`, each call runs the full
+        stateless auth chain; only the invocation hop itself gets the longer
+        :data:`CALL_TIMEOUT_SECONDS` budget, since a called tool may execute a
+        real flow.
+
+        Args:
+            advanced_automations_token: Pipe-scoped token from
+                ``PipefyClient.get_advanced_automations_token``.
+            tool_name: Exact catalog name (see :meth:`list_tools`).
+            arguments: Tool arguments, forwarded verbatim; the iPaaS host
+                validates them against its own input schema.
+
+        Raises:
+            IpaasGatewayError: When any step of the chain is refused by the
+                iPaaS host; the message names the step.
+        """
+        return await self._authed_mcp_request(
+            advanced_automations_token,
+            "tools/call",
+            params={"name": tool_name, "arguments": arguments or {}},
+            timeout_seconds=CALL_TIMEOUT_SECONDS,
+        )
+
+    async def _authed_mcp_request(
+        self,
+        advanced_automations_token: str,
+        method: str,
+        params: dict[str, Any],
+        timeout_seconds: float = REQUEST_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        """One self-contained chain: fresh client, auth, then the MCP request."""
         async with httpx.AsyncClient(
             timeout=httpx.Timeout(REQUEST_TIMEOUT_SECONDS)
         ) as http:
-            session_token, project_id = await self._exchange_session(
-                http, advanced_automations_token
+            access_token = await self._access_token(http, advanced_automations_token)
+            return await self._mcp_request(
+                http, access_token, method, params, timeout_seconds
             )
-            access_token = await self._oauth_access_token(
-                http, session_token, project_id
-            )
-            return await self._tools_list(http, access_token)
+
+    async def _access_token(
+        self, http: httpx.AsyncClient, advanced_automations_token: str
+    ) -> str:
+        """The full auth chain: pipe token -> session -> headless OAuth token.
+
+        The one seam a replica-local token cache would wrap if per-call chain
+        cost ever matters; callers only ever see an access token.
+        """
+        session_token, project_id = await self._exchange_session(
+            http, advanced_automations_token
+        )
+        return await self._oauth_access_token(http, session_token, project_id)
 
     async def _exchange_session(
         self, http: httpx.AsyncClient, advanced_automations_token: str
@@ -144,10 +204,15 @@ class IpaasGateway:
             raise _step_error("iPaaS token exchange", response)
         return response.json()["access_token"]
 
-    async def _tools_list(
-        self, http: httpx.AsyncClient, access_token: str
-    ) -> list[dict[str, Any]]:
-        """MCP handshake against the iPaaS endpoint; return the raw tool list."""
+    async def _mcp_request(
+        self,
+        http: httpx.AsyncClient,
+        access_token: str,
+        method: str,
+        params: dict[str, Any],
+        timeout_seconds: float = REQUEST_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        """MCP handshake against the iPaaS endpoint; return the JSON-RPC result."""
         headers = {
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
@@ -171,19 +236,31 @@ class IpaasGateway:
             },
             headers=headers,
         )
-        response = await http.post(
-            mcp_url,
-            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
-            headers=headers,
-        )
+        try:
+            response = await http.post(
+                mcp_url,
+                json={"jsonrpc": "2.0", "id": 2, "method": method, "params": params},
+                headers=headers,
+                timeout=timeout_seconds,
+            )
+        except httpx.TimeoutException as exc:
+            raise IpaasGatewayError(
+                f"iPaaS {method} timed out after {timeout_seconds:.0f}s; a "
+                "long-running tool may still be executing on the iPaaS host — "
+                "inspect progress with the run-listing tools instead of retrying."
+            ) from exc
         if response.status_code != 200:
-            raise _step_error("iPaaS tools/list", response)
+            raise _step_error(f"iPaaS {method}", response)
         payload = _parse_mcp_response(response)
         if "error" in payload:
             raise IpaasGatewayError(
-                f"iPaaS tools/list returned an error: {payload['error']}"
+                f"iPaaS {method} returned an error: {payload['error']}"
             )
-        return payload["result"]["tools"]
+        if "result" not in payload:
+            raise IpaasGatewayError(
+                f"iPaaS {method} returned a response with no result."
+            )
+        return payload["result"]
 
 
 def _query_param(url: str, name: str) -> str | None:
@@ -192,15 +269,28 @@ def _query_param(url: str, name: str) -> str | None:
 
 
 def _parse_mcp_response(response: httpx.Response) -> dict[str, Any]:
-    """Decode a JSON-RPC response that may arrive as JSON or one SSE event."""
-    if "text/event-stream" in response.headers.get("content-type", ""):
-        for line in response.text.splitlines():
-            if line.startswith("data:"):
-                return json.loads(line[len("data:") :].strip())
-        raise IpaasGatewayError(
-            "iPaaS MCP endpoint returned an event stream with no data event."
-        )
-    return response.json()
+    """Decode a JSON-RPC response that may arrive as JSON or SSE events.
+
+    Today the host answers one data event per request, but the stream may
+    also carry notification frames (no ``result``/``error``) ahead of the
+    response on future host versions, so the response frame is selected
+    rather than assumed first.
+    """
+    if "text/event-stream" not in response.headers.get("content-type", ""):
+        return response.json()
+    frames = [
+        json.loads(line[len("data:") :].strip())
+        for line in response.text.splitlines()
+        if line.startswith("data:")
+    ]
+    for frame in frames:
+        if "result" in frame or "error" in frame:
+            return frame
+    if frames:
+        return frames[-1]
+    raise IpaasGatewayError(
+        "iPaaS MCP endpoint returned an event stream with no data event."
+    )
 
 
 __all__ = ["IpaasGateway", "IpaasGatewayError"]

--- a/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
@@ -35,7 +35,7 @@ class IpaasTools:
         # Not marked remote-safe yet: the tool itself is per-user clean (the
         # pipe token is minted with the caller's own session), but the iPaaS
         # chain hasn't been reviewed for hosted exposure.
-        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True))
         async def get_ipaas_tools(
             pipe_id: PipefyId,
             ctx: Context,
@@ -92,6 +92,84 @@ class IpaasTools:
                     ),
                 }
             )
+
+        # Not marked remote-safe yet, for the same reason as get_ipaas_tools.
+        @mcp.tool(
+            annotations=ToolAnnotations(
+                readOnlyHint=False, destructiveHint=True, openWorldHint=True
+            )
+        )
+        async def call_ipaas_tool(
+            pipe_id: PipefyId,
+            tool_name: str,
+            ctx: Context,
+            arguments: dict[str, Any] | None = None,
+        ) -> dict:
+            """Invoke one iPaaS (Advanced Automations) tool in a pipe's workspace.
+
+            The counterpart of ``get_ipaas_tools``: that tool discovers what is
+            callable, this one calls it. Always drill into the tool first
+            (``get_ipaas_tools`` with ``tool_name``) and build ``arguments``
+            from its input schema — the iPaaS host validates them and its
+            error messages are returned here verbatim.
+
+            The catalog includes destructive operations (deleting flows,
+            tables, or records): only call those on explicit user intent.
+            Prefer the read and validate tools while iterating, and for
+            long-running executions (flow tests, retries) inspect progress
+            with the run-listing tools rather than re-invoking.
+
+            Requires permission to create automations on the pipe and iPaaS
+            enabled on the organization.
+
+            Args:
+                pipe_id: Numeric pipe ID whose iPaaS workspace to act on.
+                tool_name: Exact tool name from the ``get_ipaas_tools``
+                    catalog.
+                arguments: Arguments matching the tool's input schema. Omit
+                    for tools that take none.
+            """
+            gateway = get_ipaas_gateway(ctx)
+            if gateway is None:
+                return build_error_payload(_NOT_CONFIGURED_MESSAGE)
+
+            client = get_pipefy_client(ctx)
+            try:
+                token = await client.get_advanced_automations_token(pipe_id)
+                result = await gateway.call_tool(token, tool_name, arguments)
+            except Exception as exc:  # noqa: BLE001
+                return build_error_payload(str(exc))
+
+            return _call_result_payload(pipe_id, tool_name, result)
+
+
+def _call_result_payload(
+    pipe_id: PipefyId, tool_name: str, result: dict[str, Any]
+) -> dict:
+    """Map a wire-format ``tools/call`` result onto the standard envelope.
+
+    Text content is joined and relayed in full — the result is the
+    deliverable, so no trimming. A host-side ``isError`` becomes the standard
+    error payload; content types other than text are passed through raw
+    rather than dropped.
+    """
+    content = result.get("content") or []
+    text = "\n".join(
+        item.get("text", "") for item in content if item.get("type") == "text"
+    )
+    if result.get("isError"):
+        return build_error_payload(
+            text or f"iPaaS tool '{tool_name}' reported an error with no message."
+        )
+    payload: dict[str, Any] = {
+        "pipe_id": str(pipe_id),
+        "tool_name": tool_name,
+        "output": text,
+    }
+    other = [item for item in content if item.get("type") != "text"]
+    if other:
+        payload["content"] = other
+    return build_success_payload(payload)
 
 
 def _single_tool_payload(tools: list[dict[str, Any]], tool_name: str) -> dict:

--- a/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
@@ -88,7 +88,9 @@ class IpaasTools:
                     "tools": catalog,
                     "hint": (
                         "Call get_ipaas_tools again with tool_name=<name> for a "
-                        "tool's full description and input schema."
+                        "tool's full description and input schema, then run it "
+                        "with call_ipaas_tool(pipe_id, tool_name=<name>, "
+                        "arguments={...})."
                     ),
                 }
             )

--- a/packages/mcp/src/pipefy_mcp/tools/registry.py
+++ b/packages/mcp/src/pipefy_mcp/tools/registry.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 PIPEFY_TOOL_NAMES = frozenset(
     {
         "add_card_comment",
+        "call_ipaas_tool",
         "clone_pipe",
         "create_ai_agent",
         "create_ai_automation",

--- a/packages/mcp/tests/core/test_ipaas_gateway.py
+++ b/packages/mcp/tests/core/test_ipaas_gateway.py
@@ -9,7 +9,12 @@ import httpx
 import pytest
 import respx
 
-from pipefy_mcp.core.ipaas_gateway import IpaasGateway, IpaasGatewayError
+from pipefy_mcp.core.ipaas_gateway import (
+    CALL_TIMEOUT_SECONDS,
+    REQUEST_TIMEOUT_SECONDS,
+    IpaasGateway,
+    IpaasGatewayError,
+)
 
 IPAAS_URL = "https://ipaas.test"
 REDIRECT_URI = "https://localhost/pipefy-mcp-callback"
@@ -38,8 +43,8 @@ def gateway() -> IpaasGateway:
     )
 
 
-def _mock_happy_chain(respx_mock: respx.MockRouter, *, sse_tools_list: bool = False):
-    """Wire every endpoint of the chain; return the /mcp route for inspection."""
+def _mock_auth_chain(respx_mock: respx.MockRouter) -> None:
+    """Wire every endpoint of the chain before /mcp (session + headless OAuth)."""
     respx_mock.post(f"{IPAAS_URL}/api/v1/managed-authn/external-token").respond(
         200, json={"token": "session-token", "projectId": "proj-1"}
     )
@@ -54,7 +59,25 @@ def _mock_happy_chain(respx_mock: respx.MockRouter, *, sse_tools_list: bool = Fa
         200, json={"access_token": "access-token", "expires_in": 900}
     )
 
-    tools_result = {"jsonrpc": "2.0", "id": 2, "result": {"tools": TOOLS}}
+
+def _mock_happy_chain(
+    respx_mock: respx.MockRouter,
+    *,
+    sse_tools_list: bool = False,
+    rpc_result: dict | None = None,
+):
+    """Wire every endpoint of the chain; return the /mcp route for inspection.
+
+    ``rpc_result`` is the JSON-RPC ``result`` the non-initialize MCP request
+    answers with; it defaults to the ``tools/list`` catalog.
+    """
+    _mock_auth_chain(respx_mock)
+
+    tools_result = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": {"tools": TOOLS} if rpc_result is None else rpc_result,
+    }
 
     def mcp_responder(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
@@ -180,19 +203,7 @@ async def test_redirect_without_auth_request_id_is_reported(respx_mock, gateway)
 @pytest.mark.anyio
 @respx.mock
 async def test_jsonrpc_error_from_tools_list_raises(respx_mock, gateway):
-    respx_mock.post(f"{IPAAS_URL}/api/v1/managed-authn/external-token").respond(
-        200, json={"token": "session-token", "projectId": "proj-1"}
-    )
-    respx_mock.get(url__startswith=f"{IPAAS_URL}/authorize").respond(
-        302,
-        headers={"location": f"{IPAAS_URL}/mcp-authorize?authRequestId=auth-req-jwt"},
-    )
-    respx_mock.post(f"{IPAAS_URL}/api/v1/mcp-oauth/approve").respond(
-        200, json={"redirectUrl": f"{REDIRECT_URI}?code=auth-code"}
-    )
-    respx_mock.post(f"{IPAAS_URL}/token").respond(
-        200, json={"access_token": "access-token"}
-    )
+    _mock_auth_chain(respx_mock)
     respx_mock.post(f"{IPAAS_URL}/mcp").respond(
         200,
         json={"jsonrpc": "2.0", "id": 2, "error": {"code": -32603, "message": "boom"}},
@@ -200,3 +211,151 @@ async def test_jsonrpc_error_from_tools_list_raises(respx_mock, gateway):
 
     with pytest.raises(IpaasGatewayError, match="tools/list returned an error"):
         await gateway.list_tools("embed-jwt")
+
+
+CALL_RESULT = {
+    "content": [{"type": "text", "text": "flow created: flow-1"}],
+    "isError": False,
+}
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_call_tool_posts_tools_call_with_arguments(respx_mock, gateway):
+    mcp_route = _mock_happy_chain(respx_mock, rpc_result=CALL_RESULT)
+
+    result = await gateway.call_tool("embed-jwt", "ap_create_flow", {"name": "My flow"})
+
+    assert result == CALL_RESULT
+    body = json.loads(mcp_route.calls.last.request.content)
+    assert body["method"] == "tools/call"
+    assert body["params"] == {
+        "name": "ap_create_flow",
+        "arguments": {"name": "My flow"},
+    }
+    assert (
+        mcp_route.calls.last.request.headers["authorization"] == "Bearer access-token"
+    )
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_call_tool_defaults_arguments_to_empty_object(respx_mock, gateway):
+    mcp_route = _mock_happy_chain(respx_mock, rpc_result=CALL_RESULT)
+
+    await gateway.call_tool("embed-jwt", "ap_list_flows")
+
+    body = json.loads(mcp_route.calls.last.request.content)
+    assert body["params"] == {"name": "ap_list_flows", "arguments": {}}
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_call_tool_gives_only_the_invocation_hop_the_long_timeout(
+    respx_mock, gateway
+):
+    """A called tool may run a real flow; the handshake hops keep 30s."""
+    mcp_route = _mock_happy_chain(respx_mock, rpc_result=CALL_RESULT)
+
+    await gateway.call_tool("embed-jwt", "ap_test_flow", {"flowId": "flow-1"})
+
+    initialize, invocation = mcp_route.calls[-2].request, mcp_route.calls[-1].request
+    assert initialize.extensions["timeout"]["read"] == REQUEST_TIMEOUT_SECONDS
+    assert invocation.extensions["timeout"]["read"] == CALL_TIMEOUT_SECONDS
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_call_tool_relays_host_error_results_without_raising(respx_mock, gateway):
+    """A tool-level isError is data for the caller, not a chain failure."""
+    error_result = {
+        "content": [{"type": "text", "text": "flow not found"}],
+        "isError": True,
+    }
+    _mock_happy_chain(respx_mock, rpc_result=error_result)
+
+    result = await gateway.call_tool("embed-jwt", "ap_delete_flow", {"id": "nope"})
+
+    assert result == error_result
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_call_tool_parses_sse_encoded_response(respx_mock, gateway):
+    _mock_happy_chain(respx_mock, sse_tools_list=True, rpc_result=CALL_RESULT)
+
+    result = await gateway.call_tool("embed-jwt", "ap_create_flow", {"name": "x"})
+
+    assert result == CALL_RESULT
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_jsonrpc_error_from_tools_call_names_the_method(respx_mock, gateway):
+    _mock_auth_chain(respx_mock)
+    respx_mock.post(f"{IPAAS_URL}/mcp").respond(
+        200,
+        json={"jsonrpc": "2.0", "id": 2, "error": {"code": -32602, "message": "boom"}},
+    )
+
+    with pytest.raises(IpaasGatewayError, match="tools/call returned an error"):
+        await gateway.call_tool("embed-jwt", "ap_create_flow", {})
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_call_tool_timeout_names_the_method_and_points_at_runs(
+    respx_mock, gateway
+):
+    """A timeout on the invocation hop must not surface as a bare httpx error."""
+    _mock_auth_chain(respx_mock)
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        if json.loads(request.content)["method"] == "initialize":
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": {}})
+        raise httpx.ReadTimeout("read timed out")
+
+    respx_mock.post(f"{IPAAS_URL}/mcp").mock(side_effect=responder)
+
+    with pytest.raises(
+        IpaasGatewayError, match="tools/call timed out after 120s.*run-listing"
+    ):
+        await gateway.call_tool("embed-jwt", "ap_test_flow", {"flowId": "flow-1"})
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_response_without_result_names_the_method(respx_mock, gateway):
+    _mock_auth_chain(respx_mock)
+    respx_mock.post(f"{IPAAS_URL}/mcp").respond(200, json={"jsonrpc": "2.0", "id": 2})
+
+    with pytest.raises(IpaasGatewayError, match="tools/call.*no result"):
+        await gateway.call_tool("embed-jwt", "ap_list_flows")
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_sse_notification_frames_before_the_response_are_skipped(
+    respx_mock, gateway
+):
+    """The response frame is selected by shape, not assumed to arrive first."""
+    _mock_auth_chain(respx_mock)
+    notification = {"jsonrpc": "2.0", "method": "notifications/message", "params": {}}
+    response = {"jsonrpc": "2.0", "id": 2, "result": CALL_RESULT}
+    sse_body = (
+        f"event: message\ndata: {json.dumps(notification)}\n\n"
+        f"event: message\ndata: {json.dumps(response)}\n\n"
+    )
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        if json.loads(request.content)["method"] == "initialize":
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": {}})
+        return httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, text=sse_body
+        )
+
+    respx_mock.post(f"{IPAAS_URL}/mcp").mock(side_effect=responder)
+
+    result = await gateway.call_tool("embed-jwt", "ap_create_flow", {"name": "x"})
+
+    assert result == CALL_RESULT

--- a/packages/mcp/tests/core/test_ipaas_gateway.py
+++ b/packages/mcp/tests/core/test_ipaas_gateway.py
@@ -363,6 +363,19 @@ async def test_sse_notification_frames_before_the_response_are_skipped(
 
 @pytest.mark.anyio
 @respx.mock
+async def test_null_result_is_a_protocol_error(respx_mock, gateway):
+    """A JSON-RPC success with an explicit null result is a gateway error, not None."""
+    _mock_auth_chain(respx_mock)
+    respx_mock.post(f"{IPAAS_URL}/mcp").respond(
+        200, json={"jsonrpc": "2.0", "id": 2, "result": None}
+    )
+
+    with pytest.raises(IpaasGatewayError, match="tools/call.*non-object result"):
+        await gateway.call_tool("embed-jwt", "ap_list_flows")
+
+
+@pytest.mark.anyio
+@respx.mock
 async def test_session_exchange_missing_key_names_the_step(respx_mock, gateway):
     """A 200 with a body missing an expected key is a step error, not a raw KeyError."""
     respx_mock.post(f"{IPAAS_URL}/api/v1/managed-authn/external-token").respond(

--- a/packages/mcp/tests/tools/test_ipaas_tools.py
+++ b/packages/mcp/tests/tools/test_ipaas_tools.py
@@ -91,6 +91,8 @@ async def test_compact_catalog_lists_names_and_first_lines(
     assert "Create a new flow" in payload["result"]
     assert "Longer guidance" not in payload["result"]
     assert "inputSchema" not in payload["result"]
+    # The hint names the full discover -> expand -> call loop.
+    assert "call_ipaas_tool" in payload["result"]
 
 
 @pytest.mark.anyio
@@ -261,6 +263,27 @@ async def test_call_tool_maps_host_iserror_to_error_payload(
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "flow not found" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+async def test_call_tool_null_result_becomes_error_payload_not_attribute_error(
+    mock_client, mock_gateway, extract_payload
+):
+    """A host `result: null` surfaces (via the gateway guard) as the standard
+    envelope, never a bare `AttributeError` on a None result."""
+    mock_gateway.call_tool = AsyncMock(
+        side_effect=IpaasGatewayError("iPaaS tools/call returned a non-object result.")
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await session.call_tool(
+            "call_ipaas_tool",
+            {"pipe_id": "303088927", "tool_name": "ap_list_flows"},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "non-object result" in tool_error_message(payload)
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_ipaas_tools.py
+++ b/packages/mcp/tests/tools/test_ipaas_tools.py
@@ -183,3 +183,143 @@ async def test_int_pipe_id_is_coerced_to_string(
     payload = extract_payload(result)
     assert payload["success"] is True
     mock_client.get_advanced_automations_token.assert_awaited_once_with("303088927")
+
+
+@pytest.mark.anyio
+async def test_call_tool_forwards_arguments_and_relays_output(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.call_tool = AsyncMock(
+        return_value={
+            "content": [
+                {"type": "text", "text": "flow created"},
+                {"type": "text", "text": "id: flow-1"},
+            ],
+            "isError": False,
+        }
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await session.call_tool(
+            "call_ipaas_tool",
+            {
+                "pipe_id": "303088927",
+                "tool_name": "ap_create_flow",
+                "arguments": {"name": "My flow"},
+            },
+        )
+
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    mock_client.get_advanced_automations_token.assert_awaited_once_with("303088927")
+    mock_gateway.call_tool.assert_awaited_once_with(
+        "embed-jwt", "ap_create_flow", {"name": "My flow"}
+    )
+    # Text segments are joined and relayed in full.
+    assert "flow created" in payload["result"]
+    assert "id: flow-1" in payload["result"]
+    assert '"ap_create_flow"' in payload["result"]
+
+
+@pytest.mark.anyio
+async def test_call_tool_arguments_default_to_none(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.call_tool = AsyncMock(
+        return_value={"content": [{"type": "text", "text": "[]"}], "isError": False}
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await session.call_tool(
+            "call_ipaas_tool",
+            {"pipe_id": "303088927", "tool_name": "ap_list_flows"},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    mock_gateway.call_tool.assert_awaited_once_with("embed-jwt", "ap_list_flows", None)
+
+
+@pytest.mark.anyio
+async def test_call_tool_maps_host_iserror_to_error_payload(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.call_tool = AsyncMock(
+        return_value={
+            "content": [{"type": "text", "text": "flow not found"}],
+            "isError": True,
+        }
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await session.call_tool(
+            "call_ipaas_tool",
+            {"pipe_id": "303088927", "tool_name": "ap_delete_flow"},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "flow not found" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+async def test_call_tool_passes_non_text_content_through(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.call_tool = AsyncMock(
+        return_value={
+            "content": [
+                {"type": "text", "text": "done"},
+                {"type": "image", "data": "aGk=", "mimeType": "image/png"},
+            ],
+            "isError": False,
+        }
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await session.call_tool(
+            "call_ipaas_tool",
+            {"pipe_id": "303088927", "tool_name": "ap_get_run"},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert '"image"' in payload["result"]
+    assert "aGk=" in payload["result"]
+
+
+@pytest.mark.anyio
+async def test_call_tool_gateway_error_becomes_error_payload(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.call_tool = AsyncMock(
+        side_effect=IpaasGatewayError("iPaaS tools/call failed (HTTP 500): boom")
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await session.call_tool(
+            "call_ipaas_tool",
+            {"pipe_id": "303088927", "tool_name": "ap_create_flow"},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "tools/call" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+async def test_call_tool_unconfigured_gateway_reports_clearly(
+    mock_client, extract_payload
+):
+    server = build_ipaas_test_server(mock_client, gateway=None)
+    async with _session(server) as session:
+        result = await session.call_tool(
+            "call_ipaas_tool",
+            {"pipe_id": "303088927", "tool_name": "ap_create_flow"},
+        )
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "disabled" in tool_error_message(payload)
+    mock_client.get_advanced_automations_token.assert_not_awaited()


### PR DESCRIPTION
## Motivation
#402 gave agents discovery over a pipe's iPaaS (Advanced Automations) tool catalog, but discovery without invocation still sends the user to the product UI for every action. The natural next step of the meta-tool pattern is letting agents call what they discovered — without loading the full catalog into context, and without adding any per-deployment state or configuration.

## Outcome
Agents can now execute any tool from a pipe's iPaaS workspace with `call_ipaas_tool(pipe_id, tool_name, arguments)`, completing the discover → expand → call loop (`get_ipaas_tools` → drill into one schema → invoke). Arguments are forwarded verbatim and validated by the iPaaS host, whose error messages come back unchanged; results are relayed in full, with host-side tool errors mapped onto the standard error envelope. Every invocation runs the same stateless per-call chain as discovery — any replica serves any call — and the invocation hop gets a 120s budget (handshake hops keep 30s) since a called tool may execute a real flow; on timeout the error points agents at the catalog's run-listing tools instead of retrying. The full catalog is exposed, including destructive operations: the caller already holds the identical surface in the product's Advanced Automations UI, so the tool is annotated destructive (client approval flows apply) rather than server-filtered. The registry grows to 155 tools.

## Notes
Stacked on #402 (`rc-dev/feat/ipaas-get-tools`) — merge that first; this PR then rebases onto `dev`. Validated end-to-end against a production pipe: flow listed, created, inspected, and deleted through the new tool.