### PR TITLE
fix(cli): don't render a non-expiring refresh token as expired

### DIFF
--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -139,7 +139,7 @@ The command answers four diagnostic questions: am I signed in, as whom, via whic
   "issuer": "https://signin.pipefy.com/realms/pipefy",
   "state": "active",                              // or "refresh-expired" | "needs-login" | "n/a"
   "access_expires_at": "2026-05-20T22:14:03Z",    // ISO 8601, null for static-bearer
-  "refresh_expires_at": "2026-06-19T18:02:00Z",   // ISO 8601, null when not stored-session
+  "refresh_expires_at": "2026-06-19T18:02:00Z",   // ISO 8601; null when not a stored session, or when the IdP advertises no refresh-token expiry (refresh_expires_in: 0)
   "token_rejected": false,                        // true only when the identity `me` query returned 401
   "keychain_backend": "Keyring",                  // null for non-stored-session sources
   "masking_env_vars": []                          // env vars masking a stored session, if any

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -358,8 +358,10 @@ def _populate_stored_session(report: AuthStatusReport, oidc: OidcClient) -> None
             report.access_expires_at = _iso_expiry(
                 stale.obtained_at, stale.token.expires_in
             )
+            # refresh_expires_in: 0 is Keycloak's "no advertised expiry" sentinel,
+            # not a 0-second TTL — treat as no expiry (else it renders "expired").
             report.refresh_expires_at = _iso_expiry(
-                stale.obtained_at, stale.token.refresh_expires_in
+                stale.obtained_at, stale.token.refresh_expires_in or None
             )
         raise _StatusExit(
             report=report,
@@ -382,7 +384,7 @@ def _populate_stored_session(report: AuthStatusReport, oidc: OidcClient) -> None
         fresh_session.obtained_at, fresh_session.token.expires_in
     )
     report.refresh_expires_at = _iso_expiry(
-        fresh_session.obtained_at, fresh_session.token.refresh_expires_in
+        fresh_session.obtained_at, fresh_session.token.refresh_expires_in or None
     )
 
 

--- a/packages/cli/tests/test_auth_status.py
+++ b/packages/cli/tests/test_auth_status.py
@@ -121,6 +121,24 @@ def test_status_stored_session_text_output(
     assert "Expires:" in result.stdout
 
 
+def test_status_non_expiring_refresh_token_not_reported_expired(
+    clean_pipefy_env, saved_cwd, monkeypatch, runner, fake_keyring
+):
+    """Keycloak advertises a non-expiring refresh token as ``refresh_expires_in: 0``.
+    That must not be read as a 0-second TTL and rendered as already ``expired``."""
+    _set_auth_env(monkeypatch)
+    _seed_session(monkeypatch, refresh_expires_in=0)
+    session = storage.load_session(issuer=_ISSUER, client_id=_CLIENT_ID)
+    client = _mock_client_with_me()
+    with _patch_fresh_session(session), _patch_command_client(client):
+        json_result = _invoke_status(runner, ["--json"])
+        text_result = _invoke_status(runner)
+
+    assert json_result.exit_code == 0, json_result.stdout
+    assert json.loads(json_result.stdout)["refresh_expires_at"] is None
+    assert "Refresh token: expired" not in text_result.stdout
+
+
 # --------------------------------------------------------------------------- #
 # Scenario 2: stored-session, eager refresh runs (we mock the result as fresh) #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
`pipefy auth status` always showed `Refresh token: expired` (and `refresh_expires_at` as a past timestamp in `--json`), even on a freshly-authenticated session — misleading users, and agents polling auth during long-running work, into thinking re-login is imminent.

Refresh-token expiry is computed as `obtained_at + refresh_expires_in`. Keycloak sends `refresh_expires_in: 0` to advertise a non-expiring refresh token, but that `0` was read as a 0-second TTL, placing expiry at the login instant. Eager refresh resets `obtained_at` to now on every rotation, so it sat perpetually at ~now → perpetually "expired".

Fix: normalize the sentinel where the refresh token is read (`refresh_expires_in or None`), so `0` → no expiry → `unknown` (text) / `null` (JSON). `_iso_expiry` stays generic, so a genuine 0-second *access*-token TTL still reads as "expired". Purely a status-readout change; the refresh decision (`_is_stale`) never consults this value — it's only carried forward verbatim on rotation.

Deliberately **not** rendered as "never": per Keycloak's issue tracker, `refresh_expires_in: 0` doesn't guarantee the token never expires — with "Offline Session Max Limited" off but a non-zero "Offline Session Idle", the server still enforces an idle timeout and rejects refreshes with `invalid_grant`. `unknown`/`null` is the honest readout.

Confirmed against a live session: `refresh_expires_in = 0`, `expires_in = 300`, recent `obtained_at`.

## Testing performed
- `uv run --package pipefy-cli pytest packages/cli/tests/` → **341 passed, 13 skipped**
- `uv run ruff check packages/cli/src/pipefy_cli/commands/auth.py` → **All checks passed!**
- Added `test_status_non_expiring_refresh_token_not_reported_expired` (seeds `refresh_expires_in=0`; asserts `--json` `refresh_expires_at is None` and the text line is not `expired`).

## Docs
- `docs/cli/auth.md`: updated the `refresh_expires_at` JSON-schema note — `null` now also covers an active stored session whose refresh token advertises no expiry (`refresh_expires_in: 0`).