### PR TITLE
Remote-safe: AI agent & automation read tools

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -41,6 +41,7 @@ from pipefy_mcp.tools.graphql_error_helpers import (
     enrich_permission_denied_error,
     extract_error_strings,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 
 VALIDATE_FETCH_TIMEOUT_SECONDS = 30
@@ -481,6 +482,7 @@ class AiAgentTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_ai_agent(ctx: Context, uuid: str) -> dict:
             """Get an AI Agent by UUID with full behavior configuration.
@@ -513,6 +515,7 @@ class AiAgentTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_ai_agents(ctx: Context, repo_uuid: str) -> dict:
             """List all AI Agents for a pipe. Use before creating an agent to avoid duplicates.
@@ -575,6 +578,7 @@ class AiAgentTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            meta=REMOTE,
         )
         async def validate_ai_agent_behaviors(
             ctx: Context,

--- a/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -29,6 +29,7 @@ from pipefy_mcp.tools.automation_tool_helpers import (
     handle_automation_tool_graphql_error,
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import (
     validate_optional_tool_id,
@@ -45,6 +46,7 @@ class AiAutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            meta=REMOTE,
         )
         async def validate_ai_automation_prompt(
             ctx: Context,
@@ -125,6 +127,7 @@ class AiAutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            meta=REMOTE,
         )
         async def get_ai_automation(
             ctx: Context,
@@ -173,6 +176,7 @@ class AiAutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            meta=REMOTE,
         )
         async def get_ai_automations(
             ctx: Context,

--- a/packages/mcp/src/pipefy_mcp/tools/llm_provider_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/llm_provider_tools.py
@@ -17,6 +17,7 @@ from pipefy_mcp.tools.pagination_helpers import (
     build_pagination_info,
     validate_page_size,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
@@ -132,7 +133,7 @@ class LlmProviderTools:
                 page_size=nfirst,
             )
 
-        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True), meta=REMOTE)
         async def get_available_ai_models(
             ctx: Context,
             provider_name: str,

--- a/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
@@ -22,6 +22,7 @@ from pipefy_mcp.tools.observability_tool_helpers import (
     build_observability_read_success_payload,
     handle_observability_tool_graphql_error,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import (
     validate_optional_tool_id,
@@ -72,6 +73,7 @@ class ObservabilityTools:
     def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_ai_agent_logs(
             repo_uuid: str,
@@ -123,6 +125,7 @@ class ObservabilityTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_ai_agent_log_details(
             log_uuid: str,
@@ -261,6 +264,7 @@ class ObservabilityTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_agents_usage(
             organization_uuid: PipefyId,
@@ -369,6 +373,7 @@ class ObservabilityTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_ai_credit_usage(
             organization_uuid: PipefyId,

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -39,6 +39,20 @@ REMOTE_SEED = frozenset(
         "introspect_query",
         "introspect_mutation",
         "introspect_type",
+        # AI agent & automation reads (#437): read/validate tools that reach the
+        # API with the request-scoped bearer and are governed by API permissions;
+        # no filesystem or per-user process-global settings reads.
+        "get_ai_agent",
+        "get_ai_agents",
+        "get_ai_agent_logs",
+        "get_ai_agent_log_details",
+        "get_agents_usage",
+        "validate_ai_agent_behaviors",
+        "get_ai_automation",
+        "get_ai_automations",
+        "validate_ai_automation_prompt",
+        "get_ai_credit_usage",
+        "get_available_ai_models",
     }
 )
 


### PR DESCRIPTION
Closes #437. Part of migrating the default-deny remote profile to expose the read tools that meet the remote-safe criteria (milestone: Hosted-safe tool surface). Stacked on `dev`.

## Motivation

Under `--profile remote` the server exposes only tools carrying `meta=REMOTE` (tracked by `REMOTE_SEED`); many pure read tools that reach the API with the request-scoped bearer and are fully governed by API permissions were still withheld. This exposes the AI agent and AI automation read/log surface.

## Outcome

Marks 11 AI agent & automation read tools remote-safe: `get_ai_agent`, `get_ai_agents`, `get_ai_agent_logs`, `get_ai_agent_log_details`, `get_agents_usage`, `validate_ai_agent_behaviors`, `get_ai_automation`, `get_ai_automations`, `validate_ai_automation_prompt`, `get_ai_credit_usage`, `get_available_ai_models`. Each tool carries `meta=REMOTE` and a matching `REMOTE_SEED` entry; the drift-guard test keeps the two in lockstep. No new tools, no behavior change under the local profile.

## Remote-profile validation

The remote-safe read migration (this PR is part of the stack #437→#441) was verified end-to-end by running the code in `--profile remote --transport http` locally — behaving as a deployed instance — and connecting an MCP HTTP client with a valid RS256 Keycloak bearer. Measured on an integration branch that also carried the in-flight provider-write work (#434), so the withheld count includes those write tools:

| # | Scenario | Observed | Verdict |
|---|---|---|---|
| 1 | Server in `--profile remote --transport http` | `exposed 76, withheld 106` (default-deny) | ✅ |
| 2 | Unauthenticated request | `401` (bearer required) | ✅ |
| 3 | `tools/list` with a valid RS256 bearer | exactly the 76 remote-safe tools | ✅ |
| 4 | Remote-safe reads present | `get_organization`, `get_pipe`, `get_llm_providers`, `get_ai_agents` | ✅ |
| 5 | Writes / local-file / raw GraphQL withheld | `create_card`, `create_llm_provider`, `delete_card`, `upload_attachment_to_card`, `execute_graphql` absent — 0 leaked | ✅ |
| 6 | Live authenticated tool call (per-request bearer → outbound) | `get_organization` executed (`isError=false`) | ✅ |

The 76 remote-safe tools are the 23 pre-existing plus the 53 read tools this migration set (#437–#441) adds. Registration-time filtering is also covered by the `test_remote_profile.py` drift-guard and `test_on_exposes_seed_and_withholds_the_rest`.
