### PR TITLE
Remote-safe: knowledge base & LLM provider read tools

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/knowledge_base_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/knowledge_base_tools.py
@@ -20,6 +20,7 @@ from pipefy_mcp.core.tool_error_envelope import (
     tool_success,
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 
 _KB_ID_DISCOVERY_HINT = (
@@ -107,7 +108,7 @@ class KnowledgeBaseTools:
     def register(mcp: FastMCP) -> None:
         """Register knowledge base tools on the MCP server."""
 
-        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True), meta=REMOTE)
         async def get_ai_knowledge_bases(
             ctx: Context,
             pipe_uuid: str,
@@ -135,7 +136,7 @@ class KnowledgeBaseTools:
                 {"knowledge_bases": items}, message="Knowledge bases retrieved."
             )
 
-        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True), meta=REMOTE)
         async def get_ai_knowledge_base_plain_text(
             ctx: Context,
             plain_text_id: str,
@@ -311,7 +312,7 @@ class KnowledgeBaseTools:
                 message="Knowledge base plain text deleted.",
             )
 
-        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True), meta=REMOTE)
         async def get_ai_knowledge_base_document(
             ctx: Context,
             document_id: str,
@@ -495,7 +496,7 @@ class KnowledgeBaseTools:
                 message="Knowledge base document deleted.",
             )
 
-        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True), meta=REMOTE)
         async def get_ai_knowledge_base_data_lookup(
             ctx: Context,
             data_lookup_id: str,
@@ -709,7 +710,7 @@ class KnowledgeBaseTools:
                 message="Knowledge base data lookup deleted.",
             )
 
-        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True), meta=REMOTE)
         async def validate_knowledge_base_access(
             ctx: Context,
             pipe_uuid: str,

--- a/packages/mcp/src/pipefy_mcp/tools/llm_provider_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/llm_provider_tools.py
@@ -88,7 +88,7 @@ class LlmProviderTools:
     def register(mcp: FastMCP) -> None:
         """Register LLM provider tools on the MCP server."""
 
-        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True), meta=REMOTE)
         async def get_llm_providers(
             ctx: Context,
             organization_uuid: str,
@@ -157,7 +157,7 @@ class LlmProviderTools:
                 {"models": models}, message="Available AI models retrieved."
             )
 
-        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True), meta=REMOTE)
         async def get_default_llm_provider(
             ctx: Context,
             owner_id: str,
@@ -191,7 +191,7 @@ class LlmProviderTools:
                 {"provider": provider}, message="Default LLM provider retrieved."
             )
 
-        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True), meta=REMOTE)
         async def get_llm_provider_dependencies(
             ctx: Context,
             provider_id: str,
@@ -236,7 +236,7 @@ class LlmProviderTools:
                 page_size=nfirst,
             )
 
-        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+        @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True), meta=REMOTE)
         async def validate_llm_provider_access(
             ctx: Context,
             organization_uuid: str,

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -53,6 +53,18 @@ REMOTE_SEED = frozenset(
         "validate_ai_automation_prompt",
         "get_ai_credit_usage",
         "get_available_ai_models",
+        # knowledge base & LLM provider reads (#438): read/validate tools that
+        # reach the API with the request-scoped bearer and are governed by API
+        # permissions; no filesystem or per-user process-global settings reads.
+        "get_ai_knowledge_bases",
+        "get_ai_knowledge_base_plain_text",
+        "get_ai_knowledge_base_document",
+        "get_ai_knowledge_base_data_lookup",
+        "validate_knowledge_base_access",
+        "get_llm_providers",
+        "get_llm_provider_dependencies",
+        "get_default_llm_provider",
+        "validate_llm_provider_access",
     }
 )
 


### PR DESCRIPTION
Closes #438. Part of migrating the default-deny remote profile to expose the read tools that meet the remote-safe criteria (milestone: Hosted-safe tool surface). Stacked on `rc-dev/feat/remote-safe-ai-reads`.

## Motivation

Under `--profile remote` the server exposes only tools carrying `meta=REMOTE` (tracked by `REMOTE_SEED`); many pure read tools that reach the API with the request-scoped bearer and are fully governed by API permissions were still withheld. This exposes the knowledge base and LLM provider discovery reads (secrets stay API-redacted).

## Outcome

Marks 9 knowledge base & LLM provider read tools remote-safe: `get_ai_knowledge_bases`, `get_ai_knowledge_base_plain_text`, `get_ai_knowledge_base_document`, `get_ai_knowledge_base_data_lookup`, `validate_knowledge_base_access`, `get_llm_providers`, `get_llm_provider_dependencies`, `get_default_llm_provider`, `validate_llm_provider_access`. Each tool carries `meta=REMOTE` and a matching `REMOTE_SEED` entry; the drift-guard test keeps the two in lockstep. No new tools, no behavior change under the local profile.

## Remote-profile validation

The remote-safe read migration (this PR is part of the stack #437→#441) was verified end-to-end by running the code in `--profile remote --transport http` locally — behaving as a deployed instance — and connecting an MCP HTTP client with a valid RS256 Keycloak bearer. Measured on an integration branch that also carried the in-flight provider-write work (#434), so the withheld count includes those write tools:

| # | Scenario | Observed | Verdict |
|---|---|---|---|
| 1 | Server in `--profile remote --transport http` | `exposed 76, withheld 106` (default-deny) | ✅ |
| 2 | Unauthenticated request | `401` (bearer required) | ✅ |
| 3 | `tools/list` with a valid RS256 bearer | exactly the 76 remote-safe tools | ✅ |
| 4 | Remote-safe reads present | `get_organization`, `get_pipe`, `get_llm_providers`, `get_ai_agents` | ✅ |
| 5 | Writes / local-file / raw GraphQL withheld | `create_card`, `create_llm_provider`, `delete_card`, `upload_attachment_to_card`, `execute_graphql` absent — 0 leaked | ✅ |
| 6 | Live authenticated tool call (per-request bearer → outbound) | `get_organization` executed (`isError=false`) | ✅ |

The 76 remote-safe tools are the 23 pre-existing plus the 53 read tools this migration set (#437–#441) adds. Registration-time filtering is also covered by the `test_remote_profile.py` drift-guard and `test_on_exposes_seed_and_withholds_the_rest`.
