### PR TITLE
Remote-safe: traditional automation read & log tools

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
@@ -21,6 +21,7 @@ from pipefy_mcp.tools.automation_tool_helpers import (
 )
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import enrich_permission_denied_error
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import (
     mutation_error_if_not_optional_dict,
@@ -46,6 +47,7 @@ class AutomationTools:
     def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            meta=REMOTE,
         )
         async def get_automation(
             ctx: Context, automation_id: PipefyId
@@ -90,6 +92,7 @@ class AutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            meta=REMOTE,
         )
         async def get_automations(
             ctx: Context,
@@ -145,6 +148,7 @@ class AutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            meta=REMOTE,
         )
         async def get_automation_actions(
             ctx: Context,
@@ -189,6 +193,7 @@ class AutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            meta=REMOTE,
         )
         async def get_automation_events(
             ctx: Context, pipe_id: PipefyId
@@ -223,6 +228,7 @@ class AutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+            meta=REMOTE,
         )
         async def get_automation_event_attributes(ctx: Context) -> dict[str, Any]:
             """List the official **event-scoped** ``field_map.value`` token catalog.

--- a/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
@@ -162,6 +162,7 @@ class ObservabilityTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_automation_logs(
             automation_id: PipefyId,
@@ -213,6 +214,7 @@ class ObservabilityTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_automation_logs_by_repo(
             repo_id: PipefyId,
@@ -319,6 +321,7 @@ class ObservabilityTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_automations_usage(
             organization_uuid: PipefyId,
@@ -417,6 +420,7 @@ class ObservabilityTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_automation_execution_metrics(
             organization_id: PipefyId,
@@ -562,6 +566,7 @@ class ObservabilityTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_automation_jobs_export(
             export_id: PipefyId,
@@ -595,6 +600,7 @@ class ObservabilityTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_automation_jobs_export_csv(
             export_id: PipefyId,

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -65,6 +65,21 @@ REMOTE_SEED = frozenset(
         "get_llm_provider_dependencies",
         "get_default_llm_provider",
         "validate_llm_provider_access",
+        # traditional automation reads (#439): read/log tools that reach the API
+        # with the request-scoped bearer and are governed by API permissions; no
+        # filesystem or per-user process-global settings reads. The export CSV
+        # tool downloads in-memory (no local file) with per-call size caps.
+        "get_automation",
+        "get_automations",
+        "get_automation_actions",
+        "get_automation_events",
+        "get_automation_event_attributes",
+        "get_automation_execution_metrics",
+        "get_automation_logs",
+        "get_automation_logs_by_repo",
+        "get_automations_usage",
+        "get_automation_jobs_export",
+        "get_automation_jobs_export_csv",
     }
 )
 


### PR DESCRIPTION
Closes #439. Part of migrating the default-deny remote profile to expose the read tools that meet the remote-safe criteria (milestone: Hosted-safe tool surface). Stacked on `rc-dev/feat/remote-safe-kb-provider-reads`.

## Motivation

Under `--profile remote` the server exposes only tools carrying `meta=REMOTE` (tracked by `REMOTE_SEED`); many pure read tools that reach the API with the request-scoped bearer and are fully governed by API permissions were still withheld. This exposes the traditional automation read, log, and job-export status surface.

## Outcome

Marks 11 automation read/log tools remote-safe: `get_automation`, `get_automations`, `get_automation_actions`, `get_automation_events`, `get_automation_event_attributes`, `get_automation_execution_metrics`, `get_automation_logs`, `get_automation_logs_by_repo`, `get_automations_usage`, `get_automation_jobs_export`, `get_automation_jobs_export_csv`. Of the two export tools, `get_automation_jobs_export` is a GraphQL status poller returning `status`/`fileUrl` (no download), and `get_automation_jobs_export_csv` downloads in-memory with a per-call size cap; neither writes a local file nor reads a per-user process-global setting. Each tool carries `meta=REMOTE` and a matching `REMOTE_SEED` entry; the drift-guard test keeps the two in lockstep. No new tools, no behavior change under the local profile.

## Remote-profile validation

The remote-safe read migration (this PR is part of the stack #437→#441) was verified end-to-end by running the code in `--profile remote --transport http` locally — behaving as a deployed instance — and connecting an MCP HTTP client with a valid RS256 Keycloak bearer. Measured on an integration branch that also carried the in-flight provider-write work (#434), so the withheld count includes those write tools:

| # | Scenario | Observed | Verdict |
|---|---|---|---|
| 1 | Server in `--profile remote --transport http` | `exposed 76, withheld 106` (default-deny) | ✅ |
| 2 | Unauthenticated request | `401` (bearer required) | ✅ |
| 3 | `tools/list` with a valid RS256 bearer | exactly the 76 remote-safe tools | ✅ |
| 4 | Remote-safe reads present | `get_organization`, `get_pipe`, `get_llm_providers`, `get_ai_agents` | ✅ |
| 5 | Writes / local-file / raw GraphQL withheld | `create_card`, `create_llm_provider`, `delete_card`, `upload_attachment_to_card`, `execute_graphql` absent — 0 leaked | ✅ |
| 6 | Live authenticated tool call (per-request bearer → outbound) | `get_organization` executed (`isError=false`) | ✅ |

The 76 remote-safe tools are the 23 pre-existing plus the 53 read tools this migration set (#437–#441) adds. Registration-time filtering is also covered by the `test_remote_profile.py` drift-guard and `test_on_exposes_seed_and_withholds_the_rest`.

