### PR TITLE
Remote-safe: report read tools

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/report_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/report_tools.py
@@ -18,6 +18,7 @@ from pipefy_mcp.tools.pagination_helpers import (
     build_pagination_info,
     validate_page_size,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.report_tool_helpers import (
     build_report_error_payload,
     build_report_mutation_success_payload,
@@ -42,6 +43,7 @@ class ReportTools:
     def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_pipe_reports(
             pipe_uuid: str,
@@ -104,6 +106,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_pipe_report(
             ctx: Context[ServerSession, None],
@@ -162,6 +165,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_pipe_report_columns(
             pipe_uuid: str,
@@ -198,6 +202,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_pipe_report_filterable_fields(
             pipe_uuid: str,
@@ -233,6 +238,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_organization_report(
             report_id: PipefyId,
@@ -266,6 +272,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_organization_reports(
             organization_id: PipefyId,
@@ -317,6 +324,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_pipe_report_export(
             export_id: PipefyId,
@@ -350,6 +358,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_organization_report_export(
             export_id: PipefyId,

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -80,6 +80,18 @@ REMOTE_SEED = frozenset(
         "get_automations_usage",
         "get_automation_jobs_export",
         "get_automation_jobs_export_csv",
+        # report reads (#440): read/status tools that reach the API with the
+        # request-scoped bearer and are governed by API permissions; no filesystem
+        # or per-user process-global settings reads. The export tools poll export
+        # status (a GraphQL query returning a fileURL string), not a local write.
+        "get_organization_report",
+        "get_organization_reports",
+        "get_organization_report_export",
+        "get_pipe_report",
+        "get_pipe_reports",
+        "get_pipe_report_columns",
+        "get_pipe_report_filterable_fields",
+        "get_pipe_report_export",
     }
 )
 


### PR DESCRIPTION
Closes #440. Part of migrating the default-deny remote profile to expose the read tools that meet the remote-safe criteria (milestone: Hosted-safe tool surface). Stacked on `rc-dev/feat/remote-safe-automation-reads`.

## Motivation

Under `--profile remote` the server exposes only tools carrying `meta=REMOTE` (tracked by `REMOTE_SEED`); many pure read tools that reach the API with the request-scoped bearer and are fully governed by API permissions were still withheld. This exposes the pipe and organization report discovery/status reads.

## Outcome

Marks 8 report read tools remote-safe: `get_organization_report`, `get_organization_reports`, `get_organization_report_export`, `get_pipe_report`, `get_pipe_reports`, `get_pipe_report_columns`, `get_pipe_report_filterable_fields`, `get_pipe_report_export`. The `*_export` tools are status pollers returning a fileURL string (no in-tool download / local write). Each tool carries `meta=REMOTE` and a matching `REMOTE_SEED` entry; the drift-guard test keeps the two in lockstep. No new tools, no behavior change under the local profile.

## Remote-profile validation

The remote-safe read migration (this PR is part of the stack #437→#441) was verified end-to-end by running the code in `--profile remote --transport http` locally — behaving as a deployed instance — and connecting an MCP HTTP client with a valid RS256 Keycloak bearer. Measured on an integration branch that also carried the in-flight provider-write work (#434), so the withheld count includes those write tools:

| # | Scenario | Observed | Verdict |
|---|---|---|---|
| 1 | Server in `--profile remote --transport http` | `exposed 76, withheld 106` (default-deny) | ✅ |
| 2 | Unauthenticated request | `401` (bearer required) | ✅ |
| 3 | `tools/list` with a valid RS256 bearer | exactly the 76 remote-safe tools | ✅ |
| 4 | Remote-safe reads present | `get_organization`, `get_pipe`, `get_llm_providers`, `get_ai_agents` | ✅ |
| 5 | Writes / local-file / raw GraphQL withheld | `create_card`, `create_llm_provider`, `delete_card`, `upload_attachment_to_card`, `execute_graphql` absent — 0 leaked | ✅ |
| 6 | Live authenticated tool call (per-request bearer → outbound) | `get_organization` executed (`isError=false`) | ✅ |

The 76 remote-safe tools are the 23 pre-existing plus the 53 read tools this migration set (#437–#441) adds. Registration-time filtering is also covered by the `test_remote_profile.py` drift-guard and `test_on_exposes_seed_and_withholds_the_rest`.
