### PR TITLE
Remote-safe: pipe/card/field/member/webhook/portal read tools

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/field_condition_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/field_condition_tools.py
@@ -18,6 +18,7 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
     field_condition_actions_error_message,
     handle_pipe_config_tool_graphql_error,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import (
     validate_tool_id,
@@ -48,6 +49,7 @@ class FieldConditionTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_field_conditions(
             ctx: Context[ServerSession, None],
@@ -104,6 +106,7 @@ class FieldConditionTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_field_condition(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -370,6 +370,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_phase_allowed_move_targets(
             phase_id: PipefyId,
@@ -423,6 +424,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_phase_cards_count(
             phase_id: PipefyId,

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -326,6 +326,7 @@ class PipeTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_card_relations(
             ctx: Context[ServerSession, None],
@@ -774,6 +775,7 @@ class PipeTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_labels(
             ctx: Context[ServerSession, None],
@@ -827,6 +829,7 @@ class PipeTools:
             annotations=ToolAnnotations(
                 readOnlyHint=True,
             ),
+            meta=REMOTE,
         )
         async def get_pipe_members(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/src/pipefy_mcp/tools/portal_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/portal_tools.py
@@ -32,6 +32,7 @@ from pipefy_mcp.tools.portal_tool_helpers import (
     validate_sort_page_ids_no_duplicates,
     validate_tool_ids,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
@@ -45,6 +46,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def list_portals(
             ctx: Context[ServerSession, None],
@@ -84,6 +86,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_portal(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/src/pipefy_mcp/tools/relation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/relation_tools.py
@@ -16,6 +16,7 @@ from pipefy_mcp.tools.relation_tool_helpers import (
     build_relation_read_success_payload,
     handle_relation_tool_graphql_error,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import (
     mutation_error_if_not_optional_dict,
@@ -30,6 +31,7 @@ class RelationTools:
     def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_pipe_relations(pipe_id: PipefyId, ctx: Context) -> dict[str, Any]:
             """List pipe relations for a pipe (parent and child links, config, and repo refs).
@@ -61,6 +63,7 @@ class RelationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_table_relations(
             relation_ids: list[PipefyId], ctx: Context

--- a/packages/mcp/src/pipefy_mcp/tools/webhook_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/webhook_tools.py
@@ -10,6 +10,7 @@ from mcp.types import ToolAnnotations
 from pipefy_sdk import PipefyId
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import (
     mutation_error_if_not_optional_dict,
@@ -29,6 +30,7 @@ class WebhookTools:
     def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_email_templates(
             repo_id: PipefyId,
@@ -73,6 +75,7 @@ class WebhookTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_card_inbox_emails(
             card_id: PipefyId,
@@ -268,6 +271,7 @@ class WebhookTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
         )
         async def get_webhooks(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -92,6 +92,25 @@ REMOTE_SEED = frozenset(
         "get_pipe_report_columns",
         "get_pipe_report_filterable_fields",
         "get_pipe_report_export",
+        # pipe / card / field / member / webhook / portal reads (#441): read tools
+        # that reach the API with the request-scoped bearer and are governed by API
+        # permissions; no filesystem or per-user process-global settings reads. The
+        # relation reads may hit Pipefy's Internal API, which receives whatever
+        # credential the caller already carries (nothing service-account-specific).
+        "get_card_relations",
+        "get_card_inbox_emails",
+        "get_field_condition",
+        "get_field_conditions",
+        "get_labels",
+        "get_pipe_members",
+        "get_pipe_relations",
+        "get_phase_allowed_move_targets",
+        "get_phase_cards_count",
+        "get_table_relations",
+        "get_webhooks",
+        "get_email_templates",
+        "get_portal",
+        "list_portals",
     }
 )
 

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -95,8 +95,9 @@ REMOTE_SEED = frozenset(
         # pipe / card / field / member / webhook / portal reads (#441): read tools
         # that reach the API with the request-scoped bearer and are governed by API
         # permissions; no filesystem or per-user process-global settings reads. The
-        # relation reads may hit Pipefy's Internal API, which receives whatever
-        # credential the caller already carries (nothing service-account-specific).
+        # relation reads use the public GraphQL API only and the portal reads use
+        # the Interfaces schema; Pipefy's Internal API is reached only by mutations
+        # such as delete_card_relation, which stay withheld.
         "get_card_relations",
         "get_card_inbox_emails",
         "get_field_condition",


### PR DESCRIPTION
Closes #441. Part of migrating the default-deny remote profile to expose the read tools that meet the remote-safe criteria (milestone: Hosted-safe tool surface). Stacked on `rc-dev/feat/remote-safe-report-reads`.

## Motivation

Under `--profile remote` the server exposes only tools carrying `meta=REMOTE` (tracked by `REMOTE_SEED`); many pure read tools that reach the API with the request-scoped bearer and are fully governed by API permissions were still withheld. This exposes the remaining core relation/config/membership/portal reads.

## Outcome

Marks 14 read tools remote-safe: `get_card_relations`, `get_card_inbox_emails`, `get_field_condition`, `get_field_conditions`, `get_labels`, `get_pipe_members`, `get_pipe_relations`, `get_phase_allowed_move_targets`, `get_phase_cards_count`, `get_table_relations`, `get_webhooks`, `get_email_templates`, `get_portal`, `list_portals`. Each tool carries `meta=REMOTE` and a matching `REMOTE_SEED` entry; the drift-guard test keeps the two in lockstep. No new tools, no behavior change under the local profile.

## Remote-profile validation

The remote-safe read migration (this PR is part of the stack #437→#441) was verified end-to-end by running the code in `--profile remote --transport http` locally — behaving as a deployed instance — and connecting an MCP HTTP client with a valid RS256 Keycloak bearer. Measured on an integration branch that also carried the in-flight provider-write work (#434), so the withheld count includes those write tools:

| # | Scenario | Observed | Verdict |
|---|---|---|---|
| 1 | Server in `--profile remote --transport http` | `exposed 76, withheld 106` (default-deny) | ✅ |
| 2 | Unauthenticated request | `401` (bearer required) | ✅ |
| 3 | `tools/list` with a valid RS256 bearer | exactly the 76 remote-safe tools | ✅ |
| 4 | Remote-safe reads present | `get_organization`, `get_pipe`, `get_llm_providers`, `get_ai_agents` | ✅ |
| 5 | Writes / local-file / raw GraphQL withheld | `create_card`, `create_llm_provider`, `delete_card`, `upload_attachment_to_card`, `execute_graphql` absent — 0 leaked | ✅ |
| 6 | Live authenticated tool call (per-request bearer → outbound) | `get_organization` executed (`isError=false`) | ✅ |

The 76 remote-safe tools are the 23 pre-existing plus the 53 read tools this migration set (#437–#441) adds. Registration-time filtering is also covered by the `test_remote_profile.py` drift-guard and `test_on_exposes_seed_and_withholds_the_rest`.
