### PR TITLE
docs: document create_phase index semantics

### DIFF
--- a/docs/mcp/tools/pipes-and-cards.md
+++ b/docs/mcp/tools/pipes-and-cards.md
@@ -47,7 +47,7 @@ Pipefy’s GraphQL API uses **string** IDs for pipes, phases, cards, and most ot
 | Group | Tools | Notes |
 |-------|-------|-------|
 | Pipe | `create_pipe`, `update_pipe`, `delete_pipe`, `clone_pipe` | `delete_pipe`: two-step — preview first, then `confirm=true`. |
-| Phase | `create_phase`, `update_phase`, `delete_phase` | Destructive deletes: confirm with the user. |
+| Phase | `create_phase`, `update_phase`, `delete_phase` | `create_phase` `index`: 1-based insert among `get_pipe` workflow phases; omit to append. Prefer `1+` (not `0`). Index sets order only - not Connections / `allowed_phases` (UI-only). Destructive deletes: confirm with the user. |
 | Phase transitions | `get_phase_allowed_move_targets` | Read-only; mirrors **Phase → Connections** (`cards_can_be_moved_to_phases`). Call before `move_card_to_phase`. Edges are configured in the Pipefy UI only. |
 | Phase field | `create_phase_field`, `update_phase_field`, `delete_phase_field` | `field_type` maps to API `type`; `field_id` may be a slug or numeric ID. |
 | Label | `create_label`, `update_label`, `delete_label` | `color` must be a hex string (e.g. `#FF0000`), not a name. |

--- a/packages/cli/src/pipefy_cli/commands/phase.py
+++ b/packages/cli/src/pipefy_cli/commands/phase.py
@@ -154,7 +154,10 @@ def phase_create(
     index: float | None = typer.Option(
         None,
         "--index",
-        help="Optional position index within the pipe.",
+        help=(
+            "1-based insert among workflow phases; omit to append. "
+            "Does not set Connections (UI-only)."
+        ),
     ),
     description: str | None = typer.Option(None, "--description", "-d"),
     json_out: bool = typer.Option(False, "--json", "-j"),

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -2272,7 +2272,9 @@ Usage: pipefy phase create [OPTIONS]
 │                                  [required]                                  │
 │ *  --name         -n      TEXT   Phase display name. [required]              │
 │    --done                        Mark as a final/done phase.                 │
-│    --index                FLOAT  Optional position index within the pipe.    │
+│    --index                FLOAT  1-based insert among workflow phases; omit  │
+│                                  to append. Does not set Connections         │
+│                                  (UI-only).                                  │
 │    --description  -d      TEXT                                               │
 │    --json         -j                                                         │
 │    --help                        Show this message and exit.                 │

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -567,7 +567,13 @@ class PipeConfigTools:
                 pipe_id: Pipe that will contain the phase.
                 name: Phase name.
                 done: When True, marks a final/done phase.
-                index: Optional position index within the pipe.
+                index: Optional 1-based insert position among workflow phases
+                    returned by ``get_pipe``. Omit to append after existing
+                    phases. Prefer ``1`` or higher for normal layout; ``0``
+                    creates a phase that does not appear in ``get_pipe``'s
+                    ``phases`` list. Index only sets order - it does not
+                    configure Phase Connections / ``allowed_phases`` (UI-only);
+                    call ``get_phase_allowed_move_targets`` before moves.
                 description: Optional phase description.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """

--- a/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
+++ b/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
@@ -42,7 +42,7 @@ Read, create, update, and delete pipes, phases, phase fields, labels, cards, att
 
    CLI: `pipefy pipe create --name "Customer Onboarding" --org 123`
 
-2. **Add phases** — call `create_phase` for each phase (see Phase section below).
+2. **Add phases** — call `create_phase` for each phase (see Phase section below). Omit `index` to append after existing workflow phases, or pass a **1-based** `index` to insert among phases returned by `get_pipe`. Prefer `1` or higher; `index: 0` creates a phase that does not appear in `get_pipe`'s `phases` list. `index` only controls order — it does **not** wire Phase Connections / `allowed_phases` (configure those in the Pipefy UI; use `get_phase_allowed_move_targets` before moves).
 
 3. **Add start form fields** — call `create_phase_field` on the start form phase.
 


### PR DESCRIPTION
## Summary
- Documents `create_phase` `index` at the point of use (MCP docstring, CLI `--index` help, pipes-and-cards docs + skill).
- Semantics confirmed with a live smoke: omit appends; workflow positions are **1-based**; `index: 0` creates a phase that does not appear in `get_pipe`'s `phases` list; `index` does not configure Connections / `allowed_phases` (UI-only).

Closes #391.

## Test plan
- [x] `uv run pytest packages/cli/tests -q -k "help or phase_create" -m "not integration"`
- [x] Regenerated `cli_help_golden.txt` via `PIPEFY_UPDATE_CLI_HELP_GOLDEN=1`
- [x] Live MCP smoke: create pipe → omit / `0` / `1` → inspect phase order → delete smoke pipe
- [ ] Reviewer: skim MCP `create_phase` Args and skill step 2 for agent clarity