### PR TITLE
fix(sdk): return condition from get_automation

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
@@ -53,9 +53,11 @@ class AutomationTools:
             """Load one automation rule by ID, including trigger and action payloads.
 
             Use this to inspect or debug a specific rule, or before ``update_automation`` /
-            ``delete_automation``. Returned ``event_params`` and ``action_params`` (e.g.
-            ``aiParams`` with ``value`` / ``fieldIds`` / ``skillsIds``) align with
-            ``simulate_automation`` and ``create_automation`` inputs. For new rules, discover
+            ``delete_automation``. Returned ``event_params``, ``action_params`` (e.g.
+            ``aiParams`` with ``value`` / ``fieldIds`` / ``skillsIds``), and ``condition``
+            align with ``simulate_automation`` and ``create_automation`` inputs. A
+            ``condition`` with empty ``field_address`` / ``operation`` / ``value`` is the
+            API placeholder (no real filter), not a missing field. For new rules, discover
             ``event_id`` / ``action_id`` via ``get_automation_events`` and ``get_automation_actions``
             on the target pipe, then call ``create_automation``.
 

--- a/packages/mcp/tests/tools/test_automation_tools.py
+++ b/packages/mcp/tests/tools/test_automation_tools.py
@@ -64,6 +64,19 @@ async def test_get_automation_success(
         "action_params": {
             "aiParams": {"value": "Run prompt", "fieldIds": ["1"], "skillsIds": []},
         },
+        "condition": {
+            "id": "c1",
+            "expressions": [
+                {
+                    "id": "e1",
+                    "structure_id": "0",
+                    "field_address": "900000101",
+                    "operation": "equals",
+                    "value": "yes",
+                }
+            ],
+            "expressions_structure": [[0]],
+        },
     }
 
     async with automation_session as session:
@@ -76,6 +89,7 @@ async def test_get_automation_success(
     assert payload["data"] == mock_automation_client.get_automation.return_value
     assert payload["data"]["event_params"]["kindOfSla"] == "due_date"
     assert payload["data"]["action_params"]["aiParams"]["value"] == "Run prompt"
+    assert payload["data"]["condition"]["expressions"][0]["operation"] == "equals"
 
 
 @pytest.mark.anyio

--- a/packages/sdk/src/pipefy_sdk/queries/automation_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/automation_queries.py
@@ -123,6 +123,17 @@ GET_AUTOMATION_QUERY = gql(
                 to_phase_id
                 url
             }
+            condition {
+                id
+                expressions {
+                    id
+                    structure_id
+                    field_address
+                    operation
+                    value
+                }
+                expressions_structure
+            }
         }
     }
     """

--- a/packages/sdk/src/pipefy_sdk/services/automation_graphql_types.py
+++ b/packages/sdk/src/pipefy_sdk/services/automation_graphql_types.py
@@ -125,6 +125,24 @@ class AutomationActionParamsRecord(TypedDict, total=False):
     url: str | None
 
 
+class AutomationConditionExpressionRecord(TypedDict, total=False):
+    """One expression under ``Automation.condition``."""
+
+    id: str
+    structure_id: str | None
+    field_address: str | None
+    operation: str | None
+    value: str | None
+
+
+class AutomationConditionRecord(TypedDict, total=False):
+    """``condition`` on ``Automation`` (query-selected fields; no ``related_cards``)."""
+
+    id: str
+    expressions: list[AutomationConditionExpressionRecord] | None
+    expressions_structure: list[Any] | None
+
+
 class AutomationRuleRecord(TypedDict, total=False):
     """Single automation from ``GET_AUTOMATION_QUERY``."""
 
@@ -139,6 +157,7 @@ class AutomationRuleRecord(TypedDict, total=False):
     event_repo: AutomationEventRepoRef | None
     event_params: AutomationEventParamsRecord | None
     action_params: AutomationActionParamsRecord | None
+    condition: AutomationConditionRecord | None
 
 
 class AutomationRuleSummary(TypedDict, total=False):

--- a/packages/sdk/tests/services/pipefy/test_automation_service.py
+++ b/packages/sdk/tests/services/pipefy/test_automation_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 from _shared.mock_clients import mock_executor
 from gql.transport.exceptions import TransportQueryError
+from graphql import print_ast
 
 from pipefy_sdk.queries.automation_queries import (
     AUTOMATION_SIMULATION_QUERY,
@@ -136,6 +137,19 @@ async def test_get_automation_success():
             "email_template_id": "tmpl-1",
             "to_phase_id": "ph2",
         },
+        "condition": {
+            "id": "cond-1",
+            "expressions": [
+                {
+                    "id": "expr-1",
+                    "structure_id": "0",
+                    "field_address": "900000101",
+                    "operation": "equals",
+                    "value": "approved",
+                }
+            ],
+            "expressions_structure": [[0]],
+        },
     }
     service, executor = _make_service({"automation": automation})
     result = await service.get_automation("101")
@@ -143,6 +157,7 @@ async def test_get_automation_success():
     executor.execute_query.assert_awaited_once()
     query, variables = executor.execute_query.call_args[0]
     assert query is GET_AUTOMATION_QUERY
+    assert "condition" in print_ast(GET_AUTOMATION_QUERY.document)
     assert variables == {"id": "101"}
     assert result["id"] == "a1"
     assert result["name"] == "Notify assignee"
@@ -150,6 +165,9 @@ async def test_get_automation_success():
     assert result["event_params"]["triggerFieldIds"] == ["f1", "f2"]
     assert result["action_params"]["aiParams"]["value"] == "Summarize card"
     assert result["action_params"]["aiParams"]["fieldIds"] == ["10"]
+    assert result["condition"]["id"] == "cond-1"
+    assert result["condition"]["expressions"][0]["operation"] == "equals"
+    assert result["condition"]["expressions_structure"] == [[0]]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Adds `condition { id expressions { … } expressions_structure }` to `GET_AUTOMATION_QUERY` and `AutomationRuleRecord`.
- MCP/CLI/AI `get_*` already passthrough the SDK row; docstring notes empty placeholder vs missing field.
- List tools stay summary-only.

Closes #386.

## Test plan
- [x] `uv run pytest packages/sdk/tests/services/pipefy/test_automation_service.py packages/mcp/tests/tools/test_automation_tools.py -q -m "not integration"` (96 passed)
- [x] Live smoke: create send-task automation with condition → `uv run pipefy automation get <id> --json` returns `condition` → delete
- [x] Same selection verified via `execute_graphql` against live API