### PR TITLE
Add release orchestrator CLI for the publish flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ RALPH_TASK.md
 # Tracked release tooling only (ignore ad-hoc local scripts and smoke artifacts)
 scripts/*
 !scripts/bump_version.py
+!scripts/release.py
 
 # macOS
 .DS_Store

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,49 +12,29 @@ The next **GitHub pre-release** after the standalone repo’s [`v0.1.0-beta.1`](
 
 The Release workflow requires the git tag (without leading `v`) to **exactly match** `__version__` in `packages/sdk/src/pipefy_sdk/__init__.py` (and the MCP/CLI/Auth/Infra copies). For example tag **`v0.2.0-beta.1`** implies **`__version__ = "0.2.0-beta.1"`** in all five packages before you push the tag (set via step 2 below using `version=0.2.0-beta.1`, or edit the five `__init__.py` files together).
 
+`scripts/release.py` drives the whole flow as two subcommands split at the irreversible boundary — everything before the tag push is local and reversible, so you review the commit before anything leaves your machine.
+
 1. Merge work to `main` and ensure `CHANGELOG.md` has everything under `## [Unreleased]`.
-2. Bump the shared version (updates all five `__init__.py` files):
+2. Prepare the release. This bumps the shared version across every version-bearing file (via `scripts/bump_version.py`), stamps the `## [Unreleased]` CHANGELOG heading with the new version and today's date, re-seeds an empty `## [Unreleased]`, and commits — all locally:
 
    ```bash
-   uv run python scripts/bump_version.py patch
+   uv run python scripts/release.py prepare patch
    ```
 
-   Supported arguments: `major`, `minor`, `patch`, `prerelease`, or `version=X.Y.Z` (optional `v` prefix on `X.Y.Z`).
+   The bump argument accepts `major`, `minor`, `patch`, `prerelease`, or `version=X.Y.Z` (optional `v` prefix on `X.Y.Z`). `prepare` prints the computed target (`Will bump 0.3.0-beta.1 -> 0.3.0-beta.2 and cut tag v0.3.0-beta.2. Proceed?`) and waits for confirmation before touching any file, so a wrong bump costs nothing to walk away from (`--yes` skips the prompt for automation). Note `prerelease` only increments the current pre-release track (`beta.1 -> beta.2`) and never promotes across tracks; to go `alpha.N -> beta.1`, or to a **`v0.2.0-beta.*`** tag, or to any exact string, pass `version=X.Y.Z` with the PEP-440 form (for example `version=0.2.0-beta.1`) so it matches `GITHUB_REF_NAME` without the leading `v`.
 
-   For a **`v0.2.0-beta.*`** Git tag, pass the exact PEP-440 string (for example `version=0.2.0-beta.1`) so it matches `GITHUB_REF_NAME` without the leading `v`.
-
-3. In `CHANGELOG.md`, replace the `## [Unreleased]` heading with `## [X.Y.Z] - YYYY-MM-DD` matching the new version and date (the Release workflow uses this section as the GitHub Release notes body).
-4. Commit:
+3. Review the release commit (`git show HEAD`). Nothing has been pushed yet.
+4. Publish. This tags `vX.Y.Z`, pushes `main` and the tag, waits for the **Release** workflow (`.github/workflows/release.yml`), then verifies the result:
 
    ```bash
-   git add -A && git commit -m "chore: release vX.Y.Z"
+   uv run python scripts/release.py publish
    ```
 
-5. Tag and push:
-
-   ```bash
-   git tag vX.Y.Z && git push origin main && git push origin vX.Y.Z
-   ```
-
-6. Wait for the **Release** workflow (`.github/workflows/release.yml`) to finish.
-7. Confirm the GitHub Release lists the built wheels (`pipefy_cli-*.whl`, `pipefy_mcp_server-*.whl`, `pipefy-*.whl`, `pipefy_auth-*.whl`, and `pipefy_infra-*.whl`). Optionally verify the published version installs from PyPI (use the PEP 440 form, e.g. `0.2.0b1`, not the `v0.2.0-beta.1` git tag):
-
-   ```bash
-   uvx --from "pipefy-cli==0.2.0b1" pipefy --version
-   ```
-
-   Sanity-check that the curl installer on `main` resolves the just-cut tag (no per-release maintenance needed; it hits the GitHub API at runtime):
-
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/<owner>/<repo>/main/install.sh \
-     | sh -s -- --yes --no-skills --client none --dry-run
-   ```
-
-   Output should include `Resolved tag: vX.Y.Z` (right after `Resolving latest release from GitHub...`).
+   `publish` asks for one confirmation before the irreversible tag push (pass `--yes` to skip it in automation). Once the workflow finishes it asserts, and fails loudly on any gap, that the GitHub Release ships all five wheels (`pipefy-*.whl`, `pipefy_mcp_server-*.whl`, `pipefy_cli-*.whl`, `pipefy_auth-*.whl`, `pipefy_infra-*.whl`), that the published version installs from PyPI (`uvx --from "pipefy-cli==<PEP 440>" pipefy --version`), and that the `install.sh` dry-run resolves the just-cut tag (`Resolved tag: vX.Y.Z`). Re-run those checks any time with `uv run python scripts/release.py verify vX.Y.Z`.
 
 ## Verification (cross-platform smoke test)
 
-After tagging a release, run the following on macOS and a Linux machine (or CI runner) to confirm the wheels install correctly. Pin the **PyPI/PEP 440** version (e.g. `0.2.0b1`), which differs from the `v0.2.0-beta.1` git tag:
+`release.py publish` verifies on the machine it runs on. To confirm the wheels also install on the other platform, run the following on macOS and a Linux machine (or CI runner). Pin the **PyPI/PEP 440** version (e.g. `0.2.0b1`), which differs from the `v0.2.0-beta.1` git tag:
 
 ```bash
 # Install CLI from PyPI at the just-published version
@@ -88,6 +68,7 @@ Same steps as above. PyPI publishing already runs on every tag; a **`v1.`** tag 
 
 | Piece | Role |
 | --- | --- |
+| `scripts/release.py` | Guided release CLI. `prepare <bump>` runs `bump_version.py`, stamps the `CHANGELOG.md` `## [Unreleased]` heading, and commits (all local, reversible). `publish` tags, pushes, watches the Release workflow, then verifies. `verify <tag>` re-runs the post-publish checks (all five wheels on the GitHub Release, PyPI install resolves, `install.sh` dry-run resolves the tag). It shells out to `bump_version.py` for the transform rather than reimplementing it. |
 | `scripts/bump_version.py` | Reads the SDK `__version__`, applies the bump, writes the same value to SDK, MCP, CLI, Auth, and Infra `__init__.py`, the root `pyproject.toml`'s `[project].version`, the `.claude-plugin/plugin.json` `version`, and each published package's sibling `==` pins, then runs `uv lock` to refresh `uv.lock`. Also exposes a `verify` mode that asserts every version-bearing file agrees. |
 | `.github/workflows/ci.yml` | Invokes `scripts/bump_version.py verify` to assert that all version-bearing files match: the five `__version__` strings, the root `pyproject.toml` `[project].version`, `uv.lock`, the `.claude-plugin/plugin.json` `version`, and the sibling `==` pins in each published package's `pyproject.toml`. |
 | `.github/workflows/release.yml` | On `v*` tags: asserts the tag matches SDK `__version__`, extracts the matching `CHANGELOG.md` section as the GitHub Release body, builds wheels and sdists with `uv build --all-packages -o dist --wheel --sdist`, guards that `dist/` holds exactly five wheels (one per workspace member) so a sixth member cannot ship unnoticed, attaches wheels to the GitHub Release, and uploads all five wheels to PyPI via Trusted Publishing on every `v*` tag. |

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Release orchestrator: run the steps in RELEASE.md as one guided CLI.
+
+The release has a single natural fault line: ``git push origin <tag>`` triggers
+PyPI publishing, which cannot be undone. Everything before it is local and
+reversible; everything after is read-only verification. So this tool is two
+subcommands with a review gate between them:
+
+* ``prepare`` — bump the version, stamp CHANGELOG, commit. All local; nothing
+  has left the machine. It stops and tells you to review the commit.
+* ``publish`` — tag, push, watch the Release workflow, then verify. Asks for
+  one explicit confirmation before the irreversible push.
+
+The version transform itself is NOT reimplemented here: ``bump_version.py``
+stays the sole owner of which files carry the version and how they are
+rewritten (it is pure, offline, and separately tested). This orchestrator
+shells out to it for the bump and imports it only for read-only lookups.
+
+Verification (also runnable on its own via ``verify <tag>``) asserts the three
+things RELEASE.md tells you to check by hand, so none of them can be forgotten:
+the GitHub Release ships all five wheels, the published version installs from
+PyPI, and the ``install.sh`` dry-run resolves the just-cut tag.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# bump_version is the version-transform engine; import it for pure reads and
+# shell out to it for the mutating bump so it stays the single source of truth.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bump_version  # noqa: E402
+
+REPO_ROOT = bump_version.REPO_ROOT
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+# Filename stems of the five wheels every release must attach (order-agnostic).
+EXPECTED_WHEEL_STEMS = (
+    "pipefy-",
+    "pipefy_mcp_server-",
+    "pipefy_cli-",
+    "pipefy_auth-",
+    "pipefy_infra-",
+)
+
+# The [Unreleased] section spans from its heading to the next "## [" heading
+# (or end of file). Group 1 is the heading line, group 2 the body between it
+# and the next version heading.
+UNRELEASED_RE = re.compile(
+    r"^(## \[Unreleased\][^\n]*\n)(.*?)(?=^## \[|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+class ReleaseError(RuntimeError):
+    """A release step failed in a way the operator must resolve."""
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Echo and run a command in the repo root, raising on non-zero exit."""
+    print(f"$ {' '.join(cmd)}")
+    return subprocess.run(cmd, cwd=REPO_ROOT, check=True, **kwargs)
+
+
+def capture(cmd: list[str]) -> str:
+    """Run a command in the repo root and return its stripped stdout."""
+    result = subprocess.run(
+        cmd, cwd=REPO_ROOT, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def pep440(version: str) -> str:
+    """Normalize a raw version string to its PyPI/PEP 440 form.
+
+    The git tag and ``__version__`` carry the SemVer-style string
+    (``0.2.0-beta.1``); PyPI stores the normalized form (``0.2.0b1``). Installs
+    must pin the latter, so verification derives it here rather than have the
+    operator translate it by hand.
+    """
+    from packaging.version import Version
+
+    return str(Version(version))
+
+
+# --- preflight ------------------------------------------------------------
+
+
+def current_branch() -> str:
+    return capture(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+
+
+def working_tree_clean() -> bool:
+    return capture(["git", "status", "--porcelain"]) == ""
+
+
+def unreleased_body() -> str:
+    """Return the text under ``## [Unreleased]``, or raise if the section is absent."""
+    m = UNRELEASED_RE.search(CHANGELOG.read_text(encoding="utf-8"))
+    if not m:
+        raise ReleaseError(f"No '## [Unreleased]' section found in {CHANGELOG}")
+    return m.group(2).strip()
+
+
+def preflight_prepare() -> None:
+    """Assert the repo is in a releasable state before mutating anything."""
+    branch = current_branch()
+    if branch != "main":
+        raise ReleaseError(f"Must release from 'main', on '{branch}'")
+    if not working_tree_clean():
+        raise ReleaseError("Working tree is dirty; commit or stash first")
+
+    run(["git", "fetch", "--quiet", "origin", "main"])
+    local = capture(["git", "rev-parse", "HEAD"])
+    remote = capture(["git", "rev-parse", "origin/main"])
+    if local != remote:
+        raise ReleaseError(
+            "Local 'main' differs from 'origin/main'; pull/push so they match "
+            "before cutting a release"
+        )
+
+    if not unreleased_body():
+        raise ReleaseError(
+            "'## [Unreleased]' in CHANGELOG.md is empty; add release notes first"
+        )
+
+
+# --- prepare ---------------------------------------------------------------
+
+
+def stamp_changelog(version: str) -> None:
+    """Rename ``## [Unreleased]`` to the dated version heading, re-seeding Unreleased.
+
+    Follows Keep a Changelog: the accumulated notes become the released
+    version's section, and a fresh empty ``## [Unreleased]`` is left on top for
+    the next cycle (which ``preflight_prepare`` then requires to be non-empty).
+    """
+    today = datetime.date.today().isoformat()
+    text = CHANGELOG.read_text(encoding="utf-8")
+    new_heading = f"## [Unreleased]\n\n## [{version}] - {today}\n"
+    new_text, count = UNRELEASED_RE.subn(rf"{new_heading}\2", text, count=1)
+    if count != 1:
+        raise ReleaseError(f"Expected one '## [Unreleased]' heading in {CHANGELOG}")
+    CHANGELOG.write_text(new_text, encoding="utf-8")
+
+
+def compute_target_version(bump_arg: str) -> tuple[str, str]:
+    """Resolve ``(current, target)`` for a bump argument without mutating anything.
+
+    Uses ``bump_version``'s own bump functions so the version previewed here is
+    exactly what the bump will write. Lets ``prepare`` show the target and
+    confirm it before touching any file — catching a wrong bump (e.g. expecting
+    ``beta.1`` from ``prerelease``, which only increments the current track)
+    while it is still a no-op to walk away.
+    """
+    current = bump_version.read_sdk_version()
+    if bump_arg.lower().startswith("version="):
+        return current, bump_version.parse_explicit_version(bump_arg)
+    bumpers = {
+        "major": bump_version.bump_major,
+        "minor": bump_version.bump_minor,
+        "patch": bump_version.bump_patch,
+        "prerelease": bump_version.bump_prerelease,
+    }
+    if bump_arg not in bumpers:
+        raise ReleaseError(
+            f"Unknown bump {bump_arg!r}. Use major, minor, patch, prerelease, "
+            "or version=X.Y.Z"
+        )
+    return current, bumpers[bump_arg](current)
+
+
+def prepare(bump_arg: str, *, assume_yes: bool = False) -> str:
+    """Bump, stamp the CHANGELOG, and commit. Returns the new version string."""
+    preflight_prepare()
+
+    current, target = compute_target_version(bump_arg)
+    confirm(
+        f"Will bump {current} -> {target} and cut tag v{target}. Proceed?",
+        assume_yes=assume_yes,
+    )
+
+    # bump_version.py owns the transform; run its CLI so the file set and lock
+    # refresh live in exactly one place.
+    run(["uv", "run", "python", "scripts/bump_version.py", bump_arg])
+    version = bump_version.read_sdk_version()
+    if version != target:
+        raise ReleaseError(
+            f"bump_version wrote {version!r} but {target!r} was confirmed"
+        )
+
+    stamp_changelog(version)
+
+    run(["git", "add", "-A"])
+    run(["git", "commit", "-m", f"chore: release v{version}"])
+
+    print()
+    print(f"Prepared v{version}. Review the release commit:")
+    print("    git show HEAD")
+    print("Then publish with:")
+    print("    uv run python scripts/release.py publish")
+    return version
+
+
+# --- publish ---------------------------------------------------------------
+
+
+def confirm(prompt: str, *, assume_yes: bool) -> None:
+    """Gate an irreversible step; require --yes when there is no interactive TTY."""
+    if assume_yes:
+        return
+    if not sys.stdin.isatty():
+        raise ReleaseError(f"{prompt} Re-run with --yes to proceed non-interactively.")
+    if input(f"{prompt} [y/N] ").strip().lower() not in ("y", "yes"):
+        raise ReleaseError("Aborted by operator")
+
+
+def tag_exists(tag: str) -> bool:
+    remote = capture(["git", "ls-remote", "--tags", "origin", tag])
+    return bool(remote)
+
+
+# A tag push does not create the workflow run synchronously — GitHub registers
+# it a few seconds later — so the run lookup must poll rather than query once.
+_RUN_APPEAR_TIMEOUT_S = 90
+_RUN_POLL_INTERVAL_S = 3
+
+
+def _find_release_run_id(tag: str) -> str:
+    """Return the newest Release-workflow run id for ``tag``, or an empty string.
+
+    The Release workflow runs only on ``v*`` tag pushes, so its runs carry the
+    tag as ``headBranch``; filtering on ``headBranch == <tag>`` isolates this
+    release's run from any other tag's, and ``gh`` lists newest first so a
+    re-pushed tag resolves to its latest run.
+    """
+    runs = capture(
+        [
+            "gh",
+            "run",
+            "list",
+            "--workflow",
+            "Release",
+            "--event",
+            "push",
+            "--limit",
+            "20",
+            "--json",
+            "databaseId,headBranch",
+            "--jq",
+            f'.[] | select(.headBranch == "{tag}") | .databaseId',
+        ]
+    )
+    lines = runs.splitlines()
+    return lines[0] if lines else ""
+
+
+def watch_release_workflow(tag: str) -> None:
+    """Block until the Release workflow run for ``tag`` finishes, failing on failure.
+
+    Polls for the run to appear (the push does not create it synchronously)
+    before handing off to ``gh run watch``, which streams progress and exits
+    non-zero if the run fails.
+    """
+    print(f"Waiting for the Release workflow run for {tag} to appear...")
+    deadline = time.monotonic() + _RUN_APPEAR_TIMEOUT_S
+    run_id = _find_release_run_id(tag)
+    while not run_id and time.monotonic() < deadline:
+        time.sleep(_RUN_POLL_INTERVAL_S)
+        run_id = _find_release_run_id(tag)
+    if not run_id:
+        raise ReleaseError(
+            f"No Release workflow run appeared for {tag} within "
+            f"{_RUN_APPEAR_TIMEOUT_S}s. Check the Actions tab."
+        )
+    run(["gh", "run", "watch", run_id, "--exit-status"])
+
+
+def publish(*, assume_yes: bool) -> None:
+    """Tag, push, watch the workflow, then verify the published release."""
+    if current_branch() != "main":
+        raise ReleaseError("Must publish from 'main'")
+    if not working_tree_clean():
+        raise ReleaseError("Working tree is dirty; publish the exact reviewed commit")
+
+    version = bump_version.read_sdk_version()
+    tag = f"v{version}"
+    if tag_exists(tag):
+        raise ReleaseError(f"Tag {tag} already exists on origin")
+
+    confirm(
+        f"About to tag {tag}, push to origin, and publish to PyPI. "
+        "This cannot be undone.",
+        assume_yes=assume_yes,
+    )
+
+    run(["git", "tag", tag])
+    run(["git", "push", "origin", "main"])
+    run(["git", "push", "origin", tag])
+
+    watch_release_workflow(tag)
+    verify(tag)
+    print(f"\nReleased {tag}.")
+    print_release_links(tag, version)
+
+
+# --- verify ----------------------------------------------------------------
+
+
+def verify_github_wheels(tag: str) -> None:
+    """Assert the GitHub Release for ``tag`` attaches exactly the five expected wheels."""
+    names = capture(
+        ["gh", "release", "view", tag, "--json", "assets", "--jq", ".assets[].name"]
+    ).splitlines()
+    wheels = [n for n in names if n.endswith(".whl")]
+    missing = [
+        stem
+        for stem in EXPECTED_WHEEL_STEMS
+        if not any(w.startswith(stem) for w in wheels)
+    ]
+    if missing:
+        raise ReleaseError(
+            f"Release {tag} is missing wheels for: {', '.join(missing)}. Got: {wheels}"
+        )
+    if len(wheels) != len(EXPECTED_WHEEL_STEMS):
+        raise ReleaseError(
+            f"Release {tag} has {len(wheels)} wheels, expected "
+            f"{len(EXPECTED_WHEEL_STEMS)}: {wheels}"
+        )
+    print(f"GitHub Release {tag} ships all {len(wheels)} wheels.")
+
+
+# PyPI (and its CDN) makes a freshly uploaded release installable only after a
+# short propagation delay, so the install check must retry rather than fail on
+# the first miss when run right after publish.
+_PYPI_APPEAR_TIMEOUT_S = 120
+_PYPI_POLL_INTERVAL_S = 10
+
+
+def verify_pypi_install(version: str) -> None:
+    """Assert the just-published CLI resolves and installs from PyPI.
+
+    Retries while the release is still propagating; ``--refresh`` keeps uv from
+    serving a cached "not found" from an earlier attempt.
+    """
+    spec = f"pipefy-cli=={pep440(version)}"
+    print(f"Verifying PyPI install of {spec} ...")
+    deadline = time.monotonic() + _PYPI_APPEAR_TIMEOUT_S
+    while True:
+        try:
+            out = capture(["uvx", "--refresh", "--from", spec, "pipefy", "--version"])
+            break
+        except subprocess.CalledProcessError:
+            if time.monotonic() >= deadline:
+                raise ReleaseError(
+                    f"{spec} did not become installable from PyPI within "
+                    f"{_PYPI_APPEAR_TIMEOUT_S}s (still propagating, or the upload "
+                    f"failed). Re-run `release.py verify v{version}` once it lands."
+                ) from None
+            print(f"  not on PyPI yet; retrying in {_PYPI_POLL_INTERVAL_S}s...")
+            time.sleep(_PYPI_POLL_INTERVAL_S)
+    if pep440(version) not in pep440_candidates(out):
+        raise ReleaseError(
+            f"`pipefy --version` from PyPI returned {out!r}, expected {version}"
+        )
+    print(f"PyPI install resolves: {out}")
+
+
+def pep440_candidates(text: str) -> set[str]:
+    """Normalized versions found in a ``--version`` output line."""
+    from packaging.version import InvalidVersion, Version
+
+    found: set[str] = set()
+    for token in re.findall(r"\d[\w.\-+]*", text):
+        try:
+            found.add(str(Version(token)))
+        except InvalidVersion:
+            continue
+    return found
+
+
+def verify_installer_resolves(tag: str) -> None:
+    """Assert install.sh's dry-run resolves the just-cut tag as the latest release."""
+    print("Verifying install.sh resolves the latest release ...")
+    result = subprocess.run(
+        [
+            "sh",
+            str(INSTALL_SH),
+            "--yes",
+            "--no-skills",
+            "--client",
+            "none",
+            "--dry-run",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout + result.stderr
+    expected = f"Resolved tag: {tag}"
+    if expected not in output:
+        raise ReleaseError(
+            f"install.sh dry-run did not report '{expected}'. Output:\n{output}"
+        )
+    print(f"install.sh resolves {tag}.")
+
+
+def print_release_links(tag: str, version: str) -> None:
+    """Print the GitHub Release and per-package PyPI links for a released tag.
+
+    The repo comes from ``gh`` (so links point at whatever remote this checkout
+    tracks, fork included) and the distribution names from the workspace member
+    list, so a new published package appears here without editing a second list.
+    """
+    repo_url = capture(["gh", "repo", "view", "--json", "url", "--jq", ".url"])
+    pep = pep440(version)
+    print("\nLinks:")
+    print(f"  GitHub Release: {repo_url}/releases/tag/{tag}")
+    for dist in sorted(bump_version.workspace_members()):
+        print(f"  PyPI {dist}: https://pypi.org/project/{dist}/{pep}/")
+
+
+def version_from_tag(tag: str) -> str:
+    """Strip a leading ``v`` from a git tag to get the PEP 440-ish version."""
+    return tag[1:] if tag.startswith("v") else tag
+
+
+def verify(tag: str) -> None:
+    """Run all post-publish checks; raise on the first failure."""
+    version = version_from_tag(tag)
+    verify_github_wheels(tag)
+    verify_pypi_install(version)
+    verify_installer_resolves(tag)
+    print(f"\nAll checks passed for {tag}.")
+
+
+# --- entrypoint ------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_prepare = sub.add_parser(
+        "prepare", help="bump version, stamp CHANGELOG, commit (all local)"
+    )
+    p_prepare.add_argument(
+        "bump",
+        help="major | minor | patch | prerelease | version=X.Y.Z",
+    )
+    p_prepare.add_argument(
+        "--yes", action="store_true", help="skip the version confirmation prompt"
+    )
+
+    p_publish = sub.add_parser(
+        "publish", help="tag, push, watch the workflow, then verify (irreversible)"
+    )
+    p_publish.add_argument(
+        "--yes", action="store_true", help="skip the pre-push confirmation prompt"
+    )
+
+    p_verify = sub.add_parser("verify", help="re-run post-publish checks for a tag")
+    p_verify.add_argument("tag", help="the release tag, e.g. v0.2.0-beta.1")
+
+    args = parser.parse_args()
+    try:
+        if args.command == "prepare":
+            prepare(args.bump, assume_yes=args.yes)
+        elif args.command == "publish":
+            publish(assume_yes=args.yes)
+        elif args.command == "verify":
+            verify(args.tag)
+            print_release_links(args.tag, version_from_tag(args.tag))
+    except (ReleaseError, subprocess.CalledProcessError) as exc:
+        print(f"\nrelease: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -223,8 +223,13 @@ def confirm(prompt: str, *, assume_yes: bool) -> None:
 
 
 def tag_exists(tag: str) -> bool:
-    remote = capture(["git", "ls-remote", "--tags", "origin", tag])
-    return bool(remote)
+    """Whether ``tag`` already exists on origin."""
+    return bool(capture(["git", "ls-remote", "--tags", "origin", tag]))
+
+
+def local_tag_exists(tag: str) -> bool:
+    """Whether ``tag`` already exists in the local repository."""
+    return bool(capture(["git", "tag", "--list", tag]))
 
 
 # A tag push does not create the workflow run synchronously — GitHub registers
@@ -233,13 +238,12 @@ _RUN_APPEAR_TIMEOUT_S = 90
 _RUN_POLL_INTERVAL_S = 3
 
 
-def _find_release_run_id(tag: str) -> str:
-    """Return the newest Release-workflow run id for ``tag``, or an empty string.
+def _release_run_ids(tag: str) -> list[str]:
+    """Release-workflow run ids for ``tag``, newest first.
 
     The Release workflow runs only on ``v*`` tag pushes, so its runs carry the
     tag as ``headBranch``; filtering on ``headBranch == <tag>`` isolates this
-    release's run from any other tag's, and ``gh`` lists newest first so a
-    re-pushed tag resolves to its latest run.
+    tag's runs from any other tag's.
     """
     runs = capture(
         [
@@ -258,26 +262,34 @@ def _find_release_run_id(tag: str) -> str:
             f'.[] | select(.headBranch == "{tag}") | .databaseId',
         ]
     )
-    lines = runs.splitlines()
-    return lines[0] if lines else ""
+    return runs.splitlines()
 
 
-def watch_release_workflow(tag: str) -> None:
+def _newest_run_id(tag: str, exclude: frozenset[str]) -> str:
+    """Newest Release run id for ``tag`` not in ``exclude``, or an empty string."""
+    for run_id in _release_run_ids(tag):  # newest first
+        if run_id not in exclude:
+            return run_id
+    return ""
+
+
+def watch_release_workflow(tag: str, *, exclude: frozenset[str] = frozenset()) -> None:
     """Block until the Release workflow run for ``tag`` finishes, failing on failure.
 
-    Polls for the run to appear (the push does not create it synchronously)
-    before handing off to ``gh run watch``, which streams progress and exits
-    non-zero if the run fails.
+    Polls for a run not in ``exclude`` — the runs that already existed before
+    this push — so a re-cut of the same tag waits for its genuinely new run
+    rather than attaching to a prior completed one. Hands off to
+    ``gh run watch``, which streams progress and exits non-zero on failure.
     """
     print(f"Waiting for the Release workflow run for {tag} to appear...")
     deadline = time.monotonic() + _RUN_APPEAR_TIMEOUT_S
-    run_id = _find_release_run_id(tag)
+    run_id = _newest_run_id(tag, exclude)
     while not run_id and time.monotonic() < deadline:
         time.sleep(_RUN_POLL_INTERVAL_S)
-        run_id = _find_release_run_id(tag)
+        run_id = _newest_run_id(tag, exclude)
     if not run_id:
         raise ReleaseError(
-            f"No Release workflow run appeared for {tag} within "
+            f"No new Release workflow run appeared for {tag} within "
             f"{_RUN_APPEAR_TIMEOUT_S}s. Check the Actions tab."
         )
     run(["gh", "run", "watch", run_id, "--exit-status"])
@@ -294,6 +306,12 @@ def publish(*, assume_yes: bool) -> None:
     tag = f"v{version}"
     if tag_exists(tag):
         raise ReleaseError(f"Tag {tag} already exists on origin")
+    if local_tag_exists(tag):
+        raise ReleaseError(
+            f"Tag {tag} exists locally (likely from an earlier interrupted "
+            f"publish) but not on origin. Delete it with 'git tag -d {tag}' "
+            "and re-run."
+        )
 
     confirm(
         f"About to tag {tag}, push to origin, and publish to PyPI. "
@@ -301,11 +319,16 @@ def publish(*, assume_yes: bool) -> None:
         assume_yes=assume_yes,
     )
 
-    run(["git", "tag", tag])
+    # Push main before tagging so a rejected main push never leaves a dangling
+    # local tag to trip the next attempt.
     run(["git", "push", "origin", "main"])
+    run(["git", "tag", tag])
+    # Snapshot runs that already exist for this tag (from a prior cut) so the
+    # watcher waits for the run this push creates, not a stale completed one.
+    prior_runs = frozenset(_release_run_ids(tag))
     run(["git", "push", "origin", tag])
 
-    watch_release_workflow(tag)
+    watch_release_workflow(tag, exclude=prior_runs)
     verify(tag)
     print(f"\nReleased {tag}.")
     print_release_links(tag, version)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,111 @@
+"""Tests for scripts/release.py pure logic (CHANGELOG stamping, version parsing)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "release.py"
+_spec = importlib.util.spec_from_file_location("release", _SCRIPT)
+assert _spec and _spec.loader
+_release = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_release)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("0.2.0-beta.1", "0.2.0b1"),
+        ("0.2.0-alpha.3", "0.2.0a3"),
+        ("1.0.0rc2", "1.0.0rc2"),
+        ("1.2.3", "1.2.3"),
+    ],
+)
+def test_pep440_normalizes(raw: str, expected: str) -> None:
+    assert _release.pep440(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("pipefy, version 0.2.0b1", {"0.2.0b1"}),
+        ("pipefy-cli 1.2.3", {"1.2.3"}),
+        ("no version here", set()),
+        ("0.2.0-beta.1 build", {"0.2.0b1"}),
+    ],
+)
+def test_pep440_candidates(text: str, expected: set[str]) -> None:
+    assert _release.pep440_candidates(text) == expected
+
+
+def test_unreleased_re_captures_heading_and_body() -> None:
+    text = (
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Added\n- a thing\n\n"
+        "## [1.0.0] - 2026-01-01\n\n- old\n"
+    )
+    m = _release.UNRELEASED_RE.search(text)
+    assert m is not None
+    assert m.group(1).startswith("## [Unreleased]")
+    assert "a thing" in m.group(2)
+    assert "old" not in m.group(2)
+
+
+def test_stamp_changelog_renames_and_reseeds(tmp_path: Path, monkeypatch) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Added\n- new feature\n\n"
+        "## [1.0.0] - 2026-01-01\n\n- old\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(_release, "CHANGELOG", changelog)
+
+    _release.stamp_changelog("2.0.0")
+    out = changelog.read_text(encoding="utf-8")
+
+    # A fresh empty Unreleased is re-seeded above the dated version section.
+    assert "## [Unreleased]\n\n## [2.0.0] - " in out
+    # The accumulated notes moved under the new version, not lost.
+    idx_version = out.index("## [2.0.0]")
+    assert "new feature" in out[idx_version:]
+    # The prior release section is untouched.
+    assert "## [1.0.0] - 2026-01-01" in out
+
+
+def test_compute_target_version(monkeypatch) -> None:
+    monkeypatch.setattr(
+        _release.bump_version, "read_sdk_version", lambda: "0.3.0-beta.1"
+    )
+    assert _release.compute_target_version("major") == ("0.3.0-beta.1", "1.0.0")
+    assert _release.compute_target_version("minor") == ("0.3.0-beta.1", "0.4.0")
+    assert _release.compute_target_version("patch") == ("0.3.0-beta.1", "0.3.1")
+    # prerelease increments the current track; it does not promote alpha->beta.
+    assert _release.compute_target_version("prerelease") == (
+        "0.3.0-beta.1",
+        "0.3.0-beta.2",
+    )
+    # version= is the escape hatch for a cross-track or arbitrary jump.
+    assert _release.compute_target_version("version=0.3.0-rc.1") == (
+        "0.3.0-beta.1",
+        "0.3.0-rc.1",
+    )
+
+
+def test_compute_target_version_rejects_unknown(monkeypatch) -> None:
+    monkeypatch.setattr(_release.bump_version, "read_sdk_version", lambda: "0.3.0")
+    with pytest.raises(_release.ReleaseError):
+        _release.compute_target_version("bogus")
+
+
+def test_stamp_changelog_requires_unreleased(tmp_path: Path, monkeypatch) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## [1.0.0] - 2026-01-01\n", encoding="utf-8")
+    monkeypatch.setattr(_release, "CHANGELOG", changelog)
+
+    with pytest.raises(_release.ReleaseError):
+        _release.stamp_changelog("2.0.0")

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -96,6 +96,15 @@ def test_compute_target_version(monkeypatch) -> None:
     )
 
 
+def test_newest_run_id_skips_excluded(monkeypatch) -> None:
+    # gh lists newest first; the snapshot of prior runs must be skipped so a
+    # re-cut of the same tag waits for its genuinely new run.
+    monkeypatch.setattr(_release, "_release_run_ids", lambda tag: ["300", "200", "100"])
+    assert _release._newest_run_id("v1", frozenset()) == "300"
+    assert _release._newest_run_id("v1", frozenset({"300"})) == "200"
+    assert _release._newest_run_id("v1", frozenset({"300", "200", "100"})) == ""
+
+
 def test_compute_target_version_rejects_unknown(monkeypatch) -> None:
     monkeypatch.setattr(_release.bump_version, "read_sdk_version", lambda: "0.3.0")
     with pytest.raises(_release.ReleaseError):


### PR DESCRIPTION
## Motivation

Cutting a release meant following a long manual checklist in RELEASE.md — bump the lockstep version, rewrite the CHANGELOG heading, commit, tag, push, wait for the workflow, then run several verification commands by hand (PyPI install, and a curl install.sh sanity-check). The verification steps in particular were easy to forget, and nothing failed loudly if you skipped one.

## Outcome

`scripts/release.py` drives the flow as three subcommands split at the irreversible tag-push boundary. `prepare` bumps the version (via the existing `bump_version.py`), stamps the CHANGELOG, and commits — all local and reversible, after confirming the computed version. `publish` tags, pushes, watches the Release workflow to completion, then verifies. `verify` asserts the GitHub Release ships all five wheels, the version installs from PyPI, and `install.sh` resolves the just-cut tag, then prints the release links. The formerly manual verification steps are now assertions that fail loudly, and the version transform stays owned solely by `bump_version.py`.

## Verification / proof of work

Validated end-to-end against real GitHub infrastructure, including a full `publish` on a throwaway fork ([mocha06/ai-toolkit](https://github.com/mocha06/ai-toolkit)). This surfaced and fixed two eventual-consistency races that unit tests would not have caught, both re-confirmed live afterward: the workflow-watch queried for the run before GitHub had created it (now polls until it appears), and the PyPI-install check ran once with no allowance for propagation lag (now retries with a clear final message).

### 1. Fully-green `verify` against a real published tag

Run against [`v0.3.0-beta.1`](https://github.com/pipefy/ai-toolkit/releases/tag/v0.3.0-beta.1) — all three checks pass and the link summary prints:

```
GitHub Release v0.3.0-beta.1 ships all 5 wheels.
PyPI install resolves: 0.3.0-beta.1
install.sh resolves v0.3.0-beta.1.

All checks passed for v0.3.0-beta.1.
```

Resolved links (each verified live):

- GitHub Release: https://github.com/pipefy/ai-toolkit/releases/tag/v0.3.0-beta.1
- PyPI: [pipefy](https://pypi.org/project/pipefy/0.3.0b1/) · [pipefy-cli](https://pypi.org/project/pipefy-cli/0.3.0b1/) · [pipefy-mcp-server](https://pypi.org/project/pipefy-mcp-server/0.3.0b1/) · [pipefy-auth](https://pypi.org/project/pipefy-auth/0.3.0b1/) · [pipefy-infra](https://pypi.org/project/pipefy-infra/0.3.0b1/)

### 2. Full `publish` end-to-end on the fork

`prepare` → `publish` cut and published `v0.3.0-beta.4` on the fork:

- Release workflow run (green, built and attached all five wheels): https://github.com/mocha06/ai-toolkit/actions/runs/29769309126
- Resulting GitHub Release with all five wheels: https://github.com/mocha06/ai-toolkit/releases/tag/v0.3.0-beta.4

The fork cannot publish to the real PyPI projects (Trusted Publishing is bound to `pipefy/ai-toolkit`, so PyPI rejects a fork's OIDC), which is exactly why it is safe — the PyPI upload step is skipped and the PyPI-install check correctly exhausts its retry window instead of touching the real packages.

### 3. Both fixes, observed live

```
Waiting for the Release workflow run for v0.3.0-beta.4 to appear...
GitHub Release v0.3.0-beta.4 ships all 5 wheels.
Verifying PyPI install of pipefy-cli==0.3.0b4 ...
  not on PyPI yet; retrying in 10s...
release: pipefy-cli==0.3.0b4 did not become installable from PyPI within 120s ...
```

### 4. `prepare` confirms the computed target before any mutation

```
release: Will bump 0.3.0-beta.4 -> 0.3.0-beta.5 and cut tag v0.3.0-beta.5. Proceed?
```
