### PR TITLE
Add release-pr subcommand for dev→main release PRs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,21 @@ The next **GitHub pre-release** after the standalone repo’s [`v0.1.0-beta.1`](
 
 The Release workflow requires the git tag (without leading `v`) to **exactly match** `__version__` in `packages/sdk/src/pipefy_sdk/__init__.py` (and the MCP/CLI/Auth/Infra copies). For example tag **`v0.2.0-beta.1`** implies **`__version__ = "0.2.0-beta.1"`** in all five packages before you push the tag (set via step 2 below using `version=0.2.0-beta.1`, or edit the five `__init__.py` files together).
 
-`scripts/release.py` drives the whole flow as two subcommands split at the irreversible boundary — everything before the tag push is local and reversible, so you review the commit before anything leaves your machine.
+`scripts/release.py` drives the flow, split at the irreversible boundary — everything before the tag push is local and reversible, so you review before anything leaves your machine. The subcommands are `release-pr` (open a dev→main release PR), `prepare` (bump/stamp/commit on `main`), `publish` (tag, push, watch, verify), and `verify` (re-run the post-publish checks).
+
+### Recommended: `dev → main` release PR
+
+Most releases start from `dev`. `release.py release-pr <bump>` branches off the latest `origin/dev`, runs the same bump-and-stamp as `prepare`, pushes, and opens a PR into `main`:
+
+```bash
+uv run python scripts/release.py release-pr patch
+```
+
+It reads the current version and `## [Unreleased]` from `origin/dev` (not your checked-out branch), confirms the computed target, then opens the PR. After the PR is approved and merged into `main`, cut the release from `main` with `publish` (step 4 below) — deliberately a human step, so the tag push triggers the Release workflow. `release-pr` never tags or publishes.
+
+### From `main` directly
+
+If `main` already carries the merged work, run the steps below (this is also exactly what `release-pr` automates for steps 1–2, off `dev`).
 
 1. Merge work to `main` and ensure `CHANGELOG.md` has everything under `## [Unreleased]`.
 2. Prepare the release. This bumps the shared version across every version-bearing file (via `scripts/bump_version.py`), stamps the `## [Unreleased]` CHANGELOG heading with the new version and today's date, re-seeds an empty `## [Unreleased]`, and commits — all locally:
@@ -68,7 +82,7 @@ Same steps as above. PyPI publishing already runs on every tag; a **`v1.`** tag 
 
 | Piece | Role |
 | --- | --- |
-| `scripts/release.py` | Guided release CLI. `prepare <bump>` runs `bump_version.py`, stamps the `CHANGELOG.md` `## [Unreleased]` heading, and commits (all local, reversible). `publish` tags, pushes, watches the Release workflow, then verifies. `verify <tag>` re-runs the post-publish checks (all five wheels on the GitHub Release, PyPI install resolves, `install.sh` dry-run resolves the tag). It shells out to `bump_version.py` for the transform rather than reimplementing it. |
+| `scripts/release.py` | Guided release CLI. `release-pr <bump>` branches off `origin/dev`, prepares, and opens a release PR into `main`. `prepare <bump>` runs `bump_version.py`, stamps the `CHANGELOG.md` `## [Unreleased]` heading, and commits on `main` (all local, reversible). `publish` tags, pushes, watches the Release workflow, then verifies. `verify <tag>` re-runs the post-publish checks (all five wheels on the GitHub Release, PyPI install resolves, `install.sh` dry-run resolves the tag). It shells out to `bump_version.py` for the transform rather than reimplementing it. |
 | `scripts/bump_version.py` | Reads the SDK `__version__`, applies the bump, writes the same value to SDK, MCP, CLI, Auth, and Infra `__init__.py`, the root `pyproject.toml`'s `[project].version`, the `.claude-plugin/plugin.json` `version`, and each published package's sibling `==` pins, then runs `uv lock` to refresh `uv.lock`. Also exposes a `verify` mode that asserts every version-bearing file agrees. |
 | `.github/workflows/ci.yml` | Invokes `scripts/bump_version.py verify` to assert that all version-bearing files match: the five `__version__` strings, the root `pyproject.toml` `[project].version`, `uv.lock`, the `.claude-plugin/plugin.json` `version`, and the sibling `==` pins in each published package's `pyproject.toml`. |
 | `.github/workflows/release.yml` | On `v*` tags: asserts the tag matches SDK `__version__`, extracts the matching `CHANGELOG.md` section as the GitHub Release body, builds wheels and sdists with `uv build --all-packages -o dist --wheel --sdist`, guards that `dist/` holds exactly five wheels (one per workspace member) so a sixth member cannot ship unnoticed, attaches wheels to the GitHub Release, and uploads all five wheels to PyPI via Trusted Publishing on every `v*` tag. |

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -245,16 +245,24 @@ def _show_at(ref: str, path: str) -> str:
     return capture(["git", "show", f"{ref}:{path}"])
 
 
-def _dev_current_version() -> str:
-    """The lockstep version on ``origin/dev`` (read from its root pyproject).
+def _version_at(ref: str) -> str:
+    """The lockstep version at ``ref`` (read from its root pyproject).
 
-    ``release_pr`` computes the target from dev's version, not the working
-    tree's — the branch it is invoked from may carry a different version.
+    ``release_pr`` derives the target from ``origin/dev``'s version, not the
+    working tree's — the branch it is invoked from may carry a different one —
+    and compares against ``origin/main`` to refuse a downgrade.
     """
     import tomllib
 
-    data = tomllib.loads(_show_at(f"origin/{DEV_BRANCH}", "pyproject.toml"))
+    data = tomllib.loads(_show_at(ref, "pyproject.toml"))
     return data["project"]["version"]
+
+
+def _target_ahead_of_main(target: str, main_version: str) -> bool:
+    """Whether ``target`` is a strictly newer version than ``main_version``."""
+    from packaging.version import Version
+
+    return Version(target) > Version(main_version)
 
 
 def _dev_unreleased_body() -> str:
@@ -316,15 +324,29 @@ def release_pr(bump_arg: str, *, assume_yes: bool = False) -> None:
             "add release notes first"
         )
 
-    current = _dev_current_version()
+    current = _version_at(f"origin/{DEV_BRANCH}")
     target = target_for(bump_arg, current)
+
+    # Guard against a downgrade-shaped release: if origin/dev is behind
+    # origin/main (a release bump on main not back-merged into dev), the bump
+    # computed from dev can land below main's already-released version.
+    main_version = _version_at(f"origin/{MAIN_BRANCH}")
+    if not _target_ahead_of_main(target, main_version):
+        raise ReleaseError(
+            f"Computed target v{target} is not ahead of origin/{MAIN_BRANCH} "
+            f"(v{main_version}); origin/{DEV_BRANCH} (v{current}) is behind "
+            f"{MAIN_BRANCH}. Back-merge {MAIN_BRANCH} into {DEV_BRANCH} before "
+            "cutting a release."
+        )
+
     branch = f"rc-{MAIN_BRANCH}/release/v{target}"
     if branch_exists(branch):
         raise ReleaseError(f"Branch {branch} already exists")
 
     confirm(
-        f"Will branch off origin/{DEV_BRANCH}, bump {current} -> {target}, and "
-        f"open a release PR into {MAIN_BRANCH}. Proceed?",
+        f"Will branch off origin/{DEV_BRANCH}, bump {current} -> {target} "
+        f"(origin/{MAIN_BRANCH} is at {main_version}), and open a release PR "
+        f"into {MAIN_BRANCH}. Proceed?",
         assume_yes=assume_yes,
     )
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -3,13 +3,18 @@
 
 The release has a single natural fault line: ``git push origin <tag>`` triggers
 PyPI publishing, which cannot be undone. Everything before it is local and
-reversible; everything after is read-only verification. So this tool is two
-subcommands with a review gate between them:
+reversible; everything after is read-only verification. So this tool splits
+into subcommands with a review gate between the reversible and irreversible
+halves:
 
-* ``prepare`` — bump the version, stamp CHANGELOG, commit. All local; nothing
-  has left the machine. It stops and tells you to review the commit.
+* ``release-pr`` — branch off the latest ``origin/dev``, run the ``prepare``
+  bump, push, and open a release PR into ``main``. Reversible; the PR review
+  is the gate.
+* ``prepare`` — bump the version, stamp CHANGELOG, commit on ``main``. All
+  local; nothing has left the machine. It stops and tells you to review.
 * ``publish`` — tag, push, watch the Release workflow, then verify. Asks for
   one explicit confirmation before the irreversible push.
+* ``verify`` — re-run the post-publish checks for a tag.
 
 The version transform itself is NOT reimplemented here: ``bump_version.py``
 stays the sole owner of which files carry the version and how they are
@@ -151,18 +156,17 @@ def stamp_changelog(version: str) -> None:
     CHANGELOG.write_text(new_text, encoding="utf-8")
 
 
-def compute_target_version(bump_arg: str) -> tuple[str, str]:
-    """Resolve ``(current, target)`` for a bump argument without mutating anything.
+def target_for(bump_arg: str, current: str) -> str:
+    """Apply a bump argument to ``current`` via ``bump_version``'s own functions.
 
-    Uses ``bump_version``'s own bump functions so the version previewed here is
-    exactly what the bump will write. Lets ``prepare`` show the target and
-    confirm it before touching any file — catching a wrong bump (e.g. expecting
-    ``beta.1`` from ``prerelease``, which only increments the current track)
-    while it is still a no-op to walk away.
+    Uses bump_version's bump logic so the version previewed here is exactly what
+    the bump will write — letting a caller show the target and confirm it before
+    touching any file, and catching a wrong bump (e.g. expecting ``beta.1`` from
+    ``prerelease``, which only increments the current track) while walking away
+    is still a no-op.
     """
-    current = bump_version.read_sdk_version()
     if bump_arg.lower().startswith("version="):
-        return current, bump_version.parse_explicit_version(bump_arg)
+        return bump_version.parse_explicit_version(bump_arg)
     bumpers = {
         "major": bump_version.bump_major,
         "minor": bump_version.bump_minor,
@@ -174,19 +178,22 @@ def compute_target_version(bump_arg: str) -> tuple[str, str]:
             f"Unknown bump {bump_arg!r}. Use major, minor, patch, prerelease, "
             "or version=X.Y.Z"
         )
-    return current, bumpers[bump_arg](current)
+    return bumpers[bump_arg](current)
 
 
-def prepare(bump_arg: str, *, assume_yes: bool = False) -> str:
-    """Bump, stamp the CHANGELOG, and commit. Returns the new version string."""
-    preflight_prepare()
+def compute_target_version(bump_arg: str) -> tuple[str, str]:
+    """Resolve ``(current, target)`` from the working tree's current version."""
+    current = bump_version.read_sdk_version()
+    return current, target_for(bump_arg, current)
 
-    current, target = compute_target_version(bump_arg)
-    confirm(
-        f"Will bump {current} -> {target} and cut tag v{target}. Proceed?",
-        assume_yes=assume_yes,
-    )
 
+def _apply_prepare(bump_arg: str, target: str) -> str:
+    """Bump, stamp the CHANGELOG, and commit on the current branch.
+
+    The mutating core shared by ``prepare`` (main flow) and ``release_pr``
+    (dev→main flow); callers own the preflight and confirmation. Returns the
+    version bump_version actually wrote.
+    """
     # bump_version.py owns the transform; run its CLI so the file set and lock
     # refresh live in exactly one place.
     run(["uv", "run", "python", "scripts/bump_version.py", bump_arg])
@@ -195,11 +202,22 @@ def prepare(bump_arg: str, *, assume_yes: bool = False) -> str:
         raise ReleaseError(
             f"bump_version wrote {version!r} but {target!r} was confirmed"
         )
-
     stamp_changelog(version)
-
     run(["git", "add", "-A"])
     run(["git", "commit", "-m", f"chore: release v{version}"])
+    return version
+
+
+def prepare(bump_arg: str, *, assume_yes: bool = False) -> str:
+    """Bump, stamp the CHANGELOG, and commit on ``main``. Returns the version."""
+    preflight_prepare()
+
+    current, target = compute_target_version(bump_arg)
+    confirm(
+        f"Will bump {current} -> {target} and cut tag v{target}. Proceed?",
+        assume_yes=assume_yes,
+    )
+    version = _apply_prepare(bump_arg, target)
 
     print()
     print(f"Prepared v{version}. Review the release commit:")
@@ -207,6 +225,134 @@ def prepare(bump_arg: str, *, assume_yes: bool = False) -> str:
     print("Then publish with:")
     print("    uv run python scripts/release.py publish")
     return version
+
+
+# --- release-pr (dev -> main) ----------------------------------------------
+
+DEV_BRANCH = "dev"
+MAIN_BRANCH = "main"
+
+
+def branch_exists(branch: str) -> bool:
+    """Whether ``branch`` exists locally or on origin."""
+    local = capture(["git", "branch", "--list", branch])
+    remote = capture(["git", "ls-remote", "--heads", "origin", branch])
+    return bool(local or remote)
+
+
+def _show_at(ref: str, path: str) -> str:
+    """Return the contents of ``path`` as of ``ref`` without checking it out."""
+    return capture(["git", "show", f"{ref}:{path}"])
+
+
+def _dev_current_version() -> str:
+    """The lockstep version on ``origin/dev`` (read from its root pyproject).
+
+    ``release_pr`` computes the target from dev's version, not the working
+    tree's — the branch it is invoked from may carry a different version.
+    """
+    import tomllib
+
+    data = tomllib.loads(_show_at(f"origin/{DEV_BRANCH}", "pyproject.toml"))
+    return data["project"]["version"]
+
+
+def _dev_unreleased_body() -> str:
+    """The text under ``## [Unreleased]`` in ``origin/dev``'s CHANGELOG."""
+    m = UNRELEASED_RE.search(_show_at(f"origin/{DEV_BRANCH}", "CHANGELOG.md"))
+    if not m:
+        raise ReleaseError(
+            f"No '## [Unreleased]' section in CHANGELOG.md on origin/{DEV_BRANCH}"
+        )
+    return m.group(2).strip()
+
+
+def _release_pr_body(previous: str, version: str, released: str) -> str:
+    """Body for the dev→main release PR.
+
+    Inlines the released content (the ``[Unreleased]`` notes being finalized)
+    so a reviewer sees what ships without opening the CHANGELOG diff.
+    """
+    from packaging.version import Version
+
+    today = datetime.date.today().isoformat()
+    kind = "pre-release" if Version(version).is_prerelease else "stable"
+    return (
+        f"Cuts `v{version}`, capturing everything merged into `{DEV_BRANCH}` "
+        f"since `v{previous}`. Tagging publishes a GitHub Release with wheels "
+        f"and a {kind} PyPI upload.\n\n"
+        "## What this PR contains\n\n"
+        f"- Lockstep version bump `{previous}` -> `{version}` across every "
+        "workspace package's `__init__.py`, the root `pyproject.toml`, "
+        "`.claude-plugin/plugin.json`, and `uv.lock`.\n"
+        f"- `CHANGELOG.md`: `## [Unreleased]` finalized to "
+        f"`## [{version}] - {today}`; the Release workflow uses this section as "
+        "the GitHub Release body.\n\n"
+        "## Released content (already in dev)\n\n"
+        f"{released}\n\n"
+        "## After merge\n\n"
+        f"Run `uv run python scripts/release.py publish` from `{MAIN_BRANCH}` "
+        "to tag and publish — the one irreversible, human-gated step."
+    )
+
+
+def release_pr(bump_arg: str, *, assume_yes: bool = False) -> None:
+    """Cut a release-prep branch off the latest ``dev`` and open a PR into ``main``.
+
+    Automates the reversible half of a dev→main release: fetch dev, branch off
+    it, bump + stamp + commit, push, and open the PR. Deliberately does NOT
+    tag or publish — that stays a human ``publish`` from ``main`` after review,
+    so the tag push still triggers the Release workflow.
+    """
+    if not working_tree_clean():
+        raise ReleaseError("Working tree is dirty; commit or stash first")
+
+    run(["git", "fetch", "--quiet", "origin", DEV_BRANCH, MAIN_BRANCH])
+
+    released = _dev_unreleased_body()
+    if not released:
+        raise ReleaseError(
+            f"'## [Unreleased]' in CHANGELOG.md on origin/{DEV_BRANCH} is empty; "
+            "add release notes first"
+        )
+
+    current = _dev_current_version()
+    target = target_for(bump_arg, current)
+    branch = f"rc-{MAIN_BRANCH}/release/v{target}"
+    if branch_exists(branch):
+        raise ReleaseError(f"Branch {branch} already exists")
+
+    confirm(
+        f"Will branch off origin/{DEV_BRANCH}, bump {current} -> {target}, and "
+        f"open a release PR into {MAIN_BRANCH}. Proceed?",
+        assume_yes=assume_yes,
+    )
+
+    run(["git", "checkout", "-b", branch, f"origin/{DEV_BRANCH}"])
+    version = _apply_prepare(bump_arg, target)
+    run(["git", "push", "-u", "origin", branch])
+
+    url = capture(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            MAIN_BRANCH,
+            "--head",
+            branch,
+            "--title",
+            f"chore: release v{version}",
+            "--body",
+            _release_pr_body(current, version, released),
+        ]
+    )
+    print(f"\nOpened release PR: {url}")
+    print(
+        f"After it is approved and merged into {MAIN_BRANCH}, run from {MAIN_BRANCH}:"
+    )
+    print(f"    git checkout {MAIN_BRANCH} && git pull")
+    print("    uv run python scripts/release.py publish")
 
 
 # --- publish ---------------------------------------------------------------
@@ -472,7 +618,7 @@ def main() -> int:
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_prepare = sub.add_parser(
-        "prepare", help="bump version, stamp CHANGELOG, commit (all local)"
+        "prepare", help="bump version, stamp CHANGELOG, commit on main (all local)"
     )
     p_prepare.add_argument(
         "bump",
@@ -480,6 +626,17 @@ def main() -> int:
     )
     p_prepare.add_argument(
         "--yes", action="store_true", help="skip the version confirmation prompt"
+    )
+
+    p_release_pr = sub.add_parser(
+        "release-pr", help="branch off dev, prepare, open a release PR into main"
+    )
+    p_release_pr.add_argument(
+        "bump",
+        help="major | minor | patch | prerelease | version=X.Y.Z",
+    )
+    p_release_pr.add_argument(
+        "--yes", action="store_true", help="skip the confirmation prompt"
     )
 
     p_publish = sub.add_parser(
@@ -496,6 +653,8 @@ def main() -> int:
     try:
         if args.command == "prepare":
             prepare(args.bump, assume_yes=args.yes)
+        elif args.command == "release-pr":
+            release_pr(args.bump, assume_yes=args.yes)
         elif args.command == "publish":
             publish(assume_yes=args.yes)
         elif args.command == "verify":

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -54,6 +54,16 @@ def test_unreleased_re_captures_heading_and_body() -> None:
     assert "old" not in m.group(2)
 
 
+def test_target_ahead_of_main() -> None:
+    assert _release._target_ahead_of_main("0.3.0-beta.2", "0.3.0-beta.1")
+    assert _release._target_ahead_of_main("1.0.0", "0.9.0")
+    # dev behind main (release bump on main not back-merged): a prerelease bump
+    # from dev's alpha lands below main's beta — a downgrade-shaped release.
+    assert not _release._target_ahead_of_main("0.3.0-alpha.2", "0.3.0-beta.1")
+    # equal is not ahead
+    assert not _release._target_ahead_of_main("0.3.0-beta.1", "0.3.0-beta.1")
+
+
 def test_release_pr_body_inlines_content() -> None:
     body = _release._release_pr_body(
         "0.3.0-beta.4", "0.3.0-beta.5", "### Added\n\n- a shipped thing"

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -54,6 +54,24 @@ def test_unreleased_re_captures_heading_and_body() -> None:
     assert "old" not in m.group(2)
 
 
+def test_release_pr_body_inlines_content() -> None:
+    body = _release._release_pr_body(
+        "0.3.0-beta.4", "0.3.0-beta.5", "### Added\n\n- a shipped thing"
+    )
+    assert "Cuts `v0.3.0-beta.5`" in body
+    assert "since `v0.3.0-beta.4`" in body
+    assert "`0.3.0-beta.4` -> `0.3.0-beta.5`" in body
+    assert "## Released content" in body
+    assert "- a shipped thing" in body  # the released notes are inlined
+    assert "pre-release PyPI upload" in body
+    assert "release.py publish" in body
+
+
+def test_release_pr_body_marks_stable() -> None:
+    body = _release._release_pr_body("0.9.0", "1.0.0", "### Added\n\n- x")
+    assert "stable PyPI upload" in body
+
+
 def test_stamp_changelog_renames_and_reseeds(tmp_path: Path, monkeypatch) -> None:
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text(


### PR DESCRIPTION
## Motivation

The release CLI (added in #453) covers a release once `main` already carries the work, but getting there — branching, bumping the version, and opening the `dev → main` release PR — was still manual. Automating that prep removes the most repetitive part of a release while keeping the one irreversible step (the tag push) a deliberate human action.

## Outcome

Adds a `release-pr <bump>` subcommand. It branches off the latest `origin/dev`, runs the same bump + CHANGELOG stamp + commit as `prepare`, pushes, and opens a PR into `main`. It reads the current version and `## [Unreleased]` from `origin/dev` — not whatever branch you invoke it from — so the computed target is always correct, and it confirms that target before creating anything.

The generated PR description follows the established release-PR shape: a one-line summary, the mechanical bump it performs, the released content inlined (so a reviewer sees what ships without opening the CHANGELOG diff), and the post-merge step. Pre-release versus stable PyPI wording is derived from the version.

It deliberately does not tag or publish. After the release PR is approved and merged into `main`, a maintainer runs `release.py publish` from `main`; keeping the tag push human-driven is what lets it trigger the Release workflow (a tag pushed by CI's default token would not). The `prepare`/`publish`/`verify` behavior is unchanged; the shared bump-and-stamp core is factored out so both `prepare` and `release-pr` use it.

## Usage

```bash
# Recommended: open a dev -> main release PR (branches off latest origin/dev)
uv run python scripts/release.py release-pr patch

# After it's approved and merged into main, cut the release from main:
uv run python scripts/release.py publish

# On main directly (skip the PR flow): bump/stamp/commit, then publish
uv run python scripts/release.py prepare patch
uv run python scripts/release.py publish

# Re-run the post-publish checks for a tag
uv run python scripts/release.py verify v0.3.0-beta.5
```

| Command | What it does |
| --- | --- |
| `release-pr <bump>` | Branch off `origin/dev`, bump + stamp + commit, push, open a PR into `main`. Reversible; the PR review is the gate. |
| `prepare <bump>` | Bump + stamp CHANGELOG + commit on `main`. Local only. |
| `publish` | Tag, push, watch the Release workflow, then verify. The one irreversible step; confirms before the tag push. |
| `verify <tag>` | Assert the GitHub Release ships all wheels, the version installs from PyPI, and `install.sh` resolves the tag; print release links. |

`<bump>` is one of `major`, `minor`, `patch`, `prerelease`, or `version=X.Y.Z`. `prepare`/`release-pr` print the computed target and confirm before touching anything (`--yes` skips the prompt). Note `prerelease` only increments the current track (`beta.1 -> beta.2`); use `version=` to cross tracks (e.g. `version=0.3.0-beta.1`).

## Verification

Exercised end-to-end on a throwaway fork ([mocha06/ai-toolkit](https://github.com/mocha06/ai-toolkit)). Run from a clean `main`, `release-pr prerelease` correctly read `dev`'s version (`0.3.0-beta.4`), branched off `origin/dev`, bumped in lockstep to `0.3.0-beta.5`, stamped the CHANGELOG, pushed, and opened a `dev → main` release PR ([mocha06 PR #2](https://github.com/mocha06/ai-toolkit/pull/2)) whose generated description inlines the released content in the release-PR shape.
