### PR TITLE
docs(skills): add pipefy-ipaas skill and harden AI agents guidance

### DIFF
--- a/docs/mcp/tools/ipaas.md
+++ b/docs/mcp/tools/ipaas.md
@@ -8,7 +8,7 @@ Discover and invoke the iPaaS tools available to a pipe's workspace, and connect
 |------|-----------|------|
 | `get_ipaas_tools` | Yes | Lists the iPaaS (Advanced Automations) tools available for a pipe; with `tool_name`, expands one tool's full description and input schema. |
 | `call_ipaas_tool` | No | Invokes one iPaaS tool by name with `arguments` matching its input schema, relaying the result in full. The catalog includes destructive operations (deleting flows, tables, records) — reserve those for explicit user intent. |
-| `get_ipaas_connection_auth_url` | Yes | Step 1 for OAuth-based apps: returns the consent URL the user opens in a browser, plus a `completion` bundle for step 2. |
+| `get_ipaas_connection_auth_url` | No | Step 1 for OAuth-based apps: returns the consent URL the user opens in a browser, plus a `completion` bundle for step 2. |
 | `create_ipaas_connection` | No | Creates (or, on an existing `external_id`, rotates) an app connection in the pipe's workspace — token/API-key credentials directly, or OAuth via the two-step flow. |
 
 **`pipe_id`** matches GraphQL: use a **string** (unquoted JSON integers are coerced). See [Pipefy IDs in pipes & cards](pipes-and-cards.md#pipefy-ids-type-safety).

--- a/packages/mcp/tests/core/test_ipaas_gateway.py
+++ b/packages/mcp/tests/core/test_ipaas_gateway.py
@@ -21,12 +21,12 @@ REDIRECT_URI = "https://localhost/pipefy-mcp-callback"
 
 TOOLS = [
     {
-        "name": "ap_create_flow",
+        "name": "demo_create_flow",
         "description": "Create a new flow\n\nLonger guidance here.",
         "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}},
     },
     {
-        "name": "ap_list_flows",
+        "name": "demo_list_flows",
         "description": "List flows in the current project",
         "inputSchema": {"type": "object"},
     },
@@ -224,13 +224,15 @@ CALL_RESULT = {
 async def test_call_tool_posts_tools_call_with_arguments(respx_mock, gateway):
     mcp_route = _mock_happy_chain(respx_mock, rpc_result=CALL_RESULT)
 
-    result = await gateway.call_tool("embed-jwt", "ap_create_flow", {"name": "My flow"})
+    result = await gateway.call_tool(
+        "embed-jwt", "demo_create_flow", {"name": "My flow"}
+    )
 
     assert result == CALL_RESULT
     body = json.loads(mcp_route.calls.last.request.content)
     assert body["method"] == "tools/call"
     assert body["params"] == {
-        "name": "ap_create_flow",
+        "name": "demo_create_flow",
         "arguments": {"name": "My flow"},
     }
     assert (
@@ -243,10 +245,10 @@ async def test_call_tool_posts_tools_call_with_arguments(respx_mock, gateway):
 async def test_call_tool_defaults_arguments_to_empty_object(respx_mock, gateway):
     mcp_route = _mock_happy_chain(respx_mock, rpc_result=CALL_RESULT)
 
-    await gateway.call_tool("embed-jwt", "ap_list_flows")
+    await gateway.call_tool("embed-jwt", "demo_list_flows")
 
     body = json.loads(mcp_route.calls.last.request.content)
-    assert body["params"] == {"name": "ap_list_flows", "arguments": {}}
+    assert body["params"] == {"name": "demo_list_flows", "arguments": {}}
 
 
 @pytest.mark.anyio
@@ -257,7 +259,7 @@ async def test_call_tool_gives_only_the_invocation_hop_the_long_timeout(
     """A called tool may run a real flow; the handshake hops keep 30s."""
     mcp_route = _mock_happy_chain(respx_mock, rpc_result=CALL_RESULT)
 
-    await gateway.call_tool("embed-jwt", "ap_test_flow", {"flowId": "flow-1"})
+    await gateway.call_tool("embed-jwt", "demo_test_flow", {"flowId": "flow-1"})
 
     initialize, invocation = mcp_route.calls[-2].request, mcp_route.calls[-1].request
     assert initialize.extensions["timeout"]["read"] == REQUEST_TIMEOUT_SECONDS
@@ -274,7 +276,7 @@ async def test_call_tool_relays_host_error_results_without_raising(respx_mock, g
     }
     _mock_happy_chain(respx_mock, rpc_result=error_result)
 
-    result = await gateway.call_tool("embed-jwt", "ap_delete_flow", {"id": "nope"})
+    result = await gateway.call_tool("embed-jwt", "demo_delete_flow", {"id": "nope"})
 
     assert result == error_result
 
@@ -284,7 +286,7 @@ async def test_call_tool_relays_host_error_results_without_raising(respx_mock, g
 async def test_call_tool_parses_sse_encoded_response(respx_mock, gateway):
     _mock_happy_chain(respx_mock, sse_tools_list=True, rpc_result=CALL_RESULT)
 
-    result = await gateway.call_tool("embed-jwt", "ap_create_flow", {"name": "x"})
+    result = await gateway.call_tool("embed-jwt", "demo_create_flow", {"name": "x"})
 
     assert result == CALL_RESULT
 
@@ -299,7 +301,7 @@ async def test_jsonrpc_error_from_tools_call_names_the_method(respx_mock, gatewa
     )
 
     with pytest.raises(IpaasGatewayError, match="tools/call returned an error"):
-        await gateway.call_tool("embed-jwt", "ap_create_flow", {})
+        await gateway.call_tool("embed-jwt", "demo_create_flow", {})
 
 
 @pytest.mark.anyio
@@ -320,7 +322,7 @@ async def test_call_tool_timeout_names_the_method_and_points_at_runs(
     with pytest.raises(
         IpaasGatewayError, match="tools/call timed out after 120s.*run-listing"
     ):
-        await gateway.call_tool("embed-jwt", "ap_test_flow", {"flowId": "flow-1"})
+        await gateway.call_tool("embed-jwt", "demo_test_flow", {"flowId": "flow-1"})
 
 
 @pytest.mark.anyio
@@ -335,7 +337,7 @@ async def test_handshake_timeout_reports_retry_safe(respx_mock, gateway):
     respx_mock.post(f"{IPAAS_URL}/mcp").mock(side_effect=responder)
 
     with pytest.raises(IpaasGatewayError, match="handshake timed out.*safe to retry"):
-        await gateway.call_tool("embed-jwt", "ap_test_flow", {"flowId": "flow-1"})
+        await gateway.call_tool("embed-jwt", "demo_test_flow", {"flowId": "flow-1"})
 
 
 @pytest.mark.anyio
@@ -345,7 +347,7 @@ async def test_response_without_result_names_the_method(respx_mock, gateway):
     respx_mock.post(f"{IPAAS_URL}/mcp").respond(200, json={"jsonrpc": "2.0", "id": 2})
 
     with pytest.raises(IpaasGatewayError, match="tools/call.*no result"):
-        await gateway.call_tool("embed-jwt", "ap_list_flows")
+        await gateway.call_tool("embed-jwt", "demo_list_flows")
 
 
 PIECE_NAME = "@example/piece-demo"
@@ -562,7 +564,7 @@ async def test_sse_notification_frames_before_the_response_are_skipped(
 
     respx_mock.post(f"{IPAAS_URL}/mcp").mock(side_effect=responder)
 
-    result = await gateway.call_tool("embed-jwt", "ap_create_flow", {"name": "x"})
+    result = await gateway.call_tool("embed-jwt", "demo_create_flow", {"name": "x"})
 
     assert result == CALL_RESULT
 
@@ -577,7 +579,7 @@ async def test_null_result_is_a_protocol_error(respx_mock, gateway):
     )
 
     with pytest.raises(IpaasGatewayError, match="tools/call.*non-object result"):
-        await gateway.call_tool("embed-jwt", "ap_list_flows")
+        await gateway.call_tool("embed-jwt", "demo_list_flows")
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_ipaas_tools.py
+++ b/packages/mcp/tests/tools/test_ipaas_tools.py
@@ -20,12 +20,12 @@ from pipefy_mcp.tools.ipaas_tools import IpaasTools
 
 TOOLS = [
     {
-        "name": "ap_create_flow",
+        "name": "demo_create_flow",
         "description": "Create a new flow\n\nLonger guidance the compact list drops.",
         "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}}},
     },
     {
-        "name": "ap_list_flows",
+        "name": "demo_list_flows",
         "description": "List flows in the current project",
         "inputSchema": {"type": "object"},
     },
@@ -93,7 +93,7 @@ async def test_compact_catalog_lists_names_and_first_lines(
     mock_client.get_advanced_automations_token.assert_awaited_once_with("303088927")
     mock_gateway.list_tools.assert_awaited_once_with("embed-jwt")
     assert '"count": 2' in payload["result"]
-    assert '"ap_create_flow"' in payload["result"]
+    assert '"demo_create_flow"' in payload["result"]
     # Compact mode keeps the first description line and drops the schema.
     assert "Create a new flow" in payload["result"]
     assert "Longer guidance" not in payload["result"]
@@ -109,14 +109,14 @@ async def test_tool_name_returns_full_schema(
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
         result = await session.call_tool(
-            "get_ipaas_tools", {"pipe_id": "303088927", "tool_name": "ap_create_flow"}
+            "get_ipaas_tools", {"pipe_id": "303088927", "tool_name": "demo_create_flow"}
         )
 
     payload = extract_payload(result)
     assert payload["success"] is True
     assert "inputSchema" in payload["result"]
     assert "Longer guidance" in payload["result"]
-    assert "ap_list_flows" not in payload["result"]
+    assert "demo_list_flows" not in payload["result"]
 
 
 @pytest.mark.anyio
@@ -126,14 +126,14 @@ async def test_unknown_tool_name_lists_available(
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
         result = await session.call_tool(
-            "get_ipaas_tools", {"pipe_id": "303088927", "tool_name": "ap_nope"}
+            "get_ipaas_tools", {"pipe_id": "303088927", "tool_name": "demo_nope"}
         )
 
     payload = extract_payload(result)
     assert payload["success"] is False
     message = tool_error_message(payload)
-    assert "ap_nope" in message
-    assert "ap_create_flow" in message
+    assert "demo_nope" in message
+    assert "demo_create_flow" in message
 
 
 @pytest.mark.anyio
@@ -213,7 +213,7 @@ async def test_call_tool_forwards_arguments_and_relays_output(
             "call_ipaas_tool",
             {
                 "pipe_id": "303088927",
-                "tool_name": "ap_create_flow",
+                "tool_name": "demo_create_flow",
                 "arguments": {"name": "My flow"},
             },
         )
@@ -223,12 +223,12 @@ async def test_call_tool_forwards_arguments_and_relays_output(
     assert payload["success"] is True
     mock_client.get_advanced_automations_token.assert_awaited_once_with("303088927")
     mock_gateway.call_tool.assert_awaited_once_with(
-        "embed-jwt", "ap_create_flow", {"name": "My flow"}
+        "embed-jwt", "demo_create_flow", {"name": "My flow"}
     )
     # Text segments are joined and relayed in full.
     assert "flow created" in payload["result"]
     assert "id: flow-1" in payload["result"]
-    assert '"ap_create_flow"' in payload["result"]
+    assert '"demo_create_flow"' in payload["result"]
 
 
 @pytest.mark.anyio
@@ -242,12 +242,14 @@ async def test_call_tool_arguments_default_to_none(
     async with _session(server) as session:
         result = await session.call_tool(
             "call_ipaas_tool",
-            {"pipe_id": "303088927", "tool_name": "ap_list_flows"},
+            {"pipe_id": "303088927", "tool_name": "demo_list_flows"},
         )
 
     payload = extract_payload(result)
     assert payload["success"] is True
-    mock_gateway.call_tool.assert_awaited_once_with("embed-jwt", "ap_list_flows", None)
+    mock_gateway.call_tool.assert_awaited_once_with(
+        "embed-jwt", "demo_list_flows", None
+    )
 
 
 @pytest.mark.anyio
@@ -264,7 +266,7 @@ async def test_call_tool_maps_host_iserror_to_error_payload(
     async with _session(server) as session:
         result = await session.call_tool(
             "call_ipaas_tool",
-            {"pipe_id": "303088927", "tool_name": "ap_delete_flow"},
+            {"pipe_id": "303088927", "tool_name": "demo_delete_flow"},
         )
 
     payload = extract_payload(result)
@@ -285,7 +287,7 @@ async def test_call_tool_null_result_becomes_error_payload_not_attribute_error(
     async with _session(server) as session:
         result = await session.call_tool(
             "call_ipaas_tool",
-            {"pipe_id": "303088927", "tool_name": "ap_list_flows"},
+            {"pipe_id": "303088927", "tool_name": "demo_list_flows"},
         )
 
     payload = extract_payload(result)
@@ -310,7 +312,7 @@ async def test_call_tool_passes_non_text_content_through(
     async with _session(server) as session:
         result = await session.call_tool(
             "call_ipaas_tool",
-            {"pipe_id": "303088927", "tool_name": "ap_get_run"},
+            {"pipe_id": "303088927", "tool_name": "demo_get_run"},
         )
 
     payload = extract_payload(result)
@@ -330,7 +332,7 @@ async def test_call_tool_gateway_error_becomes_error_payload(
     async with _session(server) as session:
         result = await session.call_tool(
             "call_ipaas_tool",
-            {"pipe_id": "303088927", "tool_name": "ap_create_flow"},
+            {"pipe_id": "303088927", "tool_name": "demo_create_flow"},
         )
 
     payload = extract_payload(result)
@@ -346,7 +348,7 @@ async def test_call_tool_unconfigured_gateway_reports_clearly(
     async with _session(server) as session:
         result = await session.call_tool(
             "call_ipaas_tool",
-            {"pipe_id": "303088927", "tool_name": "ap_create_flow"},
+            {"pipe_id": "303088927", "tool_name": "demo_create_flow"},
         )
 
     payload = extract_payload(result)

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -22,7 +22,7 @@ skills/
 ```
 
 **Domain folders** match the MCP tool surface:
-`pipes-and-cards`, `database-tables`, `relations`, `reports`, `automations`, `ai-agents`, `observability`, `members-email-webhooks`, `portal-setup`, `attachments`, `introspection`, `process-design`, `process-intelligence`, `api-troubleshoot`
+`pipes-and-cards`, `database-tables`, `relations`, `reports`, `automations`, `ipaas`, `ai-agents`, `observability`, `members-email-webhooks`, `portal-setup`, `attachments`, `introspection`, `process-design`, `process-intelligence`, `api-troubleshoot`
 
 ---
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -33,6 +33,7 @@ git clone https://github.com/pipefy/ai-toolkit.git
 | **Relations** | [pipefy-relations](relations/pipefy-relations/SKILL.md) | Pipe and card relations. 8 MCP tools. |
 | **Reports** | [pipefy-reports](reports/pipefy-reports/SKILL.md) | Pipe and organization reports, async exports. 17 MCP tools. |
 | **Automations** | [pipefy-automations](automations/pipefy-automations/SKILL.md) | Traditional and AI automations, simulation. 16 MCP tools. |
+| **iPaaS (Advanced Automations)** | [pipefy-ipaas](ipaas/pipefy-ipaas/SKILL.md) | Build, test, publish, and manage integration flows. 4 MCP meta-tools over a per-pipe catalog; MCP-only. |
 | **AI Agents** | [pipefy-ai-agents](ai-agents/pipefy-ai-agents/SKILL.md) | Conversational AI agents and behaviors. 7 MCP tools. |
 | **Observability** | [pipefy-observability](observability/pipefy-observability/SKILL.md) | Logs, usage, credits, execution metrics, job exports. 11 MCP tools. |
 | **Members, Email & Webhooks** | [pipefy-members-email-webhooks](members-email-webhooks/pipefy-members-email-webhooks/SKILL.md) | Membership, email, webhooks. 11 MCP tools. |

--- a/skills/ai-agents/pipefy-ai-agents/SKILL.md
+++ b/skills/ai-agents/pipefy-ai-agents/SKILL.md
@@ -29,6 +29,8 @@ For traditional automations and AI automations (prompt-driven), see [skills/auto
 | `toggle_ai_agent_status` | `pipefy agent toggle` | No | Enable/disable the agent (e.g. `--inactive`). |
 | `validate_ai_agent_behaviors` | `pipefy agent validate-behaviors` | Yes | **Pre-flight check before create/update.** |
 
+The three read tools (`get_ai_agents`, `get_ai_agent`, `validate_ai_agent_behaviors`) are remote-safe: available under the hosted (`profile=remote`) surface. The write tools (`create`/`update`/`delete`/`toggle`) are local-only.
+
 Execution logs live in [skills/observability/](../../observability/pipefy-observability/SKILL.md) (`get_ai_agent_logs`, `get_ai_agent_log_details`).
 
 ---
@@ -64,14 +66,18 @@ For `card_moved` and `field_updated`, you MUST include `event_params`. Omitting 
 
 ### 4 — Discover valid action types
 
-`get_automation_actions(pipe_id)`. Inside `actionsAttributes`:
+`get_automation_actions(pipe_id)`. The 6 known `actionType` values and their required `metadata`:
 
 | Action (`actionType` value) | `metadata` required |
 |--------------|---------------------|
-| update_card | `pipeId` + `fieldsAttributes` with `inputMode` |
+| update_card | `pipeId` + `fieldsAttributes` (each entry needs `fieldId` + `inputMode`) |
 | move_card | `destinationPhaseId` |
 | create_card | `pipeId` + `fieldsAttributes` |
 | create_connected_card | `pipeId` + `fieldsAttributes` (requires pipe relation) |
+| create_table_record | `tableId` + `fieldsAttributes` (table field IDs; **no** `pipeId`) |
+| send_email_template | `emailTemplateId`; optional `allowTemplateModifications` (bool) |
+
+`fieldId` values for card actions accept slug or numeric `internal_id`; for `create_table_record` they are **table** field IDs (validate with `get_table` / `get_table_record`, not the pipe).
 
 ### 5 — Build the behavior dict
 
@@ -94,7 +100,8 @@ For `card_moved` and `field_updated`, you MUST include `event_params`. Omitting 
 - Each behavior MUST have at least one action in `actionsAttributes`.
 - **Maximum 5 behaviors per agent.**
 - The MCP tool auto-injects `referenceId` and `%{action:<uuid>}` placeholders — do NOT generate these yourself.
-- `inputMode: "fill_with_ai"` marks **output** fields the AI writes. **Input** field references (`%{field:<internal_id>}` in the behavior `instruction`, auto-populated into `referencedFieldIds` on create/update) are needed **only when** the AI must read card field values, not for every `fill_with_ai` (e.g. instruction-only, OCR/attachment, or knowledge-base context). When card inputs are needed and omitted, `card.fields` arrives empty at trigger time and the model may hallucinate. A wrong **numeric** input id is accepted silently (validate and create/update) and becomes a dead `referencedFieldId`; a wrong **slug** never resolves and is dropped by the digits-only extractor (unresolved token). Either way `card.fields` stays empty (same hallucination); confirm the id with `get_start_form_fields` / `get_phase_fields`. Dotted connected-pipe refs (`%{field:<parent>.<child>}`) are not forwarded at runtime; to read a connected card field, use a field on the current pipe. Omit `inputMode` and set `value` for fixed values.
+- **`inputMode` is required on every `fieldsAttributes` entry** (omitting it fails model validation). Values: `fill_with_ai` (AI writes the value into an **output** field), `fixed_value` (use the literal `value`), `copy_from` (`value` is a `%{…}` template copying another field).
+- **Input** field references (`%{field:<internal_id>}` in the behavior `instruction`, auto-populated into `referencedFieldIds` on create/update) are needed **only when** the AI must read card field values, not for every `fill_with_ai` (e.g. instruction-only, OCR/attachment, or knowledge-base context). When card inputs are needed and omitted, `card.fields` arrives empty at trigger time and the model may hallucinate. A wrong **numeric** input id is accepted silently (validate and create/update) and becomes a dead `referencedFieldId`; a wrong **slug** never resolves and is dropped by the digits-only extractor (unresolved token). Either way `card.fields` stays empty (same hallucination); confirm the id with `get_start_form_fields` / `get_phase_fields`. Dotted connected-pipe refs (`%{field:<parent>.<child>}`) are not forwarded at runtime; to read a connected card field, use a field on the current pipe.
 - For `update_card`: set `destinationPhaseId: ""` when not moving the card.
 
 #### Example identifiers (fictional)
@@ -121,6 +128,12 @@ Use real values from `get_pipe` / `get_start_form_fields` for your org. Placehol
 
 // create_card
 { "pipeId": "900000301", "fieldsAttributes": [{ "fieldId": "title", "inputMode": "fill_with_ai", "value": "" }] }
+
+// create_table_record (fieldsAttributes are TABLE field IDs; no pipeId)
+{ "tableId": "<table_id>", "fieldsAttributes": [{ "fieldId": "<table_field_id>", "inputMode": "fill_with_ai", "value": "" }] }
+
+// send_email_template
+{ "emailTemplateId": "<template_id>", "allowTemplateModifications": false }
 ```
 
 ### 5b — Optional: capabilities and LLM provider
@@ -157,21 +170,25 @@ Inside `actionParams.aiBehaviorParams` a behavior may also carry:
 - Output field IDs (`fieldsAttributes[].fieldId`) exist in the pipe
 - Phase IDs exist
 - Pipe relations exist for `create_connected_card`
-- Action types are valid
+- Action types are valid (the 6 in `KNOWN_AI_ACTION_TYPES`; `create_table_record` `fieldsAttributes` are **table** field IDs, so they are not checked against the pipe and surface a warning to verify with `get_table`; `send_email_template` metadata runs no pipe field-ID checks)
 - Behavior structure passes Pydantic validation (including canonical `capabilitiesAttributes` shape and at most one of `providerId` / `systemProviderId`)
 - `fieldsAttributes[].fieldId` values (outputs) are checked against start-form and phase fields, accepting both slug `id` and numeric `internal_id`. Instruction `%{field:...}` tokens (inputs) are **not** existence-checked: a missing id/slug still yields `valid: true`. Slug → numeric rewrite happens only on create/update, not here.
 - Pass `data_source_ids` (agent-level) to also check knowledge base membership: it is unioned with each behavior's `dataSourceIds` and checked against the pipe's knowledge bases. Unknown IDs are **warnings only** (`valid` stays true); if the knowledge base list cannot be read, a single warning is added and the check is skipped.
 
+**`strict_unknown_action_types`** (default `true`): an `actionType` outside the known 6 is reported in `problems` (blocking). Set `false` to demote unknown action types to `warnings` only, so `valid` stays true. CLI: `--strict` (default) / `--no-strict` on `agent validate-behaviors`, `agent create`, and `agent update`.
+
 ### 7 — Create the agent
 
 `create_ai_agent` with `name`, `repo_uuid`, `instruction`, and `behaviors`. One-call creation is preferred — avoids partial agent shells. Agents are **active by default**.
+
+The **CLI** `agent create` / `agent update` require `--pipe` (numeric pipe id) and run `validate_ai_agent_behaviors` automatically as a pre-flight, blocking the write when `problems` are found and surfacing `warnings` under a `preflight` key. The MCP tools do **not** auto-preflight, so call `validate_ai_agent_behaviors` yourself (step 6) before `create_ai_agent` / `update_ai_agent`. CLI flags: `--repo-uuid`, `--name`, `--instruction`, `--behaviors` (JSON array), `--data-sources` (JSON array); `agent validate-behaviors` instead takes `--data-source-id` (repeatable).
 
 On create/update, slug `fieldId` values are resolved to numeric `internal_id`, `%{field:<slug>}` is rewritten to `%{field:<internal_id>}`, and `referencedFieldIds` is auto-populated when applicable.
 
 ### 8 — Handle responses
 
 - **Success with `agent_uuid`** → done.
-- **Partial failure (UUID returned, behaviors rejected)** → call `update_ai_agent` with that UUID. Do NOT create a second agent.
+- **Partial failure (UUID returned, behaviors rejected)** → call `update_ai_agent` with the **full required payload**: `uuid`, `repo_uuid` (same pipe UUID used on create), `name`, `instruction`, and complete `behaviors` (full-replace, not patch). Do NOT create a second agent.
 - **Failure without UUID** → validation or API error. Trust the hint text in the enriched error.
 
 ### 9 — Verify
@@ -291,7 +308,7 @@ Per behavior you can pass `template_params` (or `placeholders`) with `str → st
 
 - **`update_ai_agent` is full-replace, not patch.** Fetch existing behaviors with `get_ai_agent` first, merge, then update — otherwise existing behaviors are silently dropped.
 - **Behavior save is all-or-nothing (`RECORD_NOT_SAVED`).** One invalid behavior rejects the entire list. The MCP tool auto-validates the payload on failure; if structurally correct, the error indicates a pipe-level restriction (not your payload). Inform the user this pipe does not support AI agent behaviors and suggest alternatives.
-- **Partial-failure recovery.** If `create_ai_agent` returns a UUID but reports failure, call `update_ai_agent` with that UUID. Do NOT create a second agent.
+- **Partial-failure recovery.** If `create_ai_agent` returns a UUID but reports failure, call `update_ai_agent(uuid, repo_uuid, name, instruction, behaviors)` — all five are required. Reuse the create `repo_uuid`; send the full behaviors list. Do NOT create a second agent.
 - **Cross-pipe `PERMISSION_DENIED`.** Behaviors with `create_connected_card` or cross-pipe `create_card` require the service account to be a member of **both** source and destination pipes. When it is not, the API returns a bare `PERMISSION_DENIED`. Recovery: `get_pipe_members` + `invite_members` on the destination pipe.
 - **Phase transition rule on `move_card`.** Destination must be reachable from the source phase (`cards_can_be_moved_to_phases`). Both `validate_ai_agent_behaviors` and `create_ai_agent` / `update_ai_agent` enrich this error with `valid_destinations` and a hint that transition rules are editable in the Pipefy UI only.
 - **Maximum 5 behaviors per agent.** Adding a 6th rejects the whole save.

--- a/skills/ipaas/pipefy-ipaas/SKILL.md
+++ b/skills/ipaas/pipefy-ipaas/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: pipefy-ipaas
+description: >
+  Use when the user wants to build, test, publish, or manage iPaaS
+  (Advanced Automations) flows: multi-step integrations with external apps
+  (Slack, Gmail, Google Sheets), incoming webhooks, schedules, routers, code
+  steps, or iPaaS data tables. MCP-only, driven through 4 meta-tools over a
+  per-pipe catalog discovered at runtime. For native if/then rules or
+  prompt-driven AI automations, use skills/automations/ instead.
+tags: [pipefy, ipaas, advanced-automations, flows, integrations]
+---
+
+# iPaaS (Advanced Automations)
+
+Pipefy's embedded workflow-automation platform. A **flow** is a trigger plus a sequence of steps that call **pieces** (integration connectors). The MCP server exposes it through **4 meta-tools**: the flow-builder verbs are catalog entries you discover per pipe and invoke through `call_ipaas_tool`, never a fixed tool list.
+
+## When to use
+
+- "Integrate with Slack / Gmail / Google Sheets / an external app."
+- "When a webhook comes in, do X." "On a schedule, do Y."
+- "Build a multi-step flow with a router / loop / code step."
+- Managing iPaaS data tables (separate from Pipefy database tables).
+
+**When not to use:** native if/then rules on card events, or prompt-driven AI automations, both live in [skills/automations/pipefy-automations/SKILL.md](../../automations/pipefy-automations/SKILL.md). Simple HTTP callbacks on card events are `create_webhook` in [skills/members-email-webhooks/pipefy-members-email-webhooks/SKILL.md](../../members-email-webhooks/pipefy-members-email-webhooks/SKILL.md).
+
+## Prerequisites
+
+- **iPaaS enabled on the organization.** If not, the backend typically returns a permission error (often coded `PERMISSION_DENIED` with text like "iPaaS is disabled for your organization" — exact code/string is backend-dependent).
+- **iPaaS OAuth client configured on this MCP server.** If `PIPEFY_IPAAS_OAUTH_CLIENT_ID` is blank, every tool returns a "disabled on this server" message (server-config disable, distinct from the org-level one).
+- **Permission to create automations on the pipe** (pipe-admin ability).
+- **MCP-only.** There is no CLI twin (deferred in [docs/parity.md](../../../docs/parity.md)).
+- The iPaaS workspace is **per-pipe**: the catalog and any existing flows, connections, and tables belong to one `pipe_id`, so the same call against two pipes can differ.
+- Under `profile=remote`, `$env` secret references in arguments are rejected.
+
+## Tools needed (MCP)
+
+| Tool (MCP) | Read-only | Purpose |
+|------------|-----------|---------|
+| `get_ipaas_tools` | Yes | Discover the per-pipe catalog (compact), or with `tool_name` expand one entry's full input schema. |
+| `call_ipaas_tool` | No | Invoke one catalog entry by name with `arguments` matching its schema. |
+| `get_ipaas_connection_auth_url` | No | Start an OAuth connection: returns a consent URL to hand the user, plus a completion bundle. |
+| `create_ipaas_connection` | No | Finish an OAuth connection, or create a token / API-key one directly. |
+
+## The meta-tool pattern
+
+The catalog is large (flow building, testing, tables, runs), some entries carrying very large input schemas. Do not load them all. Work in three steps:
+
+1. `get_ipaas_tools(pipe_id)` — compact catalog: each entry's `name` and one-line description.
+2. `get_ipaas_tools(pipe_id, tool_name="...")` — one entry's full description and `inputSchema`, fetched right before you use it.
+3. `call_ipaas_tool(pipe_id, tool_name="...", arguments={...})` — invoke it. Arguments are forwarded verbatim; the iPaaS host validates them and its error messages relay back.
+
+Never expand more than the entry you are about to call, and read the entry's own schema for exact argument names (they are not uniform across the catalog). What the catalog offers, by capability group:
+
+- **Author a flow** — create a flow (trigger plus steps) in one call; add or update individual steps; set or update the trigger; add conditional router branches; rename or duplicate a flow. Steps can be an integration piece, a code step, a loop, or a router (prefer a piece over code).
+- **Inspect a flow** — list flows; read a flow's step tree and per-step validity; validate a flow before publishing.
+- **Discover pieces** — search the piece catalog (exact or fuzzy); read a piece action/trigger's input properties; resolve dropdown option values; validate a step config before applying it.
+- **Connections** — list existing connections (each exposes an `externalId` used as a step's `auth`); get setup guidance.
+- **Publish / lifecycle** — lock and publish a draft (enables it); enable or disable a published flow; delete a flow.
+- **Test and runs** — test a flow end to end; test a single step; list runs; read one run's detail; retry a failed run; run one piece action once without saving a flow.
+- **iPaaS data tables** — list tables, query records, create tables and fields, insert/update/delete records, delete a table.
+- **AI** — list configured AI providers and models for agent-style steps.
+
+Destructive entries (delete flow, delete table, delete records, delete step) are permanent and have no preview. Reserve them for explicit user intent.
+
+## Steps — build and test a flow
+
+The proven lifecycle: **discover, build, validate, test, then publish.** A self-contained webhook-to-code flow (no external connection) validated this end to end live.
+
+1. **Discover** the catalog, then expand the flow-builder entry to read its schema:
+
+   ```
+   get_ipaas_tools pipe_id=<pipe_id>
+   get_ipaas_tools pipe_id=<pipe_id> tool_name=<flow-builder entry>
+   ```
+
+2. **Research the pieces** you will use and read the exact trigger/action props before building. A trigger often has required config: a webhook trigger, for example, requires an authentication-type property (set it to none for an open URL). Use the piece-research and piece-props entries from the catalog.
+
+3. **Build the flow** in one call via the flow-builder entry: a trigger plus an ordered list of steps. Reference the trigger output and earlier steps with the host's templating in each step's input. The call returns a `flowId` and a per-step validity summary.
+
+4. **Validate** before testing (the validate entry) — reports structural issues without publishing.
+
+5. **Test-run** end to end via the test entry. It runs in the TESTING environment; every `call_ipaas_tool` has a ~120s network budget (most relevant here for long runs). Pass mock trigger data when the trigger has no saved sample. A success returns each step's output — treat that payload as the source of truth for the test. **Test-run has real side effects** for external-app pieces (the action actually fires), so keep test data disposable; self-contained pieces (webhook, schedule, code, tables) are safe.
+
+6. **(Optional) Inspect the run** with the run-detail entry for full step-by-step output. Read its schema for the exact argument name. Prefer the id returned by the test; if the run is not found, fall back to the run-listing entry or stop, since the test payload already holds the outputs.
+
+7. **Publish** only on explicit user intent: the lock-and-publish entry locks the draft, publishes it, and enables it (yielding a live webhook URL for webhook triggers). A separate entry enables or disables an already-published flow.
+
+## Steps — connect an external app
+
+Any piece that touches an external app (Slack, Gmail, Google Sheets) needs a **connection** first; pass its `externalId` as the step's (or trigger's) `auth`. Self-contained pieces (webhook, schedule, HTTP, code, iPaaS tables) need none.
+
+1. List existing connections (the connection-listing entry) and reuse an `externalId` if one fits. When several candidates serve the same piece, name them and ask the user rather than pick silently.
+2. **Token / API-key pieces:** one `create_ipaas_connection` call with the credential (`connection_type` plus `value` matching the piece's auth props). To keep the secret out of the conversation, set it in the server environment and reference it as `{"$env": "PIPEFY_IPAAS_CONNECTION_<NAME>"}` (local servers only; rejected under `profile=remote`).
+3. **OAuth pieces:** `get_ipaas_connection_auth_url` returns a consent URL and a completion bundle; the user authorizes in a browser and pastes back the redirect URL; `create_ipaas_connection` finishes it. Durable tokens are stored host-side. Creation is an upsert on `external_id` (reuse an id to rotate a credential).
+4. For dropdown fields (Slack channel, sheet, label), resolve options against the connection with the option-resolving entry and use the option `value`, not the label. Large external workspaces can time out; take the ID from the user and pass it literally, since the action still works at runtime.
+
+## Steps — one-shot action (no flow)
+
+For a single task ("send one Slack message", "check my inbox"), the catalog has a run-one-action entry: a piece, action, `input`, and `auth`, executed once. No flow is created or saved.
+
+## Success criteria
+
+- The validate entry reports the flow ready to publish (all steps valid).
+- The test entry returns a success with the expected step outputs.
+- The list/structure entries show the flow with a configured trigger and no unconfigured steps.
+
+## Failure modes
+
+- **Org-level iPaaS disabled.** The backend typically returns a permission error (often `PERMISSION_DENIED` / "iPaaS is disabled for your organization"); nothing in the catalog works. Enable iPaaS on the org or use one that has it.
+- **Server-config iPaaS disabled.** When `PIPEFY_IPAAS_OAUTH_CLIENT_ID` is blank, tools return "disabled on this server" — restore the default or set a client id.
+- **Trigger unconfigured after build.** A trigger with required props (for example a webhook trigger's authentication type) blocks validation until set. Read its props first, then set them in the trigger input.
+- **Wrong argument name.** Entry schemas are not uniform (a run-detail entry may key the run id differently from how a test entry returns it). Always expand the entry with `get_ipaas_tools(pipe_id, tool_name=…)` and build arguments from that schema.
+- **Test-run has real side effects.** For external-app pieces the test performs the real action even from a draft. Keep test data disposable; self-contained pieces are safe.
+- **External step fails with an auth error.** The piece needs a connection. Create one and pass its `externalId` as the step `auth`; for Slack the bot must be a member of the target channel.
+- **Dropdown resolution times out.** Large external workspaces can time out. Ask the user for the ID and pass it literally.
+- **`$env` rejected under remote profile.** Secret references are local-only. Pass credentials through `create_ipaas_connection`, not inline `$env`.
+- **Accidental destruction.** Delete entries (flow, table, records) are permanent and have no preview. Confirm intent first; prefer updating a step over deleting it (delete destroys sample data).
+
+## See also
+
+- [skills/automations/pipefy-automations/SKILL.md](../../automations/pipefy-automations/SKILL.md) — native if/then rules and AI automations (not iPaaS).
+- [skills/members-email-webhooks/pipefy-members-email-webhooks/SKILL.md](../../members-email-webhooks/pipefy-members-email-webhooks/SKILL.md) — `create_webhook` for HTTP callbacks on card events.
+- [docs/mcp/tools/ipaas.md](../../../docs/mcp/tools/ipaas.md) and [docs/ipaas.md](../../../docs/ipaas.md) — meta-tool semantics and flow vocabulary.


### PR DESCRIPTION
## Summary

Agent-facing skills update for Advanced Automations (iPaaS) and AI agents, plus a small test rename so fixtures do not bake vendor catalog entry names.

### New: `skills/ipaas/pipefy-ipaas/`

MCP-only skill for Pipefy Advanced Automations (integration flows). Teaches agents to:

- Use the **4 meta-tools** (`get_ipaas_tools`, `call_ipaas_tool`, `get_ipaas_connection_auth_url`, `create_ipaas_connection`) instead of a fixed verb list
- Follow **discover → expand one schema → call** (compact catalog first; expand only the entry about to run)
- Treat the catalog as **per-pipe and discovered at runtime** (capability groups: author / inspect / pieces / connections / publish / test / tables / AI — no hardcoded vendor entry names)
- Run the happy path **build → validate → test → (optional) inspect run → publish**, with connections / OAuth / `$env` (local-only) notes
- Handle common failure modes (org iPaaS disabled, wrong arg names, test side effects, run-detail not-found after a SUCCEEDED test)

Also registers the `ipaas` domain in `skills/README.md` and `skills/AGENTS.md`.

### Refresh: `skills/ai-agents/pipefy-ai-agents/`

Brings the skill in line with the current MCP/CLI surface:

- Documents all **6** known `actionType`s, including `create_table_record` and `send_email_template` (with metadata examples)
- Clarifies that **`inputMode` is required** on every `fieldsAttributes` entry (`fill_with_ai` / `fixed_value` / `copy_from`)
- Notes **remote-safe** reads vs local-only writes
- Documents CLI **auto pre-flight** on `agent create` / `agent update` vs MCP (call `validate_ai_agent_behaviors` yourself)
- Documents `strict_unknown_action_types` / `--strict` / `--no-strict`
- Fixes **partial-create recovery**: `update_ai_agent` needs the full required payload (`uuid`, `repo_uuid`, `name`, `instruction`, complete `behaviors`), not uuid alone

### Tests

- `packages/mcp/tests/core/test_ipaas_gateway.py`
- `packages/mcp/tests/tools/test_ipaas_tools.py`

Fixture catalog names renamed `ap_*` → `demo_*` so unit tests match the discover-at-runtime posture (no vendor-prefixed entry names in fixtures).

## Out of scope

- No MCP/CLI tool behavior changes (skills + test fixture naming only)
- Local smoke notes under `.cursor/qa-tests-and-smoke/` remain gitignored

## Test plan

- [x] Live iPaaS lifecycle on pipe `306771710` (org `300514213`): build → validate → test-run `SUCCEEDED` → delete
- [x] `uv run pytest packages/mcp/tests/core/test_ipaas_gateway.py packages/mcp/tests/tools/test_ipaas_tools.py -q` — 58 passed
- [x] `uv run ruff format --check` on touched test files
- [x] Skills Lint CI (frontmatter + MCP/CLI refs)
- [ ] Human review: catalog links in `skills/README.md` and AI agents action-type table vs current MCP/CLI