### PR TITLE
docs: beginner onboarding for hosted MCP (extends #246)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "pipefy",
       "source": "./",
       "description": "Pipefy workflow integration for Claude Code.",
-      "version": "0.2.0-beta.1",
+      "version": "0.3.0-beta.1",
       "homepage": "https://github.com/pipefy/ai-toolkit",
       "repository": "https://github.com/pipefy/ai-toolkit"
     }

--- a/.github/workflows/scripts/lint_skill_refs.py
+++ b/.github/workflows/scripts/lint_skill_refs.py
@@ -18,6 +18,7 @@ PIPEFY_CLI_ROOT_COMMANDS = frozenset(
         "ai-provider",
         "attachment",
         "audit",
+        "auth",
         "automation",
         "card",
         "email",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Documentation map
-- **`README.md`** — Project pitch, one-page install (MCP client JSON for Claude Code / Cursor / Claude Desktop / Codex, CLI, skills), repo layout, MCP tools table, contributing.
+- **`README.md`** — Project pitch, one-page install front door (`README.md#installation`: hosted MCP, Quick install, Claude Code plugin, CLI, skills), repo layout, MCP tools table, contributing.
 - **`CONTRIBUTING.md`** — Skills contribution guide (frontmatter, CI, style); entry point for GitHub contributors.
 - **`docs/README.md`** — Index of docs by surface (MCP, CLI, SDK) and shared guides.
 - **`docs/config.md`** — `PIPEFY_*` environment variables, `config.toml` schema, precedence chain.
@@ -13,6 +13,7 @@
 - **`docs/cli/`** — CLI-specific guides (e.g. introspect-then-execute).
 - **`docs/sdk/README.md`** — Using `pipefy` as a library.
 - **`skills/AGENTS.md`** — Skill-authoring guide (frontmatter, naming, style). Start here before adding a skill.
+- **`skills/onboarding/pipefy-toolkit-setup/`** — First-time setup checklist for agents (links to README snippets; does not own commands).
 
 ## Project structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Docs / skills**: hosted MCP (`mcp.pipefy.com`) install snippet on the root README front door; first-time agent checklist [`pipefy-toolkit-setup`](skills/onboarding/pipefy-toolkit-setup/SKILL.md) (path choice / ask-your-agent / verify — commands stay in `README.md#installation`, per #246).
+
+### Fixed
+
+- **Installer**: Claude Code next-steps print `/pipefy:pipefy-login` (and the full plugin slash sequence) instead of the stale `/pipefy-login` label.
+
 ## [0.3.0-beta.1] - 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Feedback and issues: [GitHub Issues](https://github.com/pipefy/ai-toolkit/issues
 
 ## Installation
 
-> Pre-1.0 ships pre-release builds to PyPI on every tag; `uvx` and `uv tool install` resolve them. A stable PyPI release becomes the default at **v1.0**. The current pre-release line is **`v0.3.0-alpha.*`** (first tag: [`v0.3.0-alpha.1`](https://github.com/pipefy/ai-toolkit/releases/tag/v0.3.0-alpha.1)). Two install paths: the **Quick install** script below (resolves the latest GitHub Release at runtime and runs `uv tool install` for you), or **Claude Code** via the plugin marketplace.
+> Pre-1.0 ships pre-release builds to PyPI on every tag; `uvx` and `uv tool install` resolve them. A stable PyPI release becomes the default at **v1.0**. The current pre-release line is **`v0.3.0-alpha.*`** (first tag: [`v0.3.0-alpha.1`](https://github.com/pipefy/ai-toolkit/releases/tag/v0.3.0-alpha.1)). Two install paths: the **Quick install** script below (resolves the latest GitHub Release at runtime and runs `uv tool install` for you), or **Claude Code** via the plugin marketplace (or hosted MCP).
 >
 > The CLI snippets below install `pipefy-cli` from PyPI, which resolves `pipefy` and `pipefy-auth` transitively (no explicit `--with` needed). While the toolkit ships only pre-release versions (the 0.x line), `uv` resolves the latest pre-release automatically; to pin a specific one, use `pipefy-cli==X.Y.Z` (PEP 440 form, e.g. `pipefy-cli==0.3.0a1`). Do not pass a global `--prerelease allow`: it also lets transitive dependencies jump to their own pre-releases, which can pull a broken build.
 
@@ -57,6 +57,20 @@ Two auth paths:
 - **Service account (unattended / CI)**: provision a Service Account in [Pipefy Admin](https://app.pipefy.com/) (Admin → Service Accounts) and add that account to every pipe the tools should touch. Wire `PIPEFY_SERVICE_ACCOUNT_CLIENT_ID` and `PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET` into the client config below.
 
 Full env-var reference and `config.toml` precedence: [`docs/config.md`](docs/config.md).
+
+**First-time / ask your agent:** paste a setup request into Claude or Cursor and point them at this section — the checklist is [`skills/onboarding/pipefy-toolkit-setup/SKILL.md`](skills/onboarding/pipefy-toolkit-setup/SKILL.md). Pick **one** MCP registration named `pipefy` (do not mix hosted HTTP and local stdio/plugin under the same name).
+
+### Hosted MCP (Claude Code)
+
+Zero local Python: Claude Code connects over HTTPS. Auth is the client OAuth flow (`--client-id pipefy-mcp`). Hosted exposes the **remote-safe** tool surface only.
+
+```bash
+claude mcp add --transport http --scope user \
+  --client-id pipefy-mcp \
+  pipefy https://mcp.pipefy.com/mcp
+```
+
+Complete the browser login when prompted. For CLI/slash commands without a second MCP server, use [Claude Code](#claude-code) **instead**, or install the CLI only ([CLI](#cli)). Hand-wired local stdio: [`packages/mcp/README.md`](packages/mcp/README.md).
 
 ### Quick install (recommended)
 
@@ -86,7 +100,7 @@ After install, run `pipefy auth login` to authenticate (`--device` on headless s
 /pipefy:pipefy-login
 ```
 
-`/plugin install pipefy` registers the MCP server and the `/pipefy:install` + `/pipefy:pipefy-login` slash commands. `/pipefy:install` runs `uv tool install` once to put `pipefy` on PATH (idempotent). `/pipefy:pipefy-login` runs the OAuth browser flow. For hand-wired setups (paste-into-config blocks per client, the macOS `errSecParam` keychain note, the local-clone alternative for contributors), see [`packages/mcp/README.md`](packages/mcp/README.md).
+Type the slash commands **in order** (the model cannot invoke `/plugin …` for you). `/plugin install pipefy` registers the local MCP server and the `/pipefy:install` + `/pipefy:pipefy-login` slash commands. `/pipefy:install` runs `uv tool install` once to put `pipefy` on PATH (idempotent). `/pipefy:pipefy-login` runs the OAuth browser flow. For hand-wired setups (paste-into-config blocks per client, the macOS `errSecParam` keychain note, the local-clone alternative for contributors), see [`packages/mcp/README.md`](packages/mcp/README.md).
 
 ### CLI
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Feedback and issues: [GitHub Issues](https://github.com/pipefy/ai-toolkit/issues
 
 ## Installation
 
-> Pre-1.0 ships pre-release builds to PyPI on every tag; `uvx` and `uv tool install` resolve them. A stable PyPI release becomes the default at **v1.0**. The current pre-release line is **`v0.3.0-alpha.*`** (first tag: [`v0.3.0-alpha.1`](https://github.com/pipefy/ai-toolkit/releases/tag/v0.3.0-alpha.1)). Two install paths: the **Quick install** script below (resolves the latest GitHub Release at runtime and runs `uv tool install` for you), or **Claude Code** via the plugin marketplace (or hosted MCP).
+> Pre-1.0 ships pre-release builds to PyPI on every tag; `uvx` and `uv tool install` resolve them. A stable PyPI release becomes the default at **v1.0**. The current pre-release line is **`v0.3.0-beta.*`** (latest tag: [`v0.3.0-beta.1`](https://github.com/pipefy/ai-toolkit/releases/tag/v0.3.0-beta.1)). Two install paths: the **Quick install** script below (resolves the latest GitHub Release at runtime and runs `uv tool install` for you), or **Claude Code** via the plugin marketplace (or hosted MCP).
 >
-> The CLI snippets below install `pipefy-cli` from PyPI, which resolves `pipefy` and `pipefy-auth` transitively (no explicit `--with` needed). While the toolkit ships only pre-release versions (the 0.x line), `uv` resolves the latest pre-release automatically; to pin a specific one, use `pipefy-cli==X.Y.Z` (PEP 440 form, e.g. `pipefy-cli==0.3.0a1`). Do not pass a global `--prerelease allow`: it also lets transitive dependencies jump to their own pre-releases, which can pull a broken build.
+> The CLI snippets below install `pipefy-cli` from PyPI, which resolves `pipefy` and `pipefy-auth` transitively (no explicit `--with` needed). While the toolkit ships only pre-release versions (the 0.x line), `uv` resolves the latest pre-release automatically; to pin a specific one, use `pipefy-cli==X.Y.Z` (PEP 440 form, e.g. `pipefy-cli==0.3.0b1`). Do not pass a global `--prerelease allow`: it also lets transitive dependencies jump to their own pre-releases, which can pull a broken build.
 
 Two auth paths:
 

--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ Full env-var reference and `config.toml` precedence: [`docs/config.md`](docs/con
 
 Zero local Python: Claude Code connects over HTTPS. Auth is the client OAuth flow (`--client-id pipefy-mcp`). Hosted exposes the **remote-safe** tool surface only.
 
+Do **not** run this if you already have a local/plugin MCP named `pipefy` (or another Pipefy stdio entry you intend to keep). Remove the conflicting registration first: `claude mcp remove pipefy -s user` (adjust name/scope), or use the [Claude Code plugin](#claude-code) path instead of hosted.
+
 ```bash
 claude mcp add --transport http --scope user \
   --client-id pipefy-mcp \
   pipefy https://mcp.pipefy.com/mcp
 ```
 
-Complete the browser login when prompted. For CLI/slash commands without a second MCP server, use [Claude Code](#claude-code) **instead**, or install the CLI only ([CLI](#cli)). Hand-wired local stdio: [`packages/mcp/README.md`](packages/mcp/README.md).
+Complete the browser login when prompted (`claude mcp login pipefy` if the client reports Needs authentication). For CLI/slash commands without a second MCP server, use [Claude Code](#claude-code) **instead**, or install the CLI only ([CLI](#cli)). Hand-wired local stdio: [`packages/mcp/README.md`](packages/mcp/README.md).
 
 ### Quick install (recommended)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,4 +24,4 @@ Human-facing guides for the **[pipefy/ai-toolkit](https://github.com/pipefy/ai-t
 | [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Contributing skills (Markdown playbooks) |
 | [`../RELEASE.md`](../RELEASE.md) | Versioning and GitHub Releases |
 
-First-time install and per-client MCP wiring live in the root [`README.md#installation`](../README.md#installation). Package READMEs under `packages/*/README.md` cover surface-specific edge cases.
+First-time install and per-client MCP wiring live in the root [`README.md#installation`](../README.md#installation). First-time agent checklist (path choice, ask-your-agent, verify): [`skills/onboarding/pipefy-toolkit-setup/SKILL.md`](../skills/onboarding/pipefy-toolkit-setup/SKILL.md). Package READMEs under `packages/*/README.md` cover surface-specific edge cases.

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -23,6 +23,6 @@ Material in this tree describes **`pipefy-mcp-server`**: the MCP process, tool b
 
 Start with [`tools/cross-cutting.md`](tools/cross-cutting.md) for pagination, IDs, `debug`, permissions, and error shape — then open the domain guide you need.
 
-For install and per-client MCP wiring (Cursor, Claude Desktop, Claude Code, Codex), see the root [`README.md#installation`](../../README.md#installation). For environment variables and `config.toml`, see [`../config.md`](../config.md). Edge cases (`errSecParam`, `.mcp.json`, local-clone alternative): [`packages/mcp/README.md`](../../packages/mcp/README.md).
+For install and per-client MCP wiring (hosted HTTP, Cursor, Claude Desktop, Claude Code, Codex), see the root [`README.md#installation`](../../README.md#installation). First-time agent checklist: [`skills/onboarding/pipefy-toolkit-setup/SKILL.md`](../../skills/onboarding/pipefy-toolkit-setup/SKILL.md). For environment variables and `config.toml`, see [`../config.md`](../config.md). Edge cases (`errSecParam`, local `claude mcp add`, `.mcp.json`, local-clone alternative): [`packages/mcp/README.md`](../../packages/mcp/README.md).
 
 The MCP ↔ CLI coverage matrix lives at **[`../parity.md`](../parity.md)**.

--- a/install.sh
+++ b/install.sh
@@ -416,9 +416,11 @@ write_client_config() {
             ;;
         claude-code)
             cat <<EOF
-To install in Claude Code, run these slash commands:
+To install in Claude Code, run these slash commands in order:
   /plugin marketplace add $REPO
   /plugin install pipefy@pipefy
+  /pipefy:install
+  /pipefy:pipefy-login
 EOF
             ;;
         ""|none)
@@ -455,7 +457,7 @@ print_next_steps() {
     say "  Default (browser):   pipefy auth login"
     say "  Headless (device):   pipefy auth login --device"
     if [ "$CLIENT" = "claude-code" ]; then
-        say "  Via Claude Code:     /pipefy-login"
+        say "  Via Claude Code:     /pipefy:pipefy-login"
     fi
 }
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -36,14 +36,18 @@ Full reference (every `PIPEFY_*` variable, validation rules, TOML schema, preced
 
 ### Claude Code: `claude mcp add` (per-project terminal flow)
 
-Useful when you want to wire the server without editing `~/.claude.json` by hand:
+Useful when you want to wire the server without editing `~/.claude.json` by hand.
+
+**Hosted MCP (HTTP)** — zero local Python; OAuth in Claude Code. Prefer this when you do not need the full local tool surface. Do not also install the Claude Code plugin’s local `pipefy` server under the same name. Canonical snippet: [root README — Hosted MCP](../../README.md#hosted-mcp-claude-code).
+
+**Local stdio** — runs `uvx pipefy-mcp-server` on the machine:
 
 ```bash
 claude mcp add --scope project pipefy \
   -- uvx pipefy-mcp-server
 ```
 
-Then (repeat for each key you need):
+Then (repeat for each key you need; service-account path):
 
 ```bash
 claude mcp add-env pipefy PIPEFY_SERVICE_ACCOUNT_CLIENT_ID <YOUR_CLIENT_ID>

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -22,7 +22,7 @@ skills/
 ```
 
 **Domain folders** match the MCP tool surface:
-`pipes-and-cards`, `database-tables`, `relations`, `reports`, `automations`, `ai-agents`, `observability`, `members-email-webhooks`, `portal-setup`, `attachments`, `introspection`, `process-design`, `process-intelligence`, `api-troubleshoot`
+`pipes-and-cards`, `database-tables`, `relations`, `reports`, `automations`, `ai-agents`, `observability`, `members-email-webhooks`, `portal-setup`, `attachments`, `introspection`, `process-design`, `process-intelligence`, `api-troubleshoot`, `onboarding`
 
 ---
 
@@ -123,7 +123,7 @@ When a skill needs stable URLs into this repo’s Markdown:
 - **MCP tool semantics** — `docs/mcp/tools/<domain>.md` (cross-cutting rules: `docs/mcp/tools/cross-cutting.md`).
 - **CLI-only flows** — `docs/cli/` (e.g. `docs/cli/self-healing.md`).
 - **SDK usage** — `docs/sdk/README.md`.
-- **Install** — always root `README.md#installation`; **`PIPEFY_*` env vars and `config.toml`** — `docs/config.md`; **MCP ↔ CLI matrix** — `docs/parity.md`.
+- **Install** — always root `README.md#installation` (canonical snippets); first-time agent checklist — `skills/onboarding/pipefy-toolkit-setup/SKILL.md`; **`PIPEFY_*` env vars and `config.toml`** — `docs/config.md`; **MCP ↔ CLI matrix** — `docs/parity.md`.
 
 ---
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -42,6 +42,7 @@ git clone https://github.com/pipefy/ai-toolkit.git
 | **Process Design** | [pipefy-process-design](process-design/pipefy-process-design/SKILL.md) | Process architecture (consulting; not execution). |
 | **Process Intelligence** | [pipefy-process-intelligence](process-intelligence/pipefy-process-intelligence/SKILL.md) | Analyze pipes for improvement opportunities. |
 | **API Fallback** | [pipefy-api-fallback](api-troubleshoot/pipefy-api-fallback/SKILL.md) | Raw GraphQL fallback when higher-level tools are insufficient. |
+| **Onboarding** | [pipefy-toolkit-setup](onboarding/pipefy-toolkit-setup/SKILL.md) | First-time install: hosted MCP, `install.sh`, or Claude Code plugin. |
 
 ---
 

--- a/skills/onboarding/pipefy-toolkit-setup/SKILL.md
+++ b/skills/onboarding/pipefy-toolkit-setup/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: pipefy-toolkit-setup
+description: >
+  Guide a first-time user through Pipefy AI toolkit setup (hosted MCP,
+  local install.sh, or Claude Code plugin). Use when the user asks to
+  install Pipefy MCP, connect Claude/Cursor to Pipefy, run /pipefy:install,
+  or set up mcp.pipefy.com. Do not use for day-to-day Pipefy workflows
+  after MCP is already working.
+tags: [pipefy, onboarding, install, mcp, setup, claude, cursor]
+---
+
+# Pipefy toolkit setup (first-time onboarding)
+
+**Canonical install snippets** live only in the root [`README.md#installation`](../../../README.md#installation) (#246: no second god-doc of commands). This skill is the agent **checklist** — print or run the README blocks verbatim; do not invent alternate commands.
+
+Edge cases: [`packages/mcp/README.md`](../../../packages/mcp/README.md). Auth: [`docs/cli/auth.md`](../../../docs/cli/auth.md). Env: [`docs/config.md`](../../../docs/config.md).
+
+---
+
+## When to use
+
+- "Set up Pipefy", "install the MCP", "connect Claude/Cursor to Pipefy"
+- User mentions `/plugin marketplace add`, `/pipefy:install`, or `mcp.pipefy.com`
+- Fresh machine with no `pipefy` on PATH and no Pipefy MCP server
+
+**Do not use** once tools already work — switch to a domain skill (pipes, tables, …).
+
+## Prerequisites
+
+- User has a Pipefy account (Admin access if they need a service account).
+- Hosted MCP: Claude Code CLI (`claude`).
+- Local toolkit: a shell that can run `curl` (`install.sh` can install `uv`).
+- Claude Code **slash commands** (`/plugin …`, `/pipefy:…`) must be typed by the user. Print them; never claim you invoked them.
+
+## Tools needed
+
+Setup is outside the Pipefy MCP tool surface. After auth succeeds, verify with:
+
+| Tool (MCP) | CLI equivalent | Read-only |
+|------------|----------------|-----------|
+| `get_organization` | `pipefy org get` | Yes |
+
+## Steps
+
+1. **Choose one path** — ask the user; do not pick silently.
+
+   | Path | README section | Outcome |
+   |------|----------------|---------|
+   | Hosted MCP | [Hosted MCP](../../../README.md#hosted-mcp-claude-code) | HTTPS `mcp.pipefy.com` (remote-safe tools) |
+   | Local toolkit | [Quick install](../../../README.md#quick-install-recommended) | `install.sh` → local server + CLI |
+   | Claude Code plugin | [Claude Code](../../../README.md#claude-code) | Marketplace + slash install/login |
+   | CLI only | [CLI](../../../README.md#cli) | `pipefy` on PATH; no MCP |
+
+   **Never** register both hosted HTTP and local stdio/plugin under the MCP server name `pipefy`.
+
+2. **Execute the chosen README block** — run it in the shell, or print it for the user to paste (required for Claude slash commands). Do not reorder the plugin sequence: marketplace → `/plugin install pipefy` → `/pipefy:install` → `/pipefy:pipefy-login`.
+
+3. **Auth** — hosted: finish the client browser OAuth prompt. Local/plugin/CLI: `pipefy auth login` or `/pipefy:pipefy-login` (see README). Service accounts: [`docs/config.md`](../../../docs/config.md).
+
+4. **Verify**
+
+   - Shell (local / plugin / CLI): `pipefy --version`
+   - MCP: call `get_organization` (or another read-only tool the user allows)
+   - Confirm exactly one `pipefy` MCP registration
+
+## Success criteria
+
+- One active Pipefy MCP registration for the chosen path (or CLI-only with no MCP).
+- Auth completed.
+- Read-only MCP call or `pipefy --version` succeeds.
+
+## Failure modes
+
+| Symptom | Likely cause | Recovery |
+|---------|--------------|----------|
+| Slash commands missing | Plugin not installed | README [Claude Code](../../../README.md#claude-code) — marketplace + install first |
+| Two `pipefy` MCP entries | Hosted + plugin both registered | Remove one (`claude mcp remove` / client settings) |
+| `pipefy: command not found` | CLI not on PATH | `/pipefy:install` or README [CLI](../../../README.md#cli); check `$HOME/.local/bin` |
+| MCP tools empty / auth errors | Login not done | Re-run login; service accounts → `docs/config.md` |
+| macOS `errSecParam` | Keychain write | [`packages/mcp/README.md`](../../../packages/mcp/README.md) |
+
+## See also
+
+- [`README.md#installation`](../../../README.md#installation)
+- [`skills/README.md`](../../README.md)

--- a/skills/onboarding/pipefy-toolkit-setup/SKILL.md
+++ b/skills/onboarding/pipefy-toolkit-setup/SKILL.md
@@ -30,7 +30,14 @@ Edge cases: [`packages/mcp/README.md`](../../../packages/mcp/README.md). Auth: [
 - User has a Pipefy account (Admin access if they need a service account).
 - Hosted MCP: Claude Code CLI (`claude`).
 - Local toolkit: a shell that can run `curl` (`install.sh` can install `uv`).
-- Claude Code **slash commands** (`/plugin …`, `/pipefy:…`) must be typed by the user. Print them; never claim you invoked them.
+
+**Who does what**
+
+| Actor | Does |
+|-------|------|
+| **Agent** | Asks path; prints README commands verbatim; runs shell `claude mcp add` / `install.sh` when the user agrees; checks `claude mcp get` / list |
+| **User types** | Claude slash commands (`/plugin …`, `/pipefy:…`) — the model cannot invoke them |
+| **User in browser** | OAuth for hosted (`claude mcp login …`) or `/pipefy:pipefy-login` / `pipefy auth login` |
 
 ## Tools needed
 
@@ -44,6 +51,10 @@ Setup is outside the Pipefy MCP tool surface. After auth succeeds, verify with:
 
 1. **Choose one path** — ask the user; do not pick silently.
 
+   If they only say “Claude Code” (no path), ask a **closed** question:
+
+   > Hosted MCP (zero local Python, `mcp.pipefy.com`) or the Claude Code plugin (slash commands + local CLI)? If you’re unsure, Hosted is the usual first try.
+
    | Path | README section | Outcome |
    |------|----------------|---------|
    | Hosted MCP | [Hosted MCP](../../../README.md#hosted-mcp-claude-code) | HTTPS `mcp.pipefy.com` (remote-safe tools) |
@@ -55,13 +66,13 @@ Setup is outside the Pipefy MCP tool surface. After auth succeeds, verify with:
 
 2. **Execute the chosen README block** — run it in the shell, or print it for the user to paste (required for Claude slash commands). Do not reorder the plugin sequence: marketplace → `/plugin install pipefy` → `/pipefy:install` → `/pipefy:pipefy-login`.
 
-3. **Auth** — hosted: finish the client browser OAuth prompt. Local/plugin/CLI: `pipefy auth login` or `/pipefy:pipefy-login` (see README). Service accounts: [`docs/config.md`](../../../docs/config.md).
+3. **Auth** — hosted: finish the client browser OAuth prompt (`claude mcp login <name>` if status is Needs authentication). Local/plugin/CLI: `pipefy auth login` or `/pipefy:pipefy-login` (see README). Service accounts: [`docs/config.md`](../../../docs/config.md).
 
 4. **Verify**
 
    - Shell (local / plugin / CLI): `pipefy --version`
    - MCP: call `get_organization` (or another read-only tool the user allows)
-   - Confirm exactly one `pipefy` MCP registration
+   - Confirm exactly one `pipefy` MCP registration for the path you chose (hosted vs plugin)
 
 ## Success criteria
 
@@ -74,7 +85,8 @@ Setup is outside the Pipefy MCP tool surface. After auth succeeds, verify with:
 | Symptom | Likely cause | Recovery |
 |---------|--------------|----------|
 | Slash commands missing | Plugin not installed | README [Claude Code](../../../README.md#claude-code) — marketplace + install first |
-| Two `pipefy` MCP entries | Hosted + plugin both registered | Remove one (`claude mcp remove` / client settings) |
+| Two `pipefy` MCP entries | Hosted + plugin both registered | `claude mcp remove <name> -s user` (or client settings) |
+| `Needs authentication` after hosted add | OAuth not finished | `claude mcp login <name>` + browser |
 | `pipefy: command not found` | CLI not on PATH | `/pipefy:install` or README [CLI](../../../README.md#cli); check `$HOME/.local/bin` |
 | MCP tools empty / auth errors | Login not done | Re-run login; service accounts → `docs/config.md` |
 | macOS `errSecParam` | Keychain write | [`packages/mcp/README.md`](../../../packages/mcp/README.md) |


### PR DESCRIPTION
## Summary

- Adds the **hosted MCP** (`mcp.pipefy.com`) install snippet to the root `README.md#installation` front door so first-time Claude Code users have a zero-local-Python path.
- Adds skill [`pipefy-toolkit-setup`](skills/onboarding/pipefy-toolkit-setup/SKILL.md): path choice, ask-your-agent checklist, verify/failure modes — **links to README snippets** instead of owning a second command catalog.
- Aligns `install.sh` Claude Code next-steps with `/pipefy:pipefy-login` and the full plugin slash sequence.

## Relationship to #246 / PR #256

This continues the doc layout from [#246](https://github.com/pipefy/ai-toolkit/issues/246) / [#256](https://github.com/pipefy/ai-toolkit/pull/256) (`docs: dissolve setup.md…`):

| Concern | Home (unchanged from #246) |
|---------|----------------------------|
| Canonical install / per-client snippets | Root `README.md#installation` |
| `PIPEFY_*` / TOML / precedence | `docs/config.md` |
| MCP edge cases (`errSecParam`, local `claude mcp add`, clone) | `packages/mcp/README.md` |
| CLI auth tiers | `packages/cli/README.md` |

**What we deliberately did *not* do:** recreate `docs/setup.md` (or a `docs/getting-started.md` that re-owns curl/plugin/CLI blocks). That was the drift magnet #246 removed. New beginner *guidance* lives in the skill; new *commands* land only on the README front door (hosted HTTP) or stay in the package READMEs for edge cases.

## Test plan

- [ ] Open `README.md#installation` on GitHub — Hosted MCP / Quick install / Claude Code / CLI sections render; skill link works
- [ ] Confirm no `docs/getting-started.md` or `docs/setup.md` in the tree
- [ ] `uv run python .github/workflows/scripts/lint_skill_refs.py` passes
- [ ] Optional smoke: Claude Code hosted path (`claude mcp add --transport http …`) or plugin slash sequence from README