### PR TITLE
Expose service-account tools on the remote profile

### DIFF
--- a/docs/mcp/tools/service-accounts.md
+++ b/docs/mcp/tools/service-accounts.md
@@ -15,7 +15,7 @@ Create and delete organization **service accounts** — OAuth2 machine identitie
 
 - `create_service_account` returns the **client secret** and **token endpoint** in its response, and there is **no query to read them back** — capture and store them at creation time.
 - The secret is returned to the caller because it is needed to authenticate the account (mint access tokens via the OAuth2 client-credentials grant against the token endpoint). It is never logged.
-- Both tools are **excluded from the remote profile**: provisioning org-level identities is not a hosted, per-request operation.
+- Both tools are **remote-safe**: each reaches the API with the request-scoped caller's bearer and is fully governed by API permissions (org-admin to create/delete). The returned client secret goes to the authenticated caller only and is never logged (the hosted logging layer excludes response bodies).
 
 ## Lifecycle
 

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -52,7 +52,7 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | `create_portal_element` | `pipefy portal element create` | shipped | `--page-id`, `--type`, `--metadata` JSON; optional `--data-sources` JSON array. SDK validates metadata before GraphQL. |
 | `create_sub_portal` | `pipefy portal sub-portal create` | shipped | `--main-portal-uuid`; optional `--name`. Interfaces `createSubPortal`. |
 | `create_send_task_automation` | `pipefy automation send-task create` | shipped | (task title + recipients; optional `--event-params` / `--condition` JSON). |
-| `create_service_account` | `pipefy service-account create` | shipped | Org service account (`--org` uuid, `--name` <=20, `--role`, optional `--description` / `--expiration-unit` + `--expiration-value`; optional `--pipe-ids` + `--pipe-role` default admin to add it to pipes immediately). Returns the OAuth2 client secret + token endpoint once; not remote-safe. |
+| `create_service_account` | `pipefy service-account create` | shipped | Org service account (`--org` uuid, `--name` <=20, `--role`, optional `--description` / `--expiration-unit` + `--expiration-value`; optional `--pipe-ids` + `--pipe-role` default admin to add it to pipes immediately). Returns the OAuth2 client secret + token endpoint once (never logged); remote-safe. |
 | `create_table` | `pipefy table create` | shipped | — |
 | `create_table_field` | `pipefy table field create` | shipped | — |
 | `create_table_record` | `pipefy record create` | shipped | — |

--- a/packages/mcp/src/pipefy_mcp/tools/member_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/member_tools.py
@@ -19,6 +19,7 @@ from pipefy_mcp.tools.member_tool_helpers import (
     handle_member_tool_graphql_error,
     service_account_is_member,
 )
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 from pipefy_mcp.tools.validation_helpers import validate_tool_id
 
@@ -85,6 +86,7 @@ class MemberTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def add_service_account_to_pipe(
             pipe_id: PipefyId,

--- a/packages/mcp/src/pipefy_mcp/tools/service_account_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/service_account_tools.py
@@ -3,8 +3,10 @@
 Secrets contract: ``create_service_account`` returns the OAuth2 client secret and
 token endpoint ONCE — there is no query to read them back. The tool therefore
 returns them to the caller (they are needed to authenticate as the account) but
-never logs them, and the toolset is excluded from the remote profile (org-level
-provisioning is not a hosted, per-request operation).
+never logs them. These tools are remote-safe: each reaches the API with the
+request-scoped bearer and is fully governed by API permissions (org-admin to
+create/delete), and the hosted logging layer excludes response bodies, so the
+returned secret is not logged.
 """
 
 from __future__ import annotations
@@ -19,6 +21,7 @@ from pipefy_mcp.core.tool_error_envelope import tool_error, tool_success
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import handle_tool_graphql_error
 from pipefy_mcp.tools.member_tool_helpers import service_account_is_member
+from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 
 _SA_NAME_MAX = 20
@@ -32,6 +35,7 @@ class ServiceAccountTools:
     def register(mcp: FastMCP) -> None:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_service_account(
             organization_uuid: str,
@@ -163,6 +167,7 @@ class ServiceAccountTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_service_account(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -112,6 +112,17 @@ REMOTE_SEED = frozenset(
         "get_email_templates",
         "get_portal",
         "list_portals",
+        # service-account tools: the first write mutations on the seed. Each
+        # reaches the API with the request-scoped bearer and is fully governed by
+        # API permissions (org-admin to create/delete, pipe-admin to add-to-pipe);
+        # no filesystem or per-user process-global settings reads (org/pipe are
+        # per-request arguments). create_service_account returns the new account's
+        # own client secret to the authenticated caller — the hosted logging layer
+        # excludes response bodies, so it is not logged. delete_service_account is
+        # guarded by two-step confirmation.
+        "create_service_account",
+        "delete_service_account",
+        "add_service_account_to_pipe",
     }
 )
 


### PR DESCRIPTION
## Motivation

The service-account tools introduced in #460 (`create_service_account`, `delete_service_account`, `add_service_account_to_pipe`) were withheld from the hosted remote profile pending an explicit security call. They meet the remote-safe criteria — each reaches the API with the request-scoped caller's bearer and is fully governed by API permissions — so the hosted server should be able to run the service-account setup flow (provision → add to pipe → use) on the caller's behalf.

## Outcome

The three service-account tools are now marked remote-safe (`meta=REMOTE`) and added to the `REMOTE_SEED` drift guard. They are the first *write* mutations on the seed:

- Each acts as the request-scoped caller and is governed by API permissions (org-admin to create/delete, pipe-admin to add-to-pipe); `organization_uuid` / `pipe_id` are per-request arguments, so no shared-state assumption is involved.
- `create_service_account` returns the new account's own OAuth2 client secret to the authenticated caller only; the hosted logging layer excludes response bodies, so it is never logged.
- `delete_service_account` keeps its two-step destructive confirmation.

Generic membership writes (`invite_members`, `set_role`, `remove_member_from_pipe`) remain withheld — a separate decision, left unchanged here.

## Notes

Stacked on #460 (base `rc-dev/feat/add-service-account-to-pipe`). CI does not run while the base is a feature branch; once #460 merges and this retargets to `dev`, CI will fire.
