### PR TITLE
Type eventParams into AutomationEventParamsInput

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -627,7 +627,7 @@ class AiAgentTools:
             Known ``actionType`` values for pipe-context checks are:
             ``move_card``, ``update_card``, ``create_card``, ``create_connected_card``,
             ``create_table_record``, and ``send_email_template``.
-            For ``move_card`` with trigger ``card_moved`` and ``eventParams.to_phase_id``/``toPhaseId``,
+            For ``move_card`` with trigger ``card_moved`` and ``eventParams.to_phase_id``,
             the tool also checks that ``destinationPhaseId`` is allowed from that phase
             (``cards_can_be_moved_to_phases``).
             For ``create_table_record``, ``fieldsAttributes`` hold **table** field IDs — they are not

--- a/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
@@ -387,7 +387,7 @@ class AutomationTools:
             ``active: false`` to disable a rule after creation.
 
             For ``card_moved`` rules with action ``move_single_card``, when ``extra_input`` includes
-            ``event_params.to_phase_id`` (or ``toPhaseId``) and ``action_params.to_phase_id`` (or
+            ``event_params.to_phase_id`` and ``action_params.to_phase_id`` (or
             ``phase.id``), the tool rejects impossible transitions before calling the API, using the
             same read-only transition data as ``move_card_to_phase``.
 

--- a/packages/mcp/tests/tools/test_ai_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_ai_tool_helpers.py
@@ -447,13 +447,16 @@ def test_validate_invalid_event_params_to_phase_id():
         related_pipe_ids=RELATED_PIPES,
     )
     assert warnings == []
-    assert any(
-        "ph-ghost" in p and "eventParams" in p and "toPhaseId" in p for p in problems
-    )
+    assert any("ph-ghost" in p and "eventParams.to_phase_id" in p for p in problems)
 
 
 @pytest.mark.unit
-def test_validate_invalid_event_params_to_phase_id_camel_case():
+def test_validate_event_params_camel_to_phase_id_is_not_honored():
+    """``toPhaseId`` (camel) is not the declared wire spelling (``to_phase_id``).
+
+    GraphQL rejects it at coercion, so the toolkit no longer reads it as the
+    destination phase: it rides ``extra`` untouched and raises no phase problem.
+    """
     behavior = _move_card_behavior()
     del behavior["eventParams"]["to_phase_id"]
     behavior["eventParams"]["toPhaseId"] = "ph-ghost"
@@ -465,7 +468,7 @@ def test_validate_invalid_event_params_to_phase_id_camel_case():
         related_pipe_ids=RELATED_PIPES,
     )
     assert warnings == []
-    assert any("ph-ghost" in p for p in problems)
+    assert not any("ph-ghost" in p for p in problems)
 
 
 @pytest.mark.unit

--- a/packages/sdk/src/pipefy_sdk/ai_phase_transition_validation.py
+++ b/packages/sdk/src/pipefy_sdk/ai_phase_transition_validation.py
@@ -65,8 +65,8 @@ async def collect_ai_behavior_move_transition_problems(
         event_id = str(payload.event_id or "")
         if event_id != "card_moved":
             continue
-        ep = payload.event_params or {}
-        src = ep.get("to_phase_id") or ep.get("toPhaseId")
+        ep = payload.event_params
+        src = ep.to_phase_id if ep else None
         if not src:
             continue
         src_s = str(src)

--- a/packages/sdk/src/pipefy_sdk/ai_pipe_validation.py
+++ b/packages/sdk/src/pipefy_sdk/ai_pipe_validation.py
@@ -103,11 +103,11 @@ def validate_behaviors_against_pipe(
         abp = _ai_behavior_params(b)
         attrs = (abp.actions_attributes if abp else None) or []
 
-        ep = (payload.event_params if payload else None) or {}
-        to_phase = ep.get("to_phase_id") or ep.get("toPhaseId")
+        ep = payload.event_params if payload else None
+        to_phase = ep.to_phase_id if ep else None
         if to_phase and str(to_phase) not in pipe_phase_ids:
             problems.append(
-                f'{prefix}: eventParams.to_phase_id / toPhaseId "{to_phase}" '
+                f'{prefix}: eventParams.to_phase_id "{to_phase}" '
                 f"not found in pipe phases."
             )
 

--- a/packages/sdk/src/pipefy_sdk/automation_preflight.py
+++ b/packages/sdk/src/pipefy_sdk/automation_preflight.py
@@ -12,6 +12,9 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
+from pydantic import ValidationError
+
+from pipefy_sdk.models import AutomationEventParamsInput
 from pipefy_sdk.transition_hints import (
     TRANSITION_RULES_HINT,
     format_allowed_destinations_phrase,
@@ -26,6 +29,21 @@ logger = logging.getLogger(__name__)
 _AUTOMATION_MOVE_CARD_ACTION_IDS = frozenset({"move_single_card"})
 
 _DIGITS_ONLY_RE = re.compile(r"^\d+$")
+
+
+def _parse_event_params(raw: Any) -> AutomationEventParamsInput | None:
+    """Parse a trigger ``event_params`` sub-dict, or ``None`` for missing/malformed input.
+
+    Preflight is advisory and must never turn odd input into a spurious create failure,
+    so a payload that fails ``AutomationEventParamsInput`` coercion is treated as absent
+    (no-op preflight) rather than raised.
+    """
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return AutomationEventParamsInput.model_validate(raw)
+    except ValidationError:
+        return None
 
 
 class AutomationPreflightError(ValueError):
@@ -93,8 +111,8 @@ async def validate_traditional_automation_move_transition(
     if aid not in _AUTOMATION_MOVE_CARD_ACTION_IDS:
         return
     extra = extra_input if isinstance(extra_input, dict) else {}
-    ev = extra.get("event_params") or extra.get("eventParams") or {}
-    src = ev.get("to_phase_id") or ev.get("toPhaseId")
+    ev = _parse_event_params(extra.get("event_params"))
+    src = ev.to_phase_id if ev else None
     if not src:
         return
     src_s = str(src)

--- a/packages/sdk/src/pipefy_sdk/models/ai_agent.py
+++ b/packages/sdk/src/pipefy_sdk/models/ai_agent.py
@@ -6,6 +6,7 @@ from typing import Annotated, Self
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
 
+from pipefy_sdk.models.ai_automation import AutomationEventParamsInput
 from pipefy_sdk.models.validators import NonBlankStr
 
 ACTION_ID_AI_BEHAVIOR = "ai_behavior"
@@ -281,7 +282,9 @@ class BehaviorPayload(BaseModel):
     action_id: str | None = Field(default=None, alias="actionId")
     active: bool | None = None
     condition: dict | None = None
-    event_params: dict | None = Field(default=None, alias="eventParams")
+    event_params: AutomationEventParamsInput | None = Field(
+        default=None, alias="eventParams"
+    )
     action_params: AiBehaviorActionParams | None = Field(
         default=None, alias="actionParams"
     )
@@ -321,7 +324,9 @@ class BehaviorInput(BaseModel):
     action_id: str = Field(default=ACTION_ID_AI_BEHAVIOR, alias="actionId")
     active: bool = True
     condition: dict | None = None
-    event_params: dict | None = Field(default=None, alias="eventParams")
+    event_params: AutomationEventParamsInput | None = Field(
+        default=None, alias="eventParams"
+    )
     action_params: AiBehaviorActionParams | None = Field(
         default=None, alias="actionParams"
     )

--- a/packages/sdk/src/pipefy_sdk/models/ai_automation.py
+++ b/packages/sdk/src/pipefy_sdk/models/ai_automation.py
@@ -42,9 +42,23 @@ class AutomationConditionInput(BaseModel):
 
 
 class AutomationEventParamsInput(BaseModel):
-    """Pipefy automation trigger params (e.g. ``to_phase_id``, ``triggerFieldIds``)."""
+    """Pipefy ``AutomationEventParamsInput`` trigger params.
 
-    model_config = ConfigDict(extra="allow")
+    The declared inputFields mix casing in one type: ``to_phase_id`` is snake while
+    its siblings are camel. Aliases are per declared field (never a blanket
+    snake→camel pass); ``to_phase_id`` keeps its wire name (no alias) so it round-trips
+    for both reads (GET selects ``to_phase_id``) and writes. ``extra="allow"`` lets
+    sibling/unknown keys pass through verbatim. Dump with ``by_alias=True``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    kind_of_sla: str | None = Field(default=None, alias="kindOfSla")
+    from_phase_id: str | None = Field(default=None, alias="fromPhaseId")
+    in_phase_id: str | None = Field(default=None, alias="inPhaseId")
+    to_phase_id: str | None = None
+    trigger_automation_id: str | None = Field(default=None, alias="triggerAutomationId")
+    trigger_field_ids: list[str] | None = Field(default=None, alias="triggerFieldIds")
 
 
 def _default_automation_condition() -> AutomationConditionInput:

--- a/packages/sdk/src/pipefy_sdk/services/automation_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/automation_service.py
@@ -61,9 +61,10 @@ def _automation_condition_for_api(
 def _automation_event_params_for_api(
     params: AutomationEventParamsInput,
 ) -> dict[str, Any]:
-    """Serialize event_params without unset fields or explicit ``None`` values."""
+    """Serialize event_params to declared wire names, without unset/``None`` values."""
     return params.model_dump(
         mode="python",
+        by_alias=True,
         exclude_unset=True,
         exclude_none=True,
     )

--- a/packages/sdk/tests/models/test_ai_agent.py
+++ b/packages/sdk/tests/models/test_ai_agent.py
@@ -308,7 +308,8 @@ def test_behavior_input_accepts_event_params_with_trigger_field_ids():
     payload = minimal_behavior_dict(event_id="field_updated")
     payload["eventParams"] = {"triggerFieldIds": [EXAMPLE_FIELD_INTERNAL_ID]}
     inp = BehaviorInput.model_validate(payload)
-    assert inp.event_params == {"triggerFieldIds": [EXAMPLE_FIELD_INTERNAL_ID]}
+    assert inp.event_params is not None
+    assert inp.event_params.trigger_field_ids == [EXAMPLE_FIELD_INTERNAL_ID]
 
 
 @pytest.mark.unit
@@ -316,7 +317,8 @@ def test_behavior_input_accepts_event_params_with_to_phase_id():
     payload = minimal_behavior_dict(event_id="card_moved")
     payload["eventParams"] = {"to_phase_id": "12345678"}
     inp = BehaviorInput.model_validate(payload)
-    assert inp.event_params == {"to_phase_id": "12345678"}
+    assert inp.event_params is not None
+    assert inp.event_params.to_phase_id == "12345678"
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/models/test_ai_automation.py
+++ b/packages/sdk/tests/models/test_ai_automation.py
@@ -7,9 +7,53 @@ from pydantic import ValidationError
 from pipefy_sdk.models.ai_automation import (
     DEFAULT_CONDITION,
     AutomationConditionInput,
+    AutomationEventParamsInput,
     CreateAiAutomationInput,
     UpdateAiAutomationInput,
 )
+
+
+@pytest.mark.unit
+def test_event_params_input_parses_all_declared_fields_from_wire():
+    """Every declared inputField parses from its wire spelling (mixed casing)."""
+    wire = {
+        "kindOfSla": "Late",
+        "fromPhaseId": "1",
+        "inPhaseId": "2",
+        "to_phase_id": "3",
+        "triggerAutomationId": "4",
+        "triggerFieldIds": ["5", "6"],
+    }
+    params = AutomationEventParamsInput.model_validate(wire)
+    assert params.kind_of_sla == "Late"
+    assert params.from_phase_id == "1"
+    assert params.in_phase_id == "2"
+    assert params.to_phase_id == "3"
+    assert params.trigger_automation_id == "4"
+    assert params.trigger_field_ids == ["5", "6"]
+    # Dumps back to the exact declared wire names.
+    assert params.model_dump(by_alias=True, exclude_none=True) == wire
+
+
+@pytest.mark.unit
+def test_event_params_input_accepts_python_names_via_populate_by_name():
+    """populate_by_name lets snake_case python names in; dump normalizes to wire."""
+    params = AutomationEventParamsInput(from_phase_id="10", trigger_field_ids=["11"])
+    assert params.model_dump(by_alias=True, exclude_none=True) == {
+        "fromPhaseId": "10",
+        "triggerFieldIds": ["11"],
+    }
+
+
+@pytest.mark.unit
+def test_event_params_input_passes_unknown_keys_through_verbatim():
+    """extra='allow' round-trips sibling/unknown keys (GET responses carry extras)."""
+    params = AutomationEventParamsInput.model_validate(
+        {"to_phase_id": "3", "someNewField": "x"}
+    )
+    dumped = params.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["to_phase_id"] == "3"
+    assert dumped["someNewField"] == "x"
 
 
 @pytest.mark.unit
@@ -226,7 +270,8 @@ def test_create_ai_automation_input_event_params_pass_through():
         event_params=params,
     )
     assert inp.event_params is not None
-    assert inp.event_params.model_dump(mode="python") == params
+    assert inp.event_params.to_phase_id == "phase-42"
+    assert inp.event_params.model_dump(by_alias=True, exclude_none=True) == params
 
 
 @pytest.mark.unit
@@ -278,7 +323,8 @@ def test_update_ai_automation_input_event_params_pass_through():
     params = {"to_phase_id": "phase-99"}
     inp = UpdateAiAutomationInput(automation_id="456", event_params=params)
     assert inp.event_params is not None
-    assert inp.event_params.model_dump(mode="python") == params
+    assert inp.event_params.to_phase_id == "phase-99"
+    assert inp.event_params.model_dump(by_alias=True, exclude_none=True) == params
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/test_automation_preflight.py
+++ b/packages/sdk/tests/test_automation_preflight.py
@@ -108,6 +108,38 @@ async def test_validate_skips_without_src_phase(mock_client):
 
 
 @pytest.mark.anyio
+async def test_validate_ignores_camel_to_phase_id_in_event_params(mock_client):
+    """``toPhaseId`` (camel) is not the declared spelling, so it yields no src phase.
+
+    A valid snake ``action_params.to_phase_id`` dest is present as a control: the
+    check is skipped because the *event* src is camel-ignored, not because the dest
+    is missing.
+    """
+    await validate_traditional_automation_move_transition(
+        mock_client,
+        trigger_id="card_moved",
+        action_id="move_single_card",
+        extra_input={
+            "event_params": {"toPhaseId": "src"},
+            "action_params": {"to_phase_id": "dest"},
+        },
+    )
+    mock_client.get_phase_allowed_move_targets.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_validate_treats_malformed_event_params_as_absent(mock_client):
+    """Preflight is advisory: an uncoercible event_params payload is a no-op, never a raise."""
+    await validate_traditional_automation_move_transition(
+        mock_client,
+        trigger_id="card_moved",
+        action_id="move_single_card",
+        extra_input={"event_params": {"to_phase_id": ["not", "a", "scalar"]}},
+    )
+    mock_client.get_phase_allowed_move_targets.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_validate_skips_when_dest_missing(mock_client):
     await validate_traditional_automation_move_transition(
         mock_client,


### PR DESCRIPTION
## Motivation

`eventParams` was walked with dual-alias `.get("to_phase_id") or .get("toPhaseId")` branches in the AI pipe/phase-transition validators and the traditional-automation preflight, and `AutomationEventParamsInput` existed only as an empty-shell model — so `event_params` on behaviors and automations was effectively untyped. This continues the "parse, don't validate" approach proven in #417.

## What ships

- `AutomationEventParamsInput` filled with its six declared inputFields (`populate_by_name=True`, per-field aliases, `extra="allow"`).
- `event_params` typed on `BehaviorPayload` / `BehaviorInput` (alias `eventParams`) and read as typed attributes in `ai_pipe_validation` and `ai_phase_transition_validation`; the classic-automation move preflight parses `event_params` leniently (`_parse_event_params`).
- `_automation_event_params_for_api` now dumps `by_alias=True` — it was correct only by accident while the model was an empty shell with no aliased fields.

## Proven contract (introspected, live)

`AutomationEventParamsInput` inputFields: `kindOfSla`, `fromPhaseId`, `inPhaseId`, **`to_phase_id`** (snake), `triggerAutomationId`, `triggerFieldIds` — mixed casing in one type, so aliases are strictly per declared field; `to_phase_id` keeps its snake wire name (no alias). Behaviors carry event params under the camel wrapper `eventParams` (`AutomationInput`); classic automations under the snake wrapper `event_params` (`CreateAutomationInput`). Both nest the same inner type.

## Behavior boundaries

Behavior is unchanged for every payload already valid end-to-end. Camel inner spellings (`toPhaseId`) that GraphQL always rejected at coercion are no longer silently accepted; tests pinning that broken passthrough are rewritten to the declared name.

## Testing

Offline: `uv run pytest -m "not integration"` + ruff + import-linter + `bump_version.py verify` green. Live E2E on pipe `303088927`:

| # | Scenario | Expected | Observed | Verdict |
|---|----------|----------|----------|---------|
| 1 | `create_ai_automation` with `event_params.triggerFieldIds` → GET | `triggerFieldIds` round-trips as the camel wire name (by_alias) | GET returned `triggerFieldIds: ["360646190"]` | ✅ |
| 2 | Create AI agent behavior with `eventParams.to_phase_id` → GET | `to_phase_id` round-trips (snake) | GET returned `to_phase_id: "319036222"` | ✅ |
| 3 | Classic `card_moved`→`move_single_card` with `event_params.to_phase_id` → GET | `to_phase_id` round-trips | GET returned `to_phase_id: "319036222"` | ✅ |

Closes #418.
