### PR TITLE
Type behavior action metadata + shared FieldMapInput

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -78,8 +78,8 @@ def _extract_pipe_id_from_behaviors(behaviors: list[dict]) -> str | None:
         if abp is None:
             continue
         for a in abp.actions_attributes or []:
-            metadata = a.metadata if isinstance(a.metadata, dict) else {}
-            pid = metadata.get("pipeId")
+            metadata = a.metadata
+            pid = metadata.pipe_id if metadata else None
             if pid:
                 return str(pid)
     return None

--- a/packages/sdk/src/pipefy_sdk/ai_phase_transition_validation.py
+++ b/packages/sdk/src/pipefy_sdk/ai_phase_transition_validation.py
@@ -80,8 +80,8 @@ async def collect_ai_behavior_move_transition_problems(
         for j, action in enumerate(attrs):
             if action.action_type != "move_card":
                 continue
-            meta = action.metadata if isinstance(action.metadata, dict) else {}
-            dest = meta.get("destinationPhaseId")
+            meta = action.metadata
+            dest = meta.destination_phase_id if meta else None
             if not dest:
                 continue
             dest_s = str(dest)

--- a/packages/sdk/src/pipefy_sdk/ai_pipe_validation.py
+++ b/packages/sdk/src/pipefy_sdk/ai_pipe_validation.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import copy
 import logging
 import re
 from typing import TYPE_CHECKING, Any, Literal
@@ -11,7 +10,11 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import ValidationError
 
 from pipefy_sdk.behavior_placeholders import populate_referenced_field_ids
-from pipefy_sdk.models import AiBehaviorParams, BehaviorPayload
+from pipefy_sdk.models import (
+    AiBehaviorMetadataInput,
+    AiBehaviorParams,
+    BehaviorPayload,
+)
 
 if TYPE_CHECKING:
     from pipefy_sdk.client import PipefyClient
@@ -113,7 +116,7 @@ def validate_behaviors_against_pipe(
 
         for j, action in enumerate(attrs):
             action_type = action.action_type or ""
-            metadata = action.metadata if isinstance(action.metadata, dict) else {}
+            metadata = action.metadata or AiBehaviorMetadataInput()
 
             if action_type and action_type not in KNOWN_AI_ACTION_TYPES:
                 msg = (
@@ -126,7 +129,7 @@ def validate_behaviors_against_pipe(
                     warnings.append(msg)
 
             if action_type == "move_card":
-                dest = metadata.get("destinationPhaseId", "")
+                dest = metadata.destination_phase_id or ""
                 if dest and str(dest) not in pipe_phase_ids:
                     problems.append(
                         f"{prefix}, action [{j}] (move_card): "
@@ -134,7 +137,7 @@ def validate_behaviors_against_pipe(
                     )
 
             if action_type not in ("create_table_record", "send_email_template"):
-                action_pipe = str(metadata.get("pipeId", ""))
+                action_pipe = str(metadata.pipe_id or "")
                 targets_source = not action_pipe or action_pipe == pipe_id
                 if targets_source:
                     check_fields = pipe_field_ids
@@ -147,11 +150,9 @@ def validate_behaviors_against_pipe(
                     check_fields = None
 
                 if check_fields is not None:
-                    fields_attrs = metadata.get("fieldsAttributes") or []
+                    fields_attrs = metadata.fields_attributes or []
                     for k, fa in enumerate(fields_attrs):
-                        if not isinstance(fa, dict):
-                            continue
-                        fid = fa.get("fieldId", "")
+                        fid = fa.field_id or ""
                         if fid and fid not in check_fields:
                             pipe_label = (
                                 "pipe fields"
@@ -172,7 +173,7 @@ def validate_behaviors_against_pipe(
                 )
 
             if action_type == "create_connected_card" and related_pipe_ids is not None:
-                target_pipe = metadata.get("pipeId", "")
+                target_pipe = metadata.pipe_id or ""
                 if target_pipe and str(target_pipe) not in related_pipe_ids:
                     problems.append(
                         f"{prefix}, action [{j}] (create_connected_card): "
@@ -202,14 +203,14 @@ def _extract_slug_field_ids_by_pipe(
         if abp is None:
             continue
         for a in abp.actions_attributes or []:
-            metadata = a.metadata if isinstance(a.metadata, dict) else {}
-            pipe_id = str(metadata.get("pipeId", ""))
+            metadata = a.metadata
+            if metadata is None:
+                continue
+            pipe_id = str(metadata.pipe_id or "")
             if not pipe_id:
                 continue
-            for fa in metadata.get("fieldsAttributes") or []:
-                if not isinstance(fa, dict):
-                    continue
-                fid = str(fa.get("fieldId", ""))
+            for fa in metadata.fields_attributes or []:
+                fid = str(fa.field_id or "")
                 if fid and not fid.isdigit():
                     slugs_by_pipe.setdefault(pipe_id, set()).add(fid)
     return slugs_by_pipe
@@ -239,8 +240,8 @@ def pipe_ids_from_behavior(behavior: dict[str, Any]) -> set[str]:
     if abp is None:
         return pids
     for a in abp.actions_attributes or []:
-        metadata = a.metadata if isinstance(a.metadata, dict) else {}
-        pid = str(metadata.get("pipeId", ""))
+        metadata = a.metadata
+        pid = str(metadata.pipe_id or "") if metadata else ""
         if pid:
             pids.add(pid)
     return pids
@@ -397,29 +398,26 @@ async def resolve_field_slugs_to_numeric(
 
     resolved: list[dict[str, Any]] = []
     for b in behaviors:
-        # Deep-copy before parsing: pydantic keeps a reference to the input
-        # ``metadata`` dict, so mutating it in place would corrupt the caller's
-        # behavior. Parsing a copy keeps the original untouched.
-        b_copy = copy.deepcopy(b)
-        payload = _behavior_payload(b_copy)
+        # Parsing yields fresh typed models (fieldsAttributes become new FieldMapInput
+        # objects), so mutating fa.field_id cannot reach the caller's input dict; the
+        # result is rebuilt from the dumped payload. No defensive copy needed.
+        payload = _behavior_payload(b)
         abp = (
             payload.action_params.ai_behavior_params
             if payload and payload.action_params
             else None
         )
         if abp is None:
-            resolved.append(b_copy)
+            resolved.append(b)
             continue
         for a in abp.actions_attributes or []:
-            metadata = a.metadata if isinstance(a.metadata, dict) else None
+            metadata = a.metadata
             if metadata is None:
                 continue
-            for fa in metadata.get("fieldsAttributes") or []:
-                if not isinstance(fa, dict):
-                    continue
-                fid = str(fa.get("fieldId", ""))
+            for fa in metadata.fields_attributes or []:
+                fid = str(fa.field_id or "")
                 if fid in slug_to_numeric:
-                    fa["fieldId"] = slug_to_numeric[fid]
+                    fa.field_id = slug_to_numeric[fid]
         if isinstance(abp.instruction, str):
             abp.instruction = _rewrite_instruction_field_tokens(
                 abp.instruction, slug_to_numeric

--- a/packages/sdk/src/pipefy_sdk/models/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/models/__init__.py
@@ -6,6 +6,7 @@ from pipefy_sdk.models.ai_agent import (
     AiBehaviorActionAttributes,
     AiBehaviorActionParams,
     AiBehaviorCapabilityAttributes,
+    AiBehaviorMetadataInput,
     AiBehaviorParams,
     BehaviorInput,
     BehaviorPayload,
@@ -16,6 +17,7 @@ from pipefy_sdk.models.ai_automation import (
     AutomationConditionInput,
     AutomationEventParamsInput,
     CreateAiAutomationInput,
+    FieldMapInput,
     UpdateAiAutomationInput,
 )
 from pipefy_sdk.models.attachment import (
@@ -48,6 +50,7 @@ __all__ = [
     "AiBehaviorActionAttributes",
     "AiBehaviorActionParams",
     "AiBehaviorCapabilityAttributes",
+    "AiBehaviorMetadataInput",
     "AiBehaviorParams",
     "Attachment",
     "AttachmentTarget",
@@ -66,6 +69,7 @@ __all__ = [
     "CreateSendTaskAutomationInput",
     "DataLookupCondition",
     "DeleteCommentInput",
+    "FieldMapInput",
     "MemberInvite",
     "NonBlankStr",
     "PipefyId",

--- a/packages/sdk/src/pipefy_sdk/models/ai_agent.py
+++ b/packages/sdk/src/pipefy_sdk/models/ai_agent.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Self
+from typing import Annotated, Any, Self
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
 
-from pipefy_sdk.models.ai_automation import AutomationEventParamsInput
+from pipefy_sdk.models.ai_automation import (
+    AutomationEventParamsInput,
+    FieldMapInput,
+)
 from pipefy_sdk.models.validators import NonBlankStr
 
 ACTION_ID_AI_BEHAVIOR = "ai_behavior"
@@ -18,82 +21,82 @@ _CARD_FIELD_ACTION_TYPES = frozenset(
 )
 
 
-def _validate_fields_attributes_entries(action_type: str, metadata: dict) -> None:
+def _validate_fields_attributes_entries(
+    action_type: str, fields: list[FieldMapInput] | None
+) -> None:
     """Require non-empty ``fieldsAttributes`` with ``fieldId`` and ``inputMode`` per entry."""
-    fields = metadata.get("fieldsAttributes")
-    if not isinstance(fields, list) or not fields:
+    if not fields:
         raise ValueError(
             f"actionType '{action_type}' requires metadata.fieldsAttributes "
             f"as a non-empty list of field entries."
         )
     for i, entry in enumerate(fields):
-        if not isinstance(entry, dict):
-            raise ValueError(
-                f"actionType '{action_type}': fieldsAttributes[{i}] must be a dict."
-            )
-        if not entry.get("fieldId"):
+        if not entry.field_id:
             raise ValueError(
                 f"actionType '{action_type}': fieldsAttributes[{i}] requires 'fieldId'."
             )
-        if not entry.get("inputMode"):
+        if not entry.input_mode:
             raise ValueError(
                 f"actionType '{action_type}': fieldsAttributes[{i}] "
                 f"requires 'inputMode'."
             )
 
 
-def _validate_card_field_metadata(action_type: str, metadata: dict) -> None:
+def _validate_card_field_metadata(
+    action_type: str, metadata: AiBehaviorMetadataInput
+) -> None:
     """Validate metadata for actions that operate on card fields.
 
     Args:
         action_type: The actionType string (used in error messages).
-        metadata: The metadata dict from the action.
+        metadata: The typed metadata from the action.
 
     Raises:
         ValueError: When required keys are missing or malformed.
     """
-    if not metadata.get("pipeId"):
+    if not metadata.pipe_id:
         raise ValueError(
             f"actionType '{action_type}' requires metadata.pipeId "
             f"(the pipe where the action executes)."
         )
-    _validate_fields_attributes_entries(action_type, metadata)
+    _validate_fields_attributes_entries(action_type, metadata.fields_attributes)
 
 
-def _validate_create_table_record_metadata(metadata: dict) -> None:
+def _validate_create_table_record_metadata(metadata: AiBehaviorMetadataInput) -> None:
     """Validate metadata for create_table_record (table row, not pipe fields)."""
-    if not metadata.get("tableId"):
+    if not metadata.table_id:
         raise ValueError(
             "actionType 'create_table_record' requires metadata.tableId "
             "(target database table ID)."
         )
-    _validate_fields_attributes_entries("create_table_record", metadata)
+    _validate_fields_attributes_entries(
+        "create_table_record", metadata.fields_attributes
+    )
 
 
-def _validate_send_email_template_metadata(metadata: dict) -> None:
+def _validate_send_email_template_metadata(metadata: AiBehaviorMetadataInput) -> None:
     """Validate metadata for send_email_template actions."""
-    template_id = metadata.get("emailTemplateId")
+    template_id = metadata.email_template_id
     if not isinstance(template_id, str) or not template_id.strip():
         raise ValueError(
             "actionType 'send_email_template' requires metadata.emailTemplateId "
             "(non-empty email template ID)."
         )
-    if "allowTemplateModifications" in metadata:
-        mod = metadata["allowTemplateModifications"]
-        if not isinstance(mod, bool):
-            raise ValueError(
-                "actionType 'send_email_template': metadata.allowTemplateModifications "
-                "must be a boolean when set."
-            )
+    mod = metadata.allow_template_modifications
+    if mod is not None and not isinstance(mod, bool):
+        raise ValueError(
+            "actionType 'send_email_template': metadata.allowTemplateModifications "
+            "must be a boolean when set."
+        )
 
 
-def _validate_move_card_metadata(metadata: dict) -> None:
+def _validate_move_card_metadata(metadata: AiBehaviorMetadataInput) -> None:
     """Validate metadata for move_card actions.
 
     Raises:
         ValueError: When destinationPhaseId is missing or blank.
     """
-    dest = metadata.get("destinationPhaseId")
+    dest = metadata.destination_phase_id
     if not isinstance(dest, str) or not dest.strip():
         raise ValueError(
             "actionType 'move_card' requires metadata.destinationPhaseId "
@@ -173,7 +176,7 @@ def _validate_action_metadata(action: AiBehaviorActionAttributes) -> None:
     Unknown actionTypes are passed through without validation.
     """
     action_type = action.action_type or ""
-    metadata = action.metadata if isinstance(action.metadata, dict) else {}
+    metadata = action.metadata or AiBehaviorMetadataInput()
 
     if action_type in _CARD_FIELD_ACTION_TYPES:
         _validate_card_field_metadata(action_type, metadata)
@@ -202,12 +205,38 @@ class AiBehaviorCapabilityAttributes(BaseModel):
     enabled: bool | None = None
 
 
+class AiBehaviorMetadataInput(BaseModel):
+    """Behavior action ``metadata`` (``AiBehaviorMetadataInput``).
+
+    Types the fields the per-actionType validators read; ``extra="allow"`` carries
+    the growing tail (``mcpServerId``, ``toolName``, ``toolInputs``, ``emails``,
+    ``title``, …) verbatim so GET→update round-trips stay byte-identical. All declared
+    names are camelCase. ``allowTemplateModifications`` is typed ``Any`` on purpose:
+    Pydantic's lax bool coercion would silently turn ``"yes"`` into ``True``, so the
+    boolean contract is enforced by :func:`_validate_send_email_template_metadata`
+    with an actionable message instead.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    pipe_id: str | None = Field(default=None, alias="pipeId")
+    table_id: str | None = Field(default=None, alias="tableId")
+    destination_phase_id: str | None = Field(default=None, alias="destinationPhaseId")
+    email_template_id: str | None = Field(default=None, alias="emailTemplateId")
+    allow_template_modifications: Any = Field(
+        default=None, alias="allowTemplateModifications"
+    )
+    fields_attributes: list[FieldMapInput] | None = Field(
+        default=None, alias="fieldsAttributes"
+    )
+
+
 class AiBehaviorActionAttributes(BaseModel):
     """One entry in ``aiBehaviorParams.actionsAttributes``.
 
-    ``metadata`` stays an opaque dict: it is a typed input server-side but grows
-    frequently, so keeping it a pass-through keeps GET→update round-trips faithful.
-    Unknown keys (e.g. injected ``referenceId``) pass through via ``extra="allow"``.
+    ``metadata`` is a typed :class:`AiBehaviorMetadataInput` shell: the validators read
+    typed fields, while ``extra="allow"`` on that model keeps the growing tail (and
+    injected keys like ``referenceId``) so GET→update round-trips serialize identically.
     """
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
@@ -216,7 +245,7 @@ class AiBehaviorActionAttributes(BaseModel):
     name: str | None = None
     action_type: str | None = Field(default=None, alias="actionType")
     reference_id: str | None = Field(default=None, alias="referenceId")
-    metadata: dict | None = None
+    metadata: AiBehaviorMetadataInput | None = None
 
 
 class AiBehaviorParams(BaseModel):

--- a/packages/sdk/src/pipefy_sdk/models/ai_automation.py
+++ b/packages/sdk/src/pipefy_sdk/models/ai_automation.py
@@ -41,6 +41,24 @@ class AutomationConditionInput(BaseModel):
     )
 
 
+class FieldMapInput(BaseModel):
+    """Shared ``FieldMapInput`` shell: a single field-mapping entry.
+
+    Used by both behavior action ``metadata.fieldsAttributes`` and classic-automation
+    ``action_params.field_map``. The GraphQL type marks ``fieldId`` and ``inputMode``
+    NON_NULL, but this is a lenient parse shell — required-ness is enforced by the
+    consumer (behavior metadata validators with pinned messages; the API for classic
+    automations) so a malformed entry yields an actionable error, not an opaque
+    Pydantic one. ``extra="allow"`` round-trips unknown keys.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    field_id: str | None = Field(default=None, alias="fieldId")
+    input_mode: str | None = Field(default=None, alias="inputMode")
+    value: str | None = None
+
+
 class AutomationEventParamsInput(BaseModel):
     """Pipefy ``AutomationEventParamsInput`` trigger params.
 

--- a/packages/sdk/tests/models/test_ai_agent.py
+++ b/packages/sdk/tests/models/test_ai_agent.py
@@ -8,10 +8,38 @@ from pydantic import ValidationError
 from pipefy_sdk.models.ai_agent import (
     ACTION_ID_AI_BEHAVIOR,
     MAX_BEHAVIORS,
+    AiBehaviorMetadataInput,
     BehaviorInput,
     CreateAiAgentInput,
     UpdateAiAgentInput,
 )
+
+
+@pytest.mark.unit
+def test_behavior_metadata_input_round_trips_known_and_grown_tail_fields():
+    """Typed fields carry camel aliases; undeclared tail keys ride extra verbatim."""
+    wire = {
+        "pipeId": "1",
+        "fieldsAttributes": [
+            {"fieldId": "900", "inputMode": "fill_with_ai", "value": ""}
+        ],
+        # Fields added to the schema after this model was written must survive.
+        "mcpServerId": "srv-1",
+        "toolName": "search",
+        "emails": ["a@b.com"],
+        "title": "Review task",
+    }
+    meta = AiBehaviorMetadataInput.model_validate(wire)
+    assert meta.pipe_id == "1"
+    assert meta.fields_attributes[0].field_id == "900"
+    assert meta.model_dump(by_alias=True, exclude_none=True) == wire
+
+
+@pytest.mark.unit
+def test_behavior_metadata_input_does_not_coerce_allow_template_modifications():
+    """allowTemplateModifications is stored verbatim (no lax bool coercion of 'yes')."""
+    meta = AiBehaviorMetadataInput.model_validate({"allowTemplateModifications": "yes"})
+    assert meta.allow_template_modifications == "yes"
 
 
 def _make_behavior(name="Test Behavior", event_id="card_created"):
@@ -361,7 +389,7 @@ def test_metadata_valid_for_card_field_actions(action_type):
     payload = behavior_with_action(action_type, metadata)
     inp = BehaviorInput.model_validate(payload)
     action = inp.action_params.ai_behavior_params.actions_attributes[0]
-    assert action.metadata["pipeId"] == EXAMPLE_PIPE_ID
+    assert action.metadata.pipe_id == EXAMPLE_PIPE_ID
 
 
 @pytest.mark.unit
@@ -445,7 +473,7 @@ def test_metadata_valid_for_move_card():
     payload = behavior_with_action("move_card", {"destinationPhaseId": "999"})
     inp = BehaviorInput.model_validate(payload)
     action = inp.action_params.ai_behavior_params.actions_attributes[0]
-    assert action.metadata["destinationPhaseId"] == "999"
+    assert action.metadata.destination_phase_id == "999"
 
 
 @pytest.mark.unit
@@ -467,7 +495,8 @@ def test_metadata_passes_through_unknown_action_type():
     payload = behavior_with_action("send_email", {"to": "user@example.com"})
     inp = BehaviorInput.model_validate(payload)
     action = inp.action_params.ai_behavior_params.actions_attributes[0]
-    assert action.metadata["to"] == "user@example.com"
+    # Unknown metadata keys ride extra="allow" and round-trip verbatim.
+    assert action.metadata.model_extra["to"] == "user@example.com"
 
 
 @pytest.mark.unit
@@ -485,7 +514,7 @@ def test_metadata_valid_for_create_table_record():
     payload = behavior_with_action("create_table_record", metadata)
     inp = BehaviorInput.model_validate(payload)
     action = inp.action_params.ai_behavior_params.actions_attributes[0]
-    assert action.metadata["tableId"] == "tbl-999"
+    assert action.metadata.table_id == "tbl-999"
 
 
 @pytest.mark.unit
@@ -534,7 +563,7 @@ def test_metadata_valid_for_send_email_template():
     )
     inp = BehaviorInput.model_validate(payload)
     meta = inp.action_params.ai_behavior_params.actions_attributes[0].metadata
-    assert meta["emailTemplateId"] == "tmpl-1"
+    assert meta.email_template_id == "tmpl-1"
 
 
 @pytest.mark.unit
@@ -545,7 +574,7 @@ def test_metadata_send_email_template_accepts_allow_template_modifications():
     )
     inp = BehaviorInput.model_validate(payload)
     meta = inp.action_params.ai_behavior_params.actions_attributes[0].metadata
-    assert meta["allowTemplateModifications"] is False
+    assert meta.allow_template_modifications is False
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/models/test_ai_automation.py
+++ b/packages/sdk/tests/models/test_ai_automation.py
@@ -9,8 +9,36 @@ from pipefy_sdk.models.ai_automation import (
     AutomationConditionInput,
     AutomationEventParamsInput,
     CreateAiAutomationInput,
+    FieldMapInput,
     UpdateAiAutomationInput,
 )
+
+
+@pytest.mark.unit
+def test_field_map_input_parses_and_dumps_declared_wire_names():
+    """fieldId/inputMode are camel aliases; dump emits the declared wire names."""
+    entry = FieldMapInput.model_validate(
+        {"fieldId": "900", "inputMode": "fill_with_ai", "value": ""}
+    )
+    assert entry.field_id == "900"
+    assert entry.input_mode == "fill_with_ai"
+    assert entry.value == ""
+    assert entry.model_dump(by_alias=True, exclude_none=True) == {
+        "fieldId": "900",
+        "inputMode": "fill_with_ai",
+        "value": "",
+    }
+
+
+@pytest.mark.unit
+def test_field_map_input_is_a_lenient_shell():
+    """Required-ness is enforced by consumers, not the shell: partial entries parse."""
+    entry = FieldMapInput.model_validate({"inputMode": "copy_from"})
+    assert entry.field_id is None
+    assert entry.input_mode == "copy_from"
+    # Unknown keys round-trip verbatim via extra="allow".
+    entry2 = FieldMapInput.model_validate({"fieldId": "1", "futureKey": "x"})
+    assert entry2.model_dump(by_alias=True, exclude_none=True)["futureKey"] == "x"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Motivation

Behavior action `metadata` was a pass-through `dict` and the per-actionType validators in `models/ai_agent.py` walked it with raw `.get()` string keys; its `fieldsAttributes` entries were untyped dicts. Follows #418.

## What ships

- `AiBehaviorMetadataInput` — types the fields the validators read; `extra="allow"` carries the growing tail verbatim.
- A shared lenient `FieldMapInput` shell (`fieldId` / `inputMode` / `value`) reused by behavior `fieldsAttributes` and, in the next phase, classic-automation `field_map`.
- The per-actionType metadata checks read typed attributes, preserving the pinned error-message substrings; consumers (pipe/phase-transition validation, slug resolution, MCP pipe-id extraction) read typed metadata.

## Proven contract (introspected, live)

`AiBehaviorMetadataInput`: `allowTemplateModifications`, `destinationPhaseId`, `emailTemplateId`, `fieldsAttributes` (→ `FieldMapInput`), `mcpServerId`, `pipeId`, `tableId`, `toolInputs`, `toolName`, plus `emails` / `title` — the last two are **not** in the issue's field list, confirming metadata grows and must keep `extra="allow"`. `FieldMapInput`: `fieldId` / `inputMode` NON_NULL, `value` nullable String. All camelCase.

## Behavior boundaries

`metadata` is now `AiBehaviorMetadataInput` with `extra="allow"`, so GET→update round-trips serialize identically (unknown/tail keys ride through). `allowTemplateModifications` is typed `Any` on purpose: Pydantic's lax bool coercion would turn `"yes"` into `True`, so the boolean contract stays enforced by the validator with an actionable message. The slug-resolution deep-copy is dropped — parsing now yields fresh `FieldMapInput` objects, so mutating `field_id` cannot reach the caller's input.

## Testing

Offline gates green. Live E2E on pipe `303088927`:

| # | Scenario | Expected | Observed | Verdict |
|---|----------|----------|----------|---------|
| 1 | Create AI agent with `update_card` metadata (`pipeId` + `fieldsAttributes`) → GET | round-trips with camel `pipeId` and `fieldsAttributes[{fieldId,inputMode,value}]` | GET returned exactly that | ✅ |
| 2 | `validate_ai_agent_behaviors` valid (move_card + update_card) | `valid: true` | `valid: true`, no problems | ✅ |
| 3 | GET→update-clone round-trip | update succeeds | updated successfully | ✅ |

Closes #419.
