### PR TITLE
Type classic automation params in automation_preflight

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
@@ -387,8 +387,8 @@ class AutomationTools:
             ``active: false`` to disable a rule after creation.
 
             For ``card_moved`` rules with action ``move_single_card``, when ``extra_input`` includes
-            ``event_params.to_phase_id`` and ``action_params.to_phase_id`` (or
-            ``phase.id``), the tool rejects impossible transitions before calling the API, using the
+            ``event_params.to_phase_id`` and ``action_params.to_phase_id``, the tool rejects
+            impossible transitions before calling the API, using the
             same read-only transition data as ``move_card_to_phase``.
 
             **Cross-pipe actions** (e.g. ``create_connected_card``, ``move_card_to_pipe``):

--- a/packages/sdk/src/pipefy_sdk/automation_preflight.py
+++ b/packages/sdk/src/pipefy_sdk/automation_preflight.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
 
-from pipefy_sdk.models import AutomationEventParamsInput
+from pipefy_sdk.models import AutomationActionParamsInput, AutomationEventParamsInput
 from pipefy_sdk.transition_hints import (
     TRANSITION_RULES_HINT,
     format_allowed_destinations_phrase,
@@ -42,6 +42,20 @@ def _parse_event_params(raw: Any) -> AutomationEventParamsInput | None:
         return None
     try:
         return AutomationEventParamsInput.model_validate(raw)
+    except ValidationError:
+        return None
+
+
+def _parse_action_params(raw: Any) -> AutomationActionParamsInput | None:
+    """Parse an ``action_params`` sub-dict, or ``None`` for missing/malformed input.
+
+    Lenient for the same reason as :func:`_parse_event_params`: preflight is advisory
+    and must never turn odd input into a spurious create failure.
+    """
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return AutomationActionParamsInput.model_validate(raw)
     except ValidationError:
         return None
 
@@ -101,9 +115,10 @@ async def validate_traditional_automation_move_transition(
         client: Pipefy facade.
         trigger_id: Rule trigger (e.g. ``card_moved``).
         action_id: Rule action id from the catalog (e.g. ``move_single_card``).
-        extra_input: Optional ``CreateAutomationInput``-style dict (``event_params`` /
-            ``action_params`` keys in snake_case or camelCase). Non-dict values are
-            treated as empty (no-op preflight).
+        extra_input: Optional ``CreateAutomationInput``-style dict. The destination is
+            read from ``action_params.to_phase_id`` (the sole declared write field;
+            ``phase`` is output-only and rejected on write). Non-dict values are treated
+            as empty (no-op preflight).
     """
     if str(trigger_id) != "card_moved":
         return
@@ -116,11 +131,8 @@ async def validate_traditional_automation_move_transition(
     if not src:
         return
     src_s = str(src)
-    act = extra.get("action_params") or extra.get("actionParams") or {}
-    dest = act.get("to_phase_id") or act.get("toPhaseId")
-    phase_nested = act.get("phase")
-    if dest is None and isinstance(phase_nested, dict):
-        dest = phase_nested.get("id")
+    act = _parse_action_params(extra.get("action_params"))
+    dest = act.to_phase_id if act else None
     if not dest:
         return
     dest_s = str(dest)
@@ -157,20 +169,14 @@ def extract_field_map_destination_ids(
     """Return ``field_map`` destination ``fieldId`` values from ``CreateAutomationInput``-style dicts."""
     if not isinstance(extra_input, dict):
         return []
-    act = extra_input.get("action_params") or extra_input.get("actionParams") or {}
-    if not isinstance(act, dict):
-        return []
-    field_map = act.get("field_map") or act.get("fieldMap")
-    if not field_map:
+    act = _parse_action_params(extra_input.get("action_params"))
+    if act is None or not act.field_map:
         return []
     ids: list[str] = []
-    for entry in field_map:
-        if not isinstance(entry, dict):
+    for entry in act.field_map:
+        if entry.field_id is None:
             continue
-        raw = entry.get("fieldId") or entry.get("field_id")
-        if raw is None:
-            continue
-        text = str(raw).strip()
+        text = str(entry.field_id).strip()
         if text:
             ids.append(text)
     return ids
@@ -267,8 +273,8 @@ async def validate_automation_field_map_field_ids(
 ) -> None:
     """Raise :class:`AutomationPreflightError` when ``field_map`` references unknown destination fields.
 
-    Only runs when ``extra_input`` includes ``action_params.field_map`` (or camelCase
-    equivalents). Compares each ``fieldId`` to numeric ``internal_id`` values on
+    Only runs when ``extra_input`` includes ``action_params.field_map``. Compares each
+    ``fieldId`` to numeric ``internal_id`` values on
     ``action_pipe_id`` (the action repo pipe). Upstream field-load failures are logged
     and skipped so preflight does not block creates on transient API errors.
 

--- a/packages/sdk/src/pipefy_sdk/models/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/models/__init__.py
@@ -14,6 +14,7 @@ from pipefy_sdk.models.ai_agent import (
     UpdateAiAgentInput,
 )
 from pipefy_sdk.models.ai_automation import (
+    AutomationActionParamsInput,
     AutomationConditionInput,
     AutomationEventParamsInput,
     CreateAiAutomationInput,
@@ -57,6 +58,7 @@ __all__ = [
     "AttachmentUploadError",
     "AttachmentUploadResult",
     "AttachmentUploadStep",
+    "AutomationActionParamsInput",
     "AutomationConditionInput",
     "AutomationEventParamsInput",
     "BehaviorInput",

--- a/packages/sdk/src/pipefy_sdk/models/ai_automation.py
+++ b/packages/sdk/src/pipefy_sdk/models/ai_automation.py
@@ -79,6 +79,22 @@ class AutomationEventParamsInput(BaseModel):
     trigger_field_ids: list[str] | None = Field(default=None, alias="triggerFieldIds")
 
 
+class AutomationActionParamsInput(BaseModel):
+    """Classic-automation ``AutomationActionParamsInput`` subtree read by preflight.
+
+    Only the fields preflight touches are typed (``field_map``, ``to_phase_id`` — both
+    snake wire names, so no alias); ``extra="allow"`` passes every other declared or
+    unknown key (``card_id``, ``aiBehaviorParams``, ``httpMethod``, …) through verbatim.
+    There is deliberately no ``phase`` field: it is not a declared write input (Core
+    rejects it), only an output-type convenience derived from ``to_phase_id``.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    field_map: list[FieldMapInput] | None = None
+    to_phase_id: str | None = None
+
+
 def _default_automation_condition() -> AutomationConditionInput:
     """Fresh placeholder condition (deep copy) for each new create input."""
     return AutomationConditionInput.model_validate(copy.deepcopy(DEFAULT_CONDITION))

--- a/packages/sdk/tests/models/test_ai_automation.py
+++ b/packages/sdk/tests/models/test_ai_automation.py
@@ -6,12 +6,38 @@ from pydantic import ValidationError
 
 from pipefy_sdk.models.ai_automation import (
     DEFAULT_CONDITION,
+    AutomationActionParamsInput,
     AutomationConditionInput,
     AutomationEventParamsInput,
     CreateAiAutomationInput,
     FieldMapInput,
     UpdateAiAutomationInput,
 )
+
+
+@pytest.mark.unit
+def test_action_params_input_types_field_map_and_to_phase_id():
+    """field_map parses into FieldMapInput entries; to_phase_id is the snake wire name."""
+    act = AutomationActionParamsInput.model_validate(
+        {
+            "field_map": [{"fieldId": "900", "inputMode": "copy_from"}],
+            "to_phase_id": "phase-7",
+        }
+    )
+    assert act.to_phase_id == "phase-7"
+    assert isinstance(act.field_map[0], FieldMapInput)
+    assert act.field_map[0].field_id == "900"
+
+
+@pytest.mark.unit
+def test_action_params_input_passes_siblings_and_output_only_phase_through_extra():
+    """Undeclared/sibling keys (card_id, and the output-only phase) ride extra verbatim."""
+    act = AutomationActionParamsInput.model_validate(
+        {"to_phase_id": "1", "card_id": "c-1", "phase": {"id": "9"}}
+    )
+    dumped = act.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["card_id"] == "c-1"
+    assert dumped["phase"] == {"id": "9"}
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/test_automation_preflight.py
+++ b/packages/sdk/tests/test_automation_preflight.py
@@ -299,23 +299,43 @@ async def test_validate_ai_automation_prompt_overlap_prompt_and_output(mock_clie
 
 
 @pytest.mark.anyio
-async def test_validate_resolves_dest_from_nested_phase_id(mock_client):
-    """Agents often pass ``action_params.phase.id`` instead of ``to_phase_id`` — both must work."""
-    mock_client.get_phase_allowed_move_targets.return_value = {
-        "phase": {"name": "Src", "cards_can_be_moved_to_phases": []},
-    }
-    with pytest.raises(AutomationPreflightError) as excinfo:
-        await validate_traditional_automation_move_transition(
-            mock_client,
-            trigger_id="card_moved",
-            action_id="move_single_card",
-            extra_input={
-                "event_params": {"to_phase_id": "src"},
-                "action_params": {"phase": {"id": "dest"}},
-            },
-        )
-    assert "id src" in str(excinfo.value)
-    assert "id dest" in str(excinfo.value)
+async def test_validate_ignores_output_only_phase_key(mock_client):
+    """``action_params.phase`` is output-only and rejected on write, so it is not a destination.
+
+    Core exposes ``phase`` only on the read type (derived from ``to_phase_id``); the
+    write input declares only ``to_phase_id``. A payload carrying ``phase`` but no
+    ``to_phase_id`` resolves no destination, so preflight is a no-op — the API returns
+    its own unknown-argument error at create time.
+    """
+    await validate_traditional_automation_move_transition(
+        mock_client,
+        trigger_id="card_moved",
+        action_id="move_single_card",
+        extra_input={
+            "event_params": {"to_phase_id": "src"},
+            "action_params": {"phase": {"id": "dest"}},
+        },
+    )
+    mock_client.get_phase_allowed_move_targets.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_validate_ignores_camel_to_phase_id_in_action_params(mock_client):
+    """``action_params.toPhaseId`` (camel) is not the declared destination spelling.
+
+    The event src is a valid snake ``to_phase_id`` control, so the check is skipped
+    because the camel *dest* resolves to nothing, not because the src is missing.
+    """
+    await validate_traditional_automation_move_transition(
+        mock_client,
+        trigger_id="card_moved",
+        action_id="move_single_card",
+        extra_input={
+            "event_params": {"to_phase_id": "src"},
+            "action_params": {"toPhaseId": "dest"},
+        },
+    )
+    mock_client.get_phase_allowed_move_targets.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -323,18 +343,25 @@ async def test_validate_resolves_dest_from_nested_phase_id(mock_client):
 # ---------------------------------------------------------------------------
 
 
-def test_extract_field_map_ids_snake_case():
+def test_extract_field_map_ids_declared_shape():
+    """The declared write shape: snake ``field_map`` wrapper, camel ``fieldId`` entries."""
     ids = extract_field_map_destination_ids(
         {
             "action_params": {
-                "field_map": [{"field_id": "429659044", "inputMode": "copy_from"}],
+                "field_map": [{"fieldId": "429659044", "inputMode": "copy_from"}],
             },
         },
     )
     assert ids == ["429659044"]
 
 
-def test_extract_field_map_ids_camel_case():
+def test_extract_field_map_ids_ignores_camel_wrapper_keys():
+    """``actionParams``/``fieldMap`` (camel wrappers) are not declared names.
+
+    Top-level keys are normalized to ``action_params`` upstream, and ``fieldMap`` is not
+    the declared list key (``field_map``), so neither is read: the helper honors only the
+    declared wrapper spellings.
+    """
     ids = extract_field_map_destination_ids(
         {
             "actionParams": {
@@ -342,7 +369,7 @@ def test_extract_field_map_ids_camel_case():
             },
         },
     )
-    assert ids == ["111"]
+    assert ids == []
 
 
 def test_extract_field_map_ids_empty_when_missing():
@@ -466,7 +493,8 @@ async def test_validate_field_map_raises_for_slug_field_id(mock_client):
 
 
 @pytest.mark.anyio
-async def test_validate_field_map_accepts_camel_case_keys(mock_client):
+async def test_validate_field_map_ignores_camel_wrapper_keys(mock_client):
+    """Camel wrappers (``actionParams``/``fieldMap``) are not declared; nothing is validated."""
     mock_client.get_pipe.return_value = _pipe_with_internal_field("42")
     await validate_automation_field_map_field_ids(
         mock_client,
@@ -479,6 +507,7 @@ async def test_validate_field_map_accepts_camel_case_keys(mock_client):
             },
         },
     )
+    mock_client.get_pipe.assert_not_called()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Motivation

Classic-automation preflight walked `CreateAutomationInput`-style dicts with dual-alias branches (`action_params`/`actionParams`, `to_phase_id`/`toPhaseId`, `field_map`/`fieldMap`, `fieldId`/`field_id`). Follows #419.

## What ships

- `AutomationActionParamsInput` — the subtree preflight reads (`field_map` as the shared `FieldMapInput`, `to_phase_id`; both snake wire names; `extra="allow"` for every other key). The action-params reads in `automation_preflight` are now typed; the dual-alias branches are gone.
- **The `action_params.phase.id` destination fallback is removed.**

## Proven contract (introspected + backend source of truth)

`AutomationActionParamsInput` declares `field_map` / `to_phase_id` / `card_id` / `email_template_id` / `fields_map_order` (snake) alongside `aiBehaviorParams` / `httpMethod` (camel). It has **no `phase` field**. The backend confirms: move actions read the destination solely from `to_phase_id`; there is no `phase`→`to_phase_id` normalization; and any non-declared `action_params` key is rejected on write. `phase` exists only on the read/output type, derived from `to_phase_id`. So the removed fallback validated a shape the API always rejects.

## Behavior boundaries

Non-declared camel wrappers (`actionParams` / `fieldMap`) are no longer read (top-level keys are normalized to `action_params` upstream). Preflight remains advisory and fails open on malformed input. Tests pinning the non-functional passthrough are updated to the declared names.

## Testing

Offline gates green. Live E2E on pipe `303088927` (`card_moved` → `move_single_card`):

| # | Scenario | Expected | Observed | Verdict |
|---|----------|----------|----------|---------|
| 1 | Valid transition (Inbox→Doing) via `action_params.to_phase_id` → GET → delete | created; GET returns `to_phase_id` (snake); output-only `phase` derived from it | created `307697066`; GET returned `to_phase_id: 319036223` and derived `phase{Doing}` | ✅ |
| 2 | Unreachable transition (Inbox→start-form) | preflight rejects with the allowed-destinations message | rejected: "not an allowed transition. Valid destinations: Doing, Done" | ✅ |
| 3 | Deletion coverage (throwaway) | deleted | deleted | ✅ |

The `action_params.phase` rejection is proven in-process (unit) rather than forced through a live create, per the pathological-input guidance.

Closes #420.
