### PR TITLE
Canonicalize + type AI-automation summary rows (response side)

### DIFF
--- a/packages/cli/src/pipefy_cli/commands/ai_automation.py
+++ b/packages/cli/src/pipefy_cli/commands/ai_automation.py
@@ -54,11 +54,14 @@ def _extract_existing_prompt_and_field_ids(
 
     Returns ``(None, None)`` for non-AI rows or rows missing the ``aiParams`` block;
     callers must surface that as a clear user error.
+
+    The row comes from ``get_automation``, whose query selects ``action_params`` (snake)
+    with a nested ``aiParams`` / ``fieldIds`` (camel) block — one canonical key style.
     """
-    action_params = row.get("action_params") or row.get("actionParams") or {}
-    ai_params = action_params.get("aiParams") or action_params.get("ai_params") or {}
+    action_params = row.get("action_params") or {}
+    ai_params = action_params.get("aiParams") or {}
     prompt = ai_params.get("value")
-    field_ids = ai_params.get("fieldIds") or ai_params.get("field_ids")
+    field_ids = ai_params.get("fieldIds")
     if not isinstance(prompt, str):
         prompt = None
     if isinstance(field_ids, list) and all(isinstance(x, str) for x in field_ids):
@@ -266,7 +269,7 @@ def ai_automation_update(
                 "Could not infer current prompt / field_ids from the existing automation. "
                 "Pass --prompt and --field-ids explicitly."
             )
-        ev = str(row.get("event_id") or row.get("eventId") or "")
+        ev = str(row.get("event_id") or "")
         pre = await validate_ai_automation_prompt_sdk(
             client,
             pipe.strip(),

--- a/packages/mcp/tests/tools/test_ai_automation_tools.py
+++ b/packages/mcp/tests/tools/test_ai_automation_tools.py
@@ -226,9 +226,9 @@ class TestGetAiAutomations:
             },
             {
                 "id": "3",
-                "name": "Legacy",
+                "name": "AI 2",
                 "active": True,
-                "actionParams": {"aiParams": {"value": "x"}},
+                "action_id": "generate_with_ai",
             },
         ]
         async with client_session as session:
@@ -248,12 +248,14 @@ class TestGetAiAutomations:
         ids = {row["id"] for row in data}
         assert ids == {"1", "3"}
 
-    async def test_filter_accepts_camel_case_action_id(
+    async def test_filter_ignores_camel_case_action_id(
         self,
         client_session,
         mock_pipefy_client,
         extract_payload,
     ):
+        """The list query emits snake ``action_id``; a camel ``actionId`` never occurs
+        and is not treated as an AI automation."""
         mock_pipefy_client.get_automations.return_value = [
             {"id": "9", "name": "AI", "active": True, "actionId": "generate_with_ai"},
         ]
@@ -263,7 +265,7 @@ class TestGetAiAutomations:
                 {"pipe_id": "1"},
             )
         data = extract_payload(result)["data"]
-        assert len(data) == 1 and data[0]["id"] == "9"
+        assert data == []
 
     async def test_empty_when_none_match(
         self,

--- a/packages/sdk/src/pipefy_sdk/ai_preflight.py
+++ b/packages/sdk/src/pipefy_sdk/ai_preflight.py
@@ -34,18 +34,15 @@ MAX_CROSS_PIPE_FIELD_FETCH = 100
 
 
 def _is_ai_automation_summary_row(row: Any) -> bool:
-    """True when the listing row is an AI (prompt) automation."""
+    """True when the listing row is an AI (prompt) automation.
+
+    Listing rows come from ``get_automations``, whose query selects ``action_id``
+    (snake) on every node and does not select ``action_params``. So ``action_id`` is
+    the sole, canonical signal — ``generate_with_ai`` marks an AI automation.
+    """
     if not isinstance(row, dict):
         return False
-    action_id = row.get("action_id") or row.get("actionId")
-    if action_id == GENERATE_WITH_AI_ACTION_ID:
-        return True
-    ap = row.get("action_params") or row.get("actionParams")
-    if isinstance(ap, dict) and (
-        ap.get("aiParams") is not None or ap.get("ai_params") is not None
-    ):
-        return True
-    return False
+    return row.get("action_id") == GENERATE_WITH_AI_ACTION_ID
 
 
 def filter_ai_automation_summaries(rows: list[Any]) -> list[Any]:

--- a/packages/sdk/tests/test_ai_automation_summary_filter.py
+++ b/packages/sdk/tests/test_ai_automation_summary_filter.py
@@ -1,0 +1,31 @@
+"""Tests for AI-automation summary-row filtering (canonical response key style)."""
+
+import pytest
+
+from pipefy_sdk.ai_preflight import filter_ai_automation_summaries
+
+
+@pytest.mark.unit
+def test_filter_keeps_only_generate_with_ai_by_snake_action_id():
+    rows = [
+        {"id": "1", "name": "AI", "active": True, "action_id": "generate_with_ai"},
+        {"id": "2", "name": "HTTP", "active": True, "action_id": "send_http_request"},
+        {"id": "3", "name": "AI 2", "active": True, "action_id": "generate_with_ai"},
+    ]
+    kept = filter_ai_automation_summaries(rows)
+    assert [r["id"] for r in kept] == ["1", "3"]
+
+
+@pytest.mark.unit
+def test_filter_ignores_non_declared_spellings():
+    """The list query emits snake ``action_id`` only; camel/action_params never occur."""
+    rows = [
+        {"id": "9", "name": "AI", "active": True, "actionId": "generate_with_ai"},
+        {"id": "10", "name": "Legacy", "actionParams": {"aiParams": {"value": "x"}}},
+    ]
+    assert filter_ai_automation_summaries(rows) == []
+
+
+@pytest.mark.unit
+def test_filter_skips_non_dict_rows():
+    assert filter_ai_automation_summaries([None, "x", 3]) == []


### PR DESCRIPTION
## Motivation

The AI-automation listing (`_is_ai_automation_summary_row`) and the CLI update path (`_extract_existing_prompt_and_field_ids`, the `event_id` read) walked rows with dual-alias branches. Unlike the input-side issues, the row shape is set by our own query documents. Follows #420.

## What ships

Read the single canonical key each, deleting the dual-reads. The two producing queries agree: the list query (`get_automations`) selects snake `action_id` (and no `action_params`); the single query (`get_automation`) selects snake `action_params` / `event_id` with a nested camel `aiParams` / `fieldIds`. The alternate spellings the dual-reads accepted (`actionId`, `actionParams`, `ai_params`, `field_ids`, `eventId`) are never emitted, so they were dead branches. A listing row never carries `action_params`, so `action_id` is the sole AI marker.

## Behavior boundaries

No response read-model is introduced: the rows are shallow and a validating model would guard nothing (the #423 survey governs where parsing pays off). Tests pinning the non-emitted spellings are updated to assert those shapes are not honored.

## Testing

Offline gates green. Live E2E on pipe `303088927`:

| # | Scenario | Expected | Observed | Verdict |
|---|----------|----------|----------|---------|
| 1 | `get_ai_automations` with a `generate_with_ai` rule present | returns it via snake `action_id` | returned `id 307697184`, `action_id: generate_with_ai` | ✅ |
| 2 | `get_ai_automations` with none | `[]`, no crash | `[]` | ✅ |
| 3 | `get_automation` single row → CLI prompt/field-id extraction path | reads `action_params.aiParams.fieldIds` (snake wrapper, camel inner) | GET returned `action_params.aiParams.fieldIds: ["429785561"]` | ✅ |

Closes #421.
