### PR TITLE
Expose card/comment/card-relation writes on the remote profile

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -91,6 +91,7 @@ class PipeTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_card(
             ctx: Context[ServerSession, None],
@@ -390,6 +391,7 @@ class PipeTools:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
             structured_output=False,
+            meta=REMOTE,
         )
         async def add_card_comment(
             card_id: PipefyId, text: str, ctx: Context[ServerSession, None]
@@ -427,6 +429,7 @@ class PipeTools:
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
             structured_output=False,
+            meta=REMOTE,
         )
         async def update_comment(
             comment_id: PipefyId, text: str, ctx: Context[ServerSession, None]
@@ -465,6 +468,7 @@ class PipeTools:
                 destructiveHint=True,
             ),
             structured_output=False,
+            meta=REMOTE,
         )
         async def delete_comment(
             ctx: Context[ServerSession, None],
@@ -514,6 +518,7 @@ class PipeTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_card_relation(
             ctx: Context[ServerSession, None],
@@ -868,6 +873,7 @@ class PipeTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=True),
+            meta=REMOTE,
         )
         async def move_card_to_phase(
             card_id: PipefyId,
@@ -907,6 +913,7 @@ class PipeTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_card_field(
             card_id: PipefyId,
@@ -951,6 +958,7 @@ class PipeTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_card(
             card_id: PipefyId,
@@ -1085,6 +1093,7 @@ class PipeTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def fill_card_phase_fields(
             ctx: Context[ServerSession, None],
@@ -1226,6 +1235,7 @@ class PipeTools:
                 destructiveHint=True,
             ),
             structured_output=False,
+            meta=REMOTE,
         )
         async def delete_card(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/src/pipefy_mcp/tools/relation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/relation_tools.py
@@ -271,6 +271,7 @@ class RelationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_card_relation(
             parent_id: PipefyId,

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -125,6 +125,23 @@ REMOTE_SEED = frozenset(
         "create_service_account",
         "delete_service_account",
         "add_service_account_to_pipe",
+        # card / comment / card-relation writes (#472): create/update/delete and
+        # action-style mutations that reach the public (or, for delete_card_relation,
+        # Internal) API with the request-scoped bearer and are governed by API
+        # permissions; no filesystem or per-user process-global settings reads, and
+        # every input is a per-request value (ids, titles, field values). The deletes
+        # carry the two-step confirm UX guard; authorization stays the API's.
+        "add_card_comment",
+        "create_card",
+        "update_card",
+        "update_card_field",
+        "delete_card",
+        "move_card_to_phase",
+        "fill_card_phase_fields",
+        "update_comment",
+        "delete_comment",
+        "create_card_relation",
+        "delete_card_relation",
     }
 )
 


### PR DESCRIPTION
## Motivation
Under `--profile remote` the hosted server is default-deny: a tool is exposed only if its registration carries `meta=REMOTE` (tracked by `REMOTE_SEED`). The write-exposure policy (#442, AGENTS.md "Write tools on the remote profile") is set; this stages the first write category — card, comment, and card-relation mutations — against it.

## Outcome
Marks 11 write tools remote-safe: `add_card_comment`, `create_card`, `update_card`, `update_card_field`, `delete_card`, `move_card_to_phase`, `fill_card_phase_fields`, `update_comment`, `delete_comment`, `create_card_relation`, `delete_card_relation`. Each reaches the public API — or, for `delete_card_relation`, Pipefy's Internal API — with the request-scoped bearer and is fully governed by API permissions; no filesystem or per-user process-global settings reads, every input a per-request value. Deletes keep the two-step `confirm` UX guard (deliberateness, not authorization). No behavior change under the local profile.

## Testing
`test_remote_profile.py` drift-guard green (marker↔seed lockstep). The full write-migration stack was verified end-to-end under `--profile remote --transport http`: unauthenticated request → 401; authenticated `tools/list` (locally-minted RS256 bearer, served JWKS) equals `REMOTE_SEED`; these 11 tools present; the 6 hard-exclusions (`upload_attachment_to_card`, `upload_attachment_to_table_record`, `create_ai_knowledge_base_document`, `create_llm_provider`, `update_llm_provider`, `execute_graphql`) absent.

Closes #472.
