### PR TITLE
Expose pipe/phase/field/label writes on the remote profile

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -129,6 +129,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=False,
             ),
+            meta=REMOTE,
         )
         async def create_pipe(
             name: str,
@@ -173,6 +174,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=False,
             ),
+            meta=REMOTE,
         )
         async def update_pipe(
             pipe_id: PipefyId,
@@ -233,6 +235,7 @@ class PipeConfigTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_pipe(
             ctx: Context[ServerSession, None],
@@ -318,6 +321,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=False,
             ),
+            meta=REMOTE,
         )
         async def clone_pipe(
             pipe_template_id: PipefyId,
@@ -553,6 +557,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=False,
             ),
+            meta=REMOTE,
         )
         async def create_phase(
             pipe_id: PipefyId,
@@ -613,6 +618,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=False,
             ),
+            meta=REMOTE,
         )
         async def update_phase(
             phase_id: PipefyId,
@@ -714,6 +720,7 @@ class PipeConfigTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_phase(
             ctx: Context[ServerSession, None],
@@ -782,6 +789,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=False,
             ),
+            meta=REMOTE,
         )
         async def create_phase_field(
             phase_id: PipefyId,
@@ -862,6 +870,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=False,
             ),
+            meta=REMOTE,
         )
         async def update_phase_field(
             field_id: PipefyId,
@@ -978,6 +987,7 @@ class PipeConfigTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_phase_field(
             ctx: Context[ServerSession, None],
@@ -1097,6 +1107,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=False,
             ),
+            meta=REMOTE,
         )
         async def create_label(
             pipe_id: PipefyId,
@@ -1156,6 +1167,7 @@ class PipeConfigTools:
             annotations=ToolAnnotations(
                 readOnlyHint=False,
             ),
+            meta=REMOTE,
         )
         async def update_label(
             label_id: PipefyId,
@@ -1226,6 +1238,7 @@ class PipeConfigTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_label(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -142,6 +142,24 @@ REMOTE_SEED = frozenset(
         "delete_comment",
         "create_card_relation",
         "delete_card_relation",
+        # pipe / phase / phase-field / label writes (#473): create/update/delete
+        # (plus clone_pipe) that reach the public API with the request-scoped bearer
+        # and are governed by API permissions (pipe-admin to alter structure); no
+        # filesystem or per-user process-global settings reads, every input a
+        # per-request value. Deletes carry the two-step confirm UX guard.
+        "create_pipe",
+        "update_pipe",
+        "delete_pipe",
+        "clone_pipe",
+        "create_phase",
+        "update_phase",
+        "delete_phase",
+        "create_phase_field",
+        "update_phase_field",
+        "delete_phase_field",
+        "create_label",
+        "update_label",
+        "delete_label",
     }
 )
 


### PR DESCRIPTION
## Motivation
Continues staging write categories onto the default-deny remote profile against the #442 policy. This covers pipe, phase, phase-field, and label structural mutations.

## Outcome
Marks 13 write tools remote-safe: `create_pipe`, `update_pipe`, `delete_pipe`, `clone_pipe`, `create_phase`, `update_phase`, `delete_phase`, `create_phase_field`, `update_phase_field`, `delete_phase_field`, `create_label`, `update_label`, `delete_label`. Each reaches the public API with the request-scoped bearer and is governed by API permissions (pipe-admin to alter structure); no filesystem or per-user process-global settings reads, every input a per-request value. Deletes keep the two-step `confirm` UX guard. No behavior change under the local profile.

## Testing
`test_remote_profile.py` drift-guard green (marker↔seed lockstep). The full write-migration stack was verified end-to-end under `--profile remote --transport http`: unauthenticated request → 401; authenticated `tools/list` (locally-minted RS256 bearer, served JWKS) equals `REMOTE_SEED`; these 13 tools present; the 6 hard-exclusions absent.

Closes #473.
