### PR TITLE
Expose field-condition/pipe-relation writes on the remote profile

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/field_condition_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/field_condition_tools.py
@@ -156,6 +156,7 @@ class FieldConditionTools:
             annotations=ToolAnnotations(
                 readOnlyHint=False,
             ),
+            meta=REMOTE,
         )
         async def create_field_condition(
             ctx: Context,
@@ -318,6 +319,7 @@ class FieldConditionTools:
             annotations=ToolAnnotations(
                 readOnlyHint=False,
             ),
+            meta=REMOTE,
         )
         async def update_field_condition(
             ctx: Context,
@@ -436,6 +438,7 @@ class FieldConditionTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_field_condition(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/src/pipefy_mcp/tools/relation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/relation_tools.py
@@ -105,6 +105,7 @@ class RelationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_pipe_relation(
             parent_id: PipefyId,
@@ -166,6 +167,7 @@ class RelationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_pipe_relation(
             relation_id: PipefyId,
@@ -222,6 +224,7 @@ class RelationTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_pipe_relation(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -160,6 +160,16 @@ REMOTE_SEED = frozenset(
         "create_label",
         "update_label",
         "delete_label",
+        # field-condition / pipe-relation writes (#474): create/update/delete that
+        # reach the public API with the request-scoped bearer and are governed by API
+        # permissions; no filesystem or per-user process-global settings reads, every
+        # input a per-request value. Deletes carry the two-step confirm UX guard.
+        "create_field_condition",
+        "update_field_condition",
+        "delete_field_condition",
+        "create_pipe_relation",
+        "update_pipe_relation",
+        "delete_pipe_relation",
     }
 )
 


### PR DESCRIPTION
## Motivation
Continues staging write categories onto the default-deny remote profile against the #442 policy. This covers field-condition and pipe-relation mutations.

## Outcome
Marks 6 write tools remote-safe: `create_field_condition`, `update_field_condition`, `delete_field_condition`, `create_pipe_relation`, `update_pipe_relation`, `delete_pipe_relation`. Each reaches the public API with the request-scoped bearer and is governed by API permissions; no filesystem or per-user process-global settings reads, every input a per-request value. Deletes keep the two-step `confirm` UX guard. No behavior change under the local profile.

## Testing
`test_remote_profile.py` drift-guard green (marker↔seed lockstep). The full write-migration stack was verified end-to-end under `--profile remote --transport http`: unauthenticated request → 401; authenticated `tools/list` (locally-minted RS256 bearer, served JWKS) equals `REMOTE_SEED`; these 6 tools present; the 6 hard-exclusions absent.

Closes #474.
