### PR TITLE
Expose table/table-field/record writes on the remote profile

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/table_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/table_tools.py
@@ -397,6 +397,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_table(
             name: str,
@@ -449,6 +450,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_table(
             table_id: PipefyId,
@@ -514,6 +516,7 @@ class TableTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_table(
             ctx: Context[ServerSession, None],
@@ -597,6 +600,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_table_record(
             table_id: PipefyId,
@@ -681,6 +685,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_table_record(
             record_id: PipefyId,
@@ -736,6 +741,7 @@ class TableTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_table_record(
             ctx: Context[ServerSession, None],
@@ -786,6 +792,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def set_table_record_field_value(
             record_id: PipefyId,
@@ -840,6 +847,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_table_field(
             table_id: PipefyId,
@@ -911,6 +919,7 @@ class TableTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_table_field(
             field_id: PipefyId,
@@ -1004,6 +1013,7 @@ class TableTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_table_field(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -170,6 +170,22 @@ REMOTE_SEED = frozenset(
         "create_pipe_relation",
         "update_pipe_relation",
         "delete_pipe_relation",
+        # table / table-field / record writes (#475): create/update/delete and
+        # set_table_record_field_value that reach the public API with the
+        # request-scoped bearer and are governed by API permissions; no filesystem or
+        # per-user process-global settings reads, every input a per-request value.
+        # Deletes carry the two-step confirm UX guard. upload_attachment_to_table_record
+        # stays withheld (local-file input, tracked by #305).
+        "create_table",
+        "update_table",
+        "delete_table",
+        "create_table_field",
+        "update_table_field",
+        "delete_table_field",
+        "create_table_record",
+        "update_table_record",
+        "delete_table_record",
+        "set_table_record_field_value",
     }
 )
 


### PR DESCRIPTION
## Motivation
Continues staging write categories onto the default-deny remote profile against the #442 policy. This covers table, table-field, and record mutations.

## Outcome
Marks 10 write tools remote-safe: `create_table`, `update_table`, `delete_table`, `create_table_field`, `update_table_field`, `delete_table_field`, `create_table_record`, `update_table_record`, `delete_table_record`, `set_table_record_field_value`. Each reaches the public API with the request-scoped bearer and is governed by API permissions; no filesystem or per-user process-global settings reads, every input a per-request value. `upload_attachment_to_table_record` stays withheld (local-file input, #305). Deletes keep the two-step `confirm` UX guard. No behavior change under the local profile.

## Testing
`test_remote_profile.py` drift-guard green (marker↔seed lockstep). The full write-migration stack was verified end-to-end under `--profile remote --transport http`: unauthenticated request → 401; authenticated `tools/list` (locally-minted RS256 bearer, served JWKS) equals `REMOTE_SEED`; these 10 tools present; the 6 hard-exclusions absent.

Closes #475.
