### PR TITLE
Expose report writes and exports on the remote profile

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/report_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/report_tools.py
@@ -392,6 +392,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_pipe_report(
             pipe_id: PipefyId,
@@ -444,6 +445,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_pipe_report(
             report_id: PipefyId,
@@ -505,6 +507,7 @@ class ReportTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_pipe_report(
             ctx: Context[ServerSession, None],
@@ -553,6 +556,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_organization_report(
             organization_id: PipefyId,
@@ -609,6 +613,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_organization_report(
             report_id: PipefyId,
@@ -668,6 +673,7 @@ class ReportTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_organization_report(
             ctx: Context[ServerSession, None],
@@ -716,6 +722,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def export_pipe_report(
             pipe_id: PipefyId,
@@ -772,6 +779,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def export_organization_report(
             organization_id: PipefyId,
@@ -829,6 +837,7 @@ class ReportTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def export_pipe_audit_logs(
             pipe_uuid: str,

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -186,6 +186,22 @@ REMOTE_SEED = frozenset(
         "update_table_record",
         "delete_table_record",
         "set_table_record_field_value",
+        # report writes (#476): pipe/organization report create/update/delete plus
+        # the export triggers, which reach the public API with the request-scoped
+        # bearer and are governed by API permissions; no filesystem or per-user
+        # process-global settings reads, every input a per-request value. The export
+        # triggers start an async server-side export and return a status/URL through
+        # the API — no local-disk write (the matching get_*_export reads that poll the
+        # fileURL are already seeded). Deletes carry the two-step confirm UX guard.
+        "create_pipe_report",
+        "update_pipe_report",
+        "delete_pipe_report",
+        "export_pipe_report",
+        "create_organization_report",
+        "update_organization_report",
+        "delete_organization_report",
+        "export_organization_report",
+        "export_pipe_audit_logs",
     }
 )
 


### PR DESCRIPTION
## Motivation
Continues staging write categories onto the default-deny remote profile against the #442 policy. This covers pipe/organization report writes and the export triggers.

## Outcome
Marks 9 write tools remote-safe: `create_pipe_report`, `update_pipe_report`, `delete_pipe_report`, `export_pipe_report`, `create_organization_report`, `update_organization_report`, `delete_organization_report`, `export_organization_report`, `export_pipe_audit_logs`. Each reaches the public API with the request-scoped bearer and is governed by API permissions; no filesystem or per-user process-global settings reads, every input a per-request value. The export triggers start a server-side async export and return a status/URL through the API — no local-disk write — pairing with the already-seeded `get_*_export` reads that poll the fileURL. Deletes keep the two-step `confirm` UX guard. No behavior change under the local profile.

## Testing
`test_remote_profile.py` drift-guard green (marker↔seed lockstep). The full write-migration stack was verified end-to-end under `--profile remote --transport http`: unauthenticated request → 401; authenticated `tools/list` (locally-minted RS256 bearer, served JWKS) equals `REMOTE_SEED`; these 9 tools present; the 6 hard-exclusions absent.

Closes #476.
