### PR TITLE
Expose portal/sub-portal/page/element writes on the remote profile

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/portal_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/portal_tools.py
@@ -123,6 +123,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_portal(
             ctx: Context[ServerSession, None],
@@ -152,6 +153,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_portal(
             ctx: Context[ServerSession, None],
@@ -217,6 +219,7 @@ class PortalTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_portal(
             ctx: Context[ServerSession, None],
@@ -261,6 +264,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_portal_page(
             ctx: Context[ServerSession, None],
@@ -315,6 +319,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_portal_page(
             ctx: Context[ServerSession, None],
@@ -383,6 +388,7 @@ class PortalTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_portal_page(
             ctx: Context[ServerSession, None],
@@ -435,6 +441,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def sort_portal_pages(
             ctx: Context[ServerSession, None],
@@ -481,6 +488,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_portal_page_layout(
             ctx: Context[ServerSession, None],
@@ -514,6 +522,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_portal_element(
             ctx: Context[ServerSession, None],
@@ -586,6 +595,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_portal_element(
             ctx: Context[ServerSession, None],
@@ -660,6 +670,7 @@ class PortalTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_portal_element(
             ctx: Context[ServerSession, None],
@@ -712,6 +723,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def duplicate_portal_element(
             ctx: Context[ServerSession, None],
@@ -756,6 +768,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_sub_portal(
             ctx: Context[ServerSession, None],
@@ -794,6 +807,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_sub_portal_element(
             ctx: Context[ServerSession, None],
@@ -840,6 +854,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def publish_sub_portal(
             ctx: Context[ServerSession, None],
@@ -884,6 +899,7 @@ class PortalTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def unpublish_sub_portal(
             ctx: Context[ServerSession, None],
@@ -927,6 +943,7 @@ class PortalTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_sub_portal_element(
             ctx: Context[ServerSession, None],
@@ -988,6 +1005,7 @@ class PortalTools:
                 readOnlyHint=False,
                 destructiveHint=True,
             ),
+            meta=REMOTE,
         )
         async def delete_sub_portal(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -202,6 +202,29 @@ REMOTE_SEED = frozenset(
         "delete_organization_report",
         "export_organization_report",
         "export_pipe_audit_logs",
+        # portal / sub-portal / page / element writes (#477): create/update/delete
+        # and the action-style mutations (sort/layout/duplicate/publish/unpublish)
+        # reach the Interfaces API with the request-scoped bearer and are governed by
+        # API permissions; no filesystem or per-user process-global settings reads,
+        # every input a per-request value. Deletes carry the two-step confirm UX guard.
+        "create_portal",
+        "update_portal",
+        "delete_portal",
+        "create_portal_page",
+        "update_portal_page",
+        "delete_portal_page",
+        "update_portal_page_layout",
+        "sort_portal_pages",
+        "create_portal_element",
+        "update_portal_element",
+        "delete_portal_element",
+        "duplicate_portal_element",
+        "create_sub_portal",
+        "delete_sub_portal",
+        "publish_sub_portal",
+        "unpublish_sub_portal",
+        "update_sub_portal_element",
+        "delete_sub_portal_element",
     }
 )
 


### PR DESCRIPTION
## Motivation
Continues staging write categories onto the default-deny remote profile against the #442 policy. This covers portal, sub-portal, page, and element mutations.

## Outcome
Marks 18 write tools remote-safe: `create_portal`, `update_portal`, `delete_portal`, `create_portal_page`, `update_portal_page`, `delete_portal_page`, `update_portal_page_layout`, `sort_portal_pages`, `create_portal_element`, `update_portal_element`, `delete_portal_element`, `duplicate_portal_element`, `create_sub_portal`, `delete_sub_portal`, `publish_sub_portal`, `unpublish_sub_portal`, `update_sub_portal_element`, `delete_sub_portal_element`. Each reaches the Interfaces API with the request-scoped bearer and is governed by API permissions; no filesystem or per-user process-global settings reads, every input a per-request value. Deletes keep the two-step `confirm` UX guard. No behavior change under the local profile.

## Testing
`test_remote_profile.py` drift-guard green (marker↔seed lockstep). The full write-migration stack was verified end-to-end under `--profile remote --transport http`: unauthenticated request → 401; authenticated `tools/list` (locally-minted RS256 bearer, served JWKS) equals `REMOTE_SEED`; these 18 tools present; the 6 hard-exclusions absent.

Closes #477.
