### PR TITLE
Expose traditional & AI automation writes on the remote profile

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -240,6 +240,7 @@ class AiAutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+            meta=REMOTE,
         )
         async def delete_ai_automation(
             ctx: Context[ServerSession, None],
@@ -297,6 +298,7 @@ class AiAutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_ai_automation(
             ctx: Context,
@@ -378,6 +380,7 @@ class AiAutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_ai_automation(
             ctx: Context,

--- a/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
@@ -261,6 +261,7 @@ class AutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+            meta=REMOTE,
         )
         async def simulate_automation(
             ctx: Context,
@@ -365,6 +366,7 @@ class AutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_automation(
             ctx: Context,
@@ -506,6 +508,7 @@ class AutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+            meta=REMOTE,
         )
         async def create_send_task_automation(
             ctx: Context,
@@ -586,6 +589,7 @@ class AutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_automation(
             ctx: Context,
@@ -640,6 +644,7 @@ class AutomationTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+            meta=REMOTE,
         )
         async def delete_automation(
             ctx: Context[ServerSession, None],

--- a/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/observability_tools.py
@@ -527,6 +527,7 @@ class ObservabilityTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def export_automation_jobs(
             organization_id: PipefyId,

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -242,6 +242,22 @@ REMOTE_SEED = frozenset(
         "set_role",
         "send_inbox_email",
         "send_email_with_template",
+        # traditional & AI automation writes (#479): create/update/delete, the
+        # send-task automation, simulate_automation, and the automation-jobs export
+        # trigger reach the public API with the request-scoped bearer and are
+        # governed by API permissions; no filesystem or per-user process-global
+        # settings reads, every input a per-request value. The export trigger starts
+        # a server-side async export (its get_automation_jobs_export reads are already
+        # seeded), no local write. Deletes carry the two-step confirm UX guard.
+        "create_automation",
+        "update_automation",
+        "delete_automation",
+        "create_send_task_automation",
+        "simulate_automation",
+        "export_automation_jobs",
+        "create_ai_automation",
+        "update_ai_automation",
+        "delete_ai_automation",
     }
 )
 


### PR DESCRIPTION
## Motivation
Continues staging write categories onto the default-deny remote profile against the #442 policy. This covers traditional and AI automation mutations.

## Outcome
Marks 9 write tools remote-safe: `create_automation`, `update_automation`, `delete_automation`, `create_send_task_automation`, `simulate_automation`, `export_automation_jobs`, `create_ai_automation`, `update_ai_automation`, `delete_ai_automation`. Each reaches the public API with the request-scoped bearer and is governed by API permissions; no filesystem or per-user process-global settings reads, every input a per-request value. The export trigger starts a server-side async export (its `get_automation_jobs_export` reads are already seeded), no local write. Deletes keep the two-step `confirm` UX guard. No behavior change under the local profile.

## Testing
`test_remote_profile.py` drift-guard green (marker↔seed lockstep). The full write-migration stack was verified end-to-end under `--profile remote --transport http`: unauthenticated request → 401; authenticated `tools/list` (locally-minted RS256 bearer, served JWKS) equals `REMOTE_SEED`; these 9 tools present; the 6 hard-exclusions absent.

Closes #479.
