### PR TITLE
Expose AI agent writes on the remote profile

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -155,6 +155,7 @@ class AiAgentTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def create_ai_agent(
             ctx: Context,
@@ -362,6 +363,7 @@ class AiAgentTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def update_ai_agent(
             ctx: Context,
@@ -482,6 +484,7 @@ class AiAgentTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
+            meta=REMOTE,
         )
         async def toggle_ai_agent_status(
             ctx: Context,
@@ -568,6 +571,7 @@ class AiAgentTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+            meta=REMOTE,
         )
         async def delete_ai_agent(
             ctx: Context, uuid: str, confirm: bool = False

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -258,6 +258,15 @@ REMOTE_SEED = frozenset(
         "create_ai_automation",
         "update_ai_automation",
         "delete_ai_automation",
+        # AI agent writes (#480): create/update/delete and the enable/disable toggle
+        # reach the public API with the request-scoped bearer and are governed by API
+        # permissions (manage_ai_agents); no filesystem or per-user process-global
+        # settings reads, every input a per-request value. delete carries the
+        # two-step confirm UX guard.
+        "create_ai_agent",
+        "update_ai_agent",
+        "delete_ai_agent",
+        "toggle_ai_agent_status",
     }
 )
 


### PR DESCRIPTION
## Motivation
Continues staging write categories onto the default-deny remote profile against the #442 policy. This covers AI agent mutations.

## Outcome
Marks 4 write tools remote-safe: `create_ai_agent`, `update_ai_agent`, `delete_ai_agent`, `toggle_ai_agent_status`. Each reaches the public API with the request-scoped bearer and is governed by API permissions (`manage_ai_agents`); no filesystem or per-user process-global settings reads, every input a per-request value. `delete_ai_agent` keeps the two-step `confirm` UX guard. No behavior change under the local profile.

## Testing
`test_remote_profile.py` drift-guard green (marker↔seed lockstep). The full write-migration stack was verified end-to-end under `--profile remote --transport http`: unauthenticated request → 401; authenticated `tools/list` (locally-minted RS256 bearer, served JWKS) equals `REMOTE_SEED`; these 4 tools present; the 6 hard-exclusions absent.

Closes #480.
