### PR TITLE
Expose knowledge-base writes on the remote profile

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/knowledge_base_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/knowledge_base_tools.py
@@ -172,6 +172,7 @@ class KnowledgeBaseTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+            meta=REMOTE,
         )
         async def create_ai_knowledge_base_plain_text(
             ctx: Context,
@@ -215,6 +216,7 @@ class KnowledgeBaseTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+            meta=REMOTE,
         )
         async def update_ai_knowledge_base_plain_text(
             ctx: Context,
@@ -263,6 +265,7 @@ class KnowledgeBaseTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+            meta=REMOTE,
         )
         async def delete_ai_knowledge_base_plain_text(
             ctx: Context,
@@ -403,6 +406,7 @@ class KnowledgeBaseTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+            meta=REMOTE,
         )
         async def update_ai_knowledge_base_document(
             ctx: Context,
@@ -447,6 +451,7 @@ class KnowledgeBaseTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+            meta=REMOTE,
         )
         async def delete_ai_knowledge_base_document(
             ctx: Context,
@@ -537,6 +542,7 @@ class KnowledgeBaseTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+            meta=REMOTE,
         )
         async def create_ai_knowledge_base_data_lookup(
             ctx: Context,
@@ -598,6 +604,7 @@ class KnowledgeBaseTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+            meta=REMOTE,
         )
         async def update_ai_knowledge_base_data_lookup(
             ctx: Context,
@@ -659,6 +666,7 @@ class KnowledgeBaseTools:
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+            meta=REMOTE,
         )
         async def delete_ai_knowledge_base_data_lookup(
             ctx: Context,

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -267,6 +267,21 @@ REMOTE_SEED = frozenset(
         "update_ai_agent",
         "delete_ai_agent",
         "toggle_ai_agent_status",
+        # knowledge-base writes (#481): plain-text and data-lookup CRUD plus document
+        # metadata update/delete reach the public API with the request-scoped bearer
+        # and are governed by API permissions (manage_ai_agents); no filesystem or
+        # per-user process-global settings reads, every input a per-request value.
+        # update_ai_knowledge_base_document edits metadata only (no file input).
+        # create_ai_knowledge_base_document stays withheld (local-file upload, #305).
+        # Deletes carry the two-step confirm UX guard.
+        "create_ai_knowledge_base_plain_text",
+        "update_ai_knowledge_base_plain_text",
+        "delete_ai_knowledge_base_plain_text",
+        "update_ai_knowledge_base_document",
+        "delete_ai_knowledge_base_document",
+        "create_ai_knowledge_base_data_lookup",
+        "update_ai_knowledge_base_data_lookup",
+        "delete_ai_knowledge_base_data_lookup",
     }
 )
 


### PR DESCRIPTION
## Motivation
Continues staging write categories onto the default-deny remote profile against the #442 policy. This covers knowledge-base mutations.

## Outcome
Marks 8 write tools remote-safe: `create_ai_knowledge_base_plain_text`, `update_ai_knowledge_base_plain_text`, `delete_ai_knowledge_base_plain_text`, `update_ai_knowledge_base_document`, `delete_ai_knowledge_base_document`, `create_ai_knowledge_base_data_lookup`, `update_ai_knowledge_base_data_lookup`, `delete_ai_knowledge_base_data_lookup`. Each reaches the public API with the request-scoped bearer and is governed by API permissions (`manage_ai_agents`); no filesystem or per-user process-global settings reads, every input a per-request value. `update_ai_knowledge_base_document` edits metadata only (no file input); `create_ai_knowledge_base_document` stays withheld (local-file upload, #305). Deletes keep the two-step `confirm` UX guard. No behavior change under the local profile.

## Testing
`test_remote_profile.py` drift-guard green (marker↔seed lockstep). The full write-migration stack was verified end-to-end under `--profile remote --transport http`: unauthenticated request → 401; authenticated `tools/list` (locally-minted RS256 bearer, served JWKS) equals `REMOTE_SEED`; these 8 tools present; the 6 hard-exclusions absent.

Closes #481.
