### PR TITLE
docs: canonical identifier map (which tool expects which id)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - **`docs/MIGRATION.md`** — What existing MCP users need to know about v0.1.
 - **`docs/dependencies.md`** — Rationale for runtime dependencies.
 - **`docs/architecture.md`**: Intra-package layering (domain, adapter, composition root), type ownership at boundaries, ports, and the alternative-constructor guide.
-- **`docs/mcp/tools/`** — Per-area MCP tool reference (parameters, edge cases, cross-cutting behavior).
+- **`docs/mcp/tools/`** — Per-area MCP tool reference (parameters, edge cases, cross-cutting behavior). Includes `identifiers.md`, the canonical map of which tool/argument expects slug vs `internal_id` vs uuid vs numeric id.
 - **`docs/cli/`** — CLI-specific guides (e.g. introspect-then-execute).
 - **`docs/sdk/README.md`** — Using `pipefy` as a library.
 - **`skills/AGENTS.md`** — Skill-authoring guide (frontmatter, naming, style). Start here before adding a skill.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **Docs / skills**: hosted MCP (`mcp.pipefy.com`) install snippet on the root README front door; first-time agent checklist [`pipefy-toolkit-setup`](skills/onboarding/pipefy-toolkit-setup/SKILL.md) (path choice / ask-your-agent / verify — commands stay in `README.md#installation`, per #246).
+- **Docs / skills**: canonical [Identifiers map](docs/mcp/tools/identifiers.md) — which tool/argument expects slug vs `internal_id` vs uuid vs numeric id (the five argument names for a pipe, the UUID-named-accepts-numeric exceptions, and a per-area quick reference). The per-area doc Identifiers sections and identifier-heavy skills link into its relevant section. Closes #390.
 
 ### Fixed
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -7,6 +7,7 @@ Material in this tree describes **`pipefy-mcp-server`**: the MCP process, tool b
 | Path | Description |
 |------|-------------|
 | [`tools/cross-cutting.md`](tools/cross-cutting.md) | Shared conventions: pagination, IDs, `debug`, destructive deletes, permissions, errors |
+| [`tools/identifiers.md`](tools/identifiers.md) | Canonical map: which tool/argument expects slug vs internal_id vs uuid vs numeric id |
 | [`tools/pipes-and-cards.md`](tools/pipes-and-cards.md) | Pipes, phases, fields, labels, cards, field conditions, card attachments |
 | [`tools/database-tables.md`](tools/database-tables.md) | Tables, records, table fields, table-record attachments |
 | [`tools/relations.md`](tools/relations.md) | Pipe and card relations |

--- a/docs/mcp/tools/automations-and-ai.md
+++ b/docs/mcp/tools/automations-and-ai.md
@@ -86,7 +86,7 @@ Official **event-scoped** catalog only: `get_automation_event_attributes` (MCP) 
 
 #### Slug vs `internal_id`
 
-Full cross-tool identifier map: [identifiers.md](identifiers.md).
+Full cross-tool identifier map: [identifiers.md](identifiers.md#field-references-slug-vs-internal_id).
 
 | Surface | Field identifier |
 | --- | --- |

--- a/docs/mcp/tools/automations-and-ai.md
+++ b/docs/mcp/tools/automations-and-ai.md
@@ -86,6 +86,8 @@ Official **event-scoped** catalog only: `get_automation_event_attributes` (MCP) 
 
 #### Slug vs `internal_id`
 
+Full cross-tool identifier map: [identifiers.md](identifiers.md).
+
 | Surface | Field identifier |
 | --- | --- |
 | MCP `update_card_field` (`field_id` arg) | **slug** (`id` on field rows from `get_phase_fields`) |

--- a/docs/mcp/tools/cross-cutting.md
+++ b/docs/mcp/tools/cross-cutting.md
@@ -10,7 +10,7 @@ List-style tools accept `first` and `after`. Continue with `pageInfo.endCursor` 
 
 Pipefy GraphQL uses string IDs. Pass IDs as strings (e.g. `"301234"`). Some parameters also accept JSON integers; the server normalizes to string before calling the API. Success payloads return string IDs. Empty, zero, or otherwise invalid IDs fail validation before any network call.
 
-Which **form** each tool expects (slug vs `internal_id` vs uuid vs numeric id) is the canonical [Identifiers map](identifiers.md). Type-safety and coercion detail: [Pipefy IDs and type safety](pipes-and-cards.md#pipefy-ids-type-safety).
+Which **form** each tool expects (slug vs `internal_id` vs uuid vs numeric id) is the canonical [Identifiers map](identifiers.md#the-four-forms). Type-safety and coercion detail: [Pipefy IDs and type safety](pipes-and-cards.md#pipefy-ids-type-safety).
 
 ## `debug=true`
 

--- a/docs/mcp/tools/cross-cutting.md
+++ b/docs/mcp/tools/cross-cutting.md
@@ -10,7 +10,7 @@ List-style tools accept `first` and `after`. Continue with `pageInfo.endCursor` 
 
 Pipefy GraphQL uses string IDs. Pass IDs as strings (e.g. `"301234"`). Some parameters also accept JSON integers; the server normalizes to string before calling the API. Success payloads return string IDs. Empty, zero, or otherwise invalid IDs fail validation before any network call.
 
-More detail: [Pipefy IDs and type safety](pipes-and-cards.md#pipefy-ids-type-safety).
+Which **form** each tool expects (slug vs `internal_id` vs uuid vs numeric id) is the canonical [Identifiers map](identifiers.md). Type-safety and coercion detail: [Pipefy IDs and type safety](pipes-and-cards.md#pipefy-ids-type-safety).
 
 ## `debug=true`
 

--- a/docs/mcp/tools/identifiers.md
+++ b/docs/mcp/tools/identifiers.md
@@ -1,0 +1,91 @@
+# Identifiers: which tool expects which id
+
+Pipefy exposes several identifier forms, and different tools expect different ones. This is the canonical map of which form each tool and argument wants, so you don't have to learn it by trial. Per-area guides link here rather than each keeping their own partial list.
+
+## The four forms
+
+| Form | Looks like | What it is |
+| --- | --- | --- |
+| **numeric id** | `"303088927"` | The node's numeric database id, as a string. Pipes, cards, organizations, automations. GraphQL types it as `ID` — always pass a string; a JSON integer is coerced to the same string. |
+| **uuid** | `"5f66417e-5adc-4c83-908f-0b888493c847"` | The node's UUID. Pipe UUID (`repo_uuid` / `pipe_uuid`), organization UUID, portal UUID, agent UUID, data-source id, log UUID. |
+| **slug** | `"document_upload"` | A field's human-readable id (GraphQL `id` on a field row). Used to address a **card** field for a one-off edit. |
+| **internal_id** | `"429659034"` | A field's numeric id (GraphQL `internal_id` on a field row). Used by automations, field conditions, and AI prompt/behavior field references. |
+
+Discover ids with `list_organizations` (org id + uuid, no input needed), `search_pipes` / `get_pipe` (pipe id + uuid), and `get_start_form_fields` / `get_phase_fields` (a field's `id` = slug **and** `internal_id`).
+
+## The pipe has five argument names
+
+The single biggest source of wrong-id errors: the same pipe is addressed by five different argument names across tools, in two different forms. Read the form from this table, not the name.
+
+| Argument | Form | Where |
+| --- | --- | --- |
+| `pipe_id` | numeric id | pipes/cards, automations, relations, most tools |
+| `repo_id` | numeric id (string) | observability automation-by-repo logs (`get_automation_logs_by_repo`) |
+| `source_repo_id` | numeric id | knowledge-base data lookups (a UUID is accepted on create but breaks at index time — use the numeric id) |
+| `repo_uuid` | **uuid** | AI agents (`get_ai_agents`, `create_ai_agent`, …), AI agent logs |
+| `pipe_uuid` | **uuid** | knowledge-base tools |
+
+## UUID-named arguments that also accept a numeric id
+
+A few arguments are named `*_uuid` but the API resolves a numeric id too. Prefer the UUID; a numeric id is a documented fallback:
+
+- `get_ai_credit_usage(organization_uuid)`
+- `list_portals(organization_uuid)`, `create_portal(organization_uuid)`
+
+Everywhere else, an argument named `*_uuid` wants a UUID and an argument named `*_id` wants a numeric id.
+
+## Field references: slug vs internal_id
+
+A field is addressed by **slug** for one-off card edits, and by **internal_id** everywhere a rule or prompt references it.
+
+| Surface | Field identifier |
+| --- | --- |
+| `update_card_field` / `update_card` field keys | **slug** |
+| `create_card` / `fill_card_phase_fields` field keys | **slug** |
+| `upload_attachment_to_card` (`field_id`) | **slug** (a UUID returns `RESOURCE_NOT_FOUND`) |
+| `set_table_record_field_value` / `upload_attachment_to_table_record` (`field_id`) | **slug** |
+| Traditional automation `action_params.field_map[].fieldId` | **internal_id** (a slug typically yields `INTERNAL_SERVER_ERROR`) |
+| Automation / AI-automation `condition.expressions[].field_address` | **internal_id** (the last dotted segment for a connected-card field) |
+| Field condition `condition.expressions[].field_address` and `actions[].phaseFieldId` | **internal_id** |
+| AI automation prompt / AI agent behavior `%{…}` references | **internal_id** |
+| Data-lookup `output_fields` / `conditions[].field` | **slug** (plus statics like `id`, `title`, `current_phase`) |
+
+`get_phase_fields` / `get_start_form_fields` return both the `id` (slug) and the `internal_id` for each field, so you can pick the form the target surface needs.
+
+### Phase fields (create vs update)
+
+`create_phase_field` returns both the `id` (slug) and the `internal_id`. To update or delete a phase field, pass its **slug** as `field_id` together with `phase_id` (or `pipe_id`), and the SDK resolves it to the internal id; a numeric `internal_id` is also accepted, and a `uuid` disambiguates when a slug is ambiguous.
+
+## Per-area quick reference
+
+### Pipes & cards
+- `get_pipe` / `get_card` / `create_card` / `move_card_to_phase`: numeric ids (`pipe_id`, `card_id`, `destination_phase_id`).
+- Field references: see [Field references](#field-references-slug-vs-internal_id) above.
+
+### AI agents & knowledge bases
+- AI agent tools scope by `repo_uuid` (pipe **UUID**); the agent itself is addressed by its own `uuid`.
+- Knowledge-base tools scope by `pipe_uuid` (pipe **UUID**); items (plain text, document, data source) by their data-source **UUID**; data lookups read `source_repo_id` (numeric pipe id).
+- `dataSourceIds` / `data_source_ids`: knowledge-base item **UUIDs**.
+
+### Automations
+- `create_automation` / `create_ai_automation`: `pipe_id` numeric; `automation_id` (get/update/delete) is the automation's own id, not the pipe's.
+- Field references inside `field_map` and `condition`: **internal_id** (see above).
+
+### Tables & records
+- `table_id` and record ids are strings — numeric or an opaque token (e.g. `"fIVcd19N"`). Record field references use the field **slug**.
+
+### LLM providers
+- List / dependencies / create / update / delete: `organization_uuid` (**UUID**).
+- Default get / set / reset: numeric `organization_id` / `owner_id`.
+- `get_available_ai_models(provider_name)`: the vendor's snake_case name (e.g. `amazon_bedrock`), not the hyphenated `configuration.provider`.
+
+### Observability
+- `get_ai_agent_logs(repo_uuid)` (pipe UUID); `get_ai_agent_log_details(log_uuid)`.
+- `get_automation_logs_by_repo(repo_id)` (numeric pipe id, string); `get_automation_logs(automation_id)`.
+- Usage tools take `organization_uuid` (UUID); metrics/export take numeric `organization_id`; `get_ai_credit_usage(organization_uuid)` accepts UUID or numeric.
+
+### Organization, portal, relations, reports
+- `list_organizations`: no id. `get_organization(organization_id)`: numeric id.
+- Portal: `organization_uuid` (UUID or numeric); `portal_uuid` (interface UUID).
+- Relations: `get_pipe_relations(pipe_id)` (numeric pipe id); `get_table_relations(relation_ids)` (table-**relation** ids, not table ids); `create_card_relation(source_id)` = a pipe-relation id from `get_pipe_relations`.
+- Reports: filter `field` values come from `get_pipe_report_filterable_fields`.

--- a/docs/mcp/tools/identifiers.md
+++ b/docs/mcp/tools/identifiers.md
@@ -58,11 +58,11 @@ A field is addressed by **slug** for one-off card edits, and by **internal_id** 
 
 ## Per-area quick reference
 
-### Pipes & cards
+### Pipes and cards
 - `get_pipe` / `get_card` / `create_card` / `move_card_to_phase`: numeric ids (`pipe_id`, `card_id`, `destination_phase_id`).
 - Field references: see [Field references](#field-references-slug-vs-internal_id) above.
 
-### AI agents & knowledge bases
+### AI agents and knowledge bases
 - AI agent tools scope by `repo_uuid` (pipe **UUID**); the agent itself is addressed by its own `uuid`.
 - Knowledge-base tools scope by `pipe_uuid` (pipe **UUID**); items (plain text, document, data source) by their data-source **UUID**; data lookups read `source_repo_id` (numeric pipe id).
 - `dataSourceIds` / `data_source_ids`: knowledge-base item **UUIDs**.
@@ -71,7 +71,7 @@ A field is addressed by **slug** for one-off card edits, and by **internal_id** 
 - `create_automation` / `create_ai_automation`: `pipe_id` numeric; `automation_id` (get/update/delete) is the automation's own id, not the pipe's.
 - Field references inside `field_map` and `condition`: **internal_id** (see above).
 
-### Tables & records
+### Tables and records
 - `table_id` and record ids are strings — numeric or an opaque token (e.g. `"fIVcd19N"`). Record field references use the field **slug**.
 
 ### LLM providers

--- a/docs/mcp/tools/identifiers.md
+++ b/docs/mcp/tools/identifiers.md
@@ -23,16 +23,16 @@ The single biggest source of wrong-id errors: the same pipe is addressed by five
 | `repo_id` | numeric id (string) | observability automation-by-repo logs (`get_automation_logs_by_repo`) |
 | `source_repo_id` | numeric id | knowledge-base data lookups (a UUID is accepted on create but breaks at index time — use the numeric id) |
 | `repo_uuid` | **uuid** | AI agents (`get_ai_agents`, `create_ai_agent`, …), AI agent logs |
-| `pipe_uuid` | **uuid** | knowledge-base tools |
+| `pipe_uuid` | **uuid** | knowledge-base tools; pipe report **reads** (`get_pipe_report*`) — report create/update use numeric `pipe_id` |
 
 ## UUID-named arguments that also accept a numeric id
 
-A few arguments are named `*_uuid` but the API resolves a numeric id too. Prefer the UUID; a numeric id is a documented fallback:
+A few arguments are named `*_uuid` but a numeric id is resolved automatically too. Prefer the UUID; a numeric id is a documented fallback:
 
-- `get_ai_credit_usage(organization_uuid)`
+- The three observability usage tools: `get_agents_usage(organization_uuid)`, `get_automations_usage(organization_uuid)`, `get_ai_credit_usage(organization_uuid)`
 - `list_portals(organization_uuid)`, `create_portal(organization_uuid)`
 
-Everywhere else, an argument named `*_uuid` wants a UUID and an argument named `*_id` wants a numeric id.
+Elsewhere, an argument named `*_uuid` wants a UUID and an argument named `*_id` wants a numeric id.
 
 ## Field references: slug vs internal_id
 
@@ -82,7 +82,7 @@ A field is addressed by **slug** for one-off card edits, and by **internal_id** 
 ### Observability
 - `get_ai_agent_logs(repo_uuid)` (pipe UUID); `get_ai_agent_log_details(log_uuid)`.
 - `get_automation_logs_by_repo(repo_id)` (numeric pipe id, string); `get_automation_logs(automation_id)`.
-- Usage tools take `organization_uuid` (UUID); metrics/export take numeric `organization_id`; `get_ai_credit_usage(organization_uuid)` accepts UUID or numeric.
+- Usage tools (`get_agents_usage`, `get_automations_usage`, `get_ai_credit_usage`) take `organization_uuid` — UUID **or** numeric org id (resolved server-side). Metrics (`get_automation_execution_metrics`) and export (`export_automation_jobs`) take numeric `organization_id` only.
 
 ### Organization, portal, relations, reports
 - `list_organizations`: no id. `get_organization(organization_id)`: numeric id.

--- a/docs/mcp/tools/knowledge-bases.md
+++ b/docs/mcp/tools/knowledge-bases.md
@@ -25,7 +25,7 @@ Knowledge bases are the data sources an AI agent draws on. Each item's `id` is w
 
 ## Identifiers: pipe UUID, not numeric ID
 
-> Full cross-tool map: [identifiers.md](identifiers.md).
+> Full cross-tool map: [identifiers.md](identifiers.md#ai-agents-and-knowledge-bases).
 
 Every knowledge base operation is scoped by the pipe **UUID** (`pipe_uuid`), not the numeric pipe ID — this follows the Pipefy GraphQL API. `get_pipe` returns the `uuid` field; `get_ai_knowledge_bases` returns each item's `id` (a data-source UUID) for the by-id operations and for `dataSourceIds`. The one deliberate exception is a data lookup's `source_repo_id`, which is the **numeric** ID of the source pipe (see below).
 

--- a/docs/mcp/tools/knowledge-bases.md
+++ b/docs/mcp/tools/knowledge-bases.md
@@ -25,6 +25,8 @@ Knowledge bases are the data sources an AI agent draws on. Each item's `id` is w
 
 ## Identifiers: pipe UUID, not numeric ID
 
+> Full cross-tool map: [identifiers.md](identifiers.md).
+
 Every knowledge base operation is scoped by the pipe **UUID** (`pipe_uuid`), not the numeric pipe ID — this follows the Pipefy GraphQL API. `get_pipe` returns the `uuid` field; `get_ai_knowledge_bases` returns each item's `id` (a data-source UUID) for the by-id operations and for `dataSourceIds`. The one deliberate exception is a data lookup's `source_repo_id`, which is the **numeric** ID of the source pipe (see below).
 
 ## Plain-text limits (enforced client-side)

--- a/docs/mcp/tools/llm-providers.md
+++ b/docs/mcp/tools/llm-providers.md
@@ -31,6 +31,8 @@ These are the counterpart to the `providerId` / `systemProviderId` fields on AI 
 
 ## Identifiers: UUID vs numeric ID
 
+> Full cross-tool map: [identifiers.md](identifiers.md).
+
 The organization identifier is **not uniform** across these tools — this follows the Pipefy GraphQL API, not a toolkit choice:
 
 - `get_llm_providers`, `get_llm_provider_dependencies`, `create_llm_provider`, `update_llm_provider`, and `delete_llm_provider` take the organization **UUID** (`organization_uuid`).

--- a/docs/mcp/tools/llm-providers.md
+++ b/docs/mcp/tools/llm-providers.md
@@ -31,7 +31,7 @@ These are the counterpart to the `providerId` / `systemProviderId` fields on AI 
 
 ## Identifiers: UUID vs numeric ID
 
-> Full cross-tool map: [identifiers.md](identifiers.md).
+> Full cross-tool map: [identifiers.md](identifiers.md#llm-providers).
 
 The organization identifier is **not uniform** across these tools — this follows the Pipefy GraphQL API, not a toolkit choice:
 

--- a/docs/mcp/tools/observability.md
+++ b/docs/mcp/tools/observability.md
@@ -8,6 +8,8 @@ Read-only observability tools use `readOnlyHint=True`. The async export mutation
 
 ## Identifiers (avoid mixing pipe vs automation vs org)
 
+> Full cross-tool map: [identifiers.md](identifiers.md).
+
 | Concept | What observability tools expect | How to obtain it |
 |--------|--------------------------------|------------------|
 | **Pipe for AI agent logs** | `repo_uuid` — the pipe **UUID** | `get_pipe` with numeric `pipe_id`; use `pipe.uuid` as `repo_uuid`. |

--- a/docs/mcp/tools/observability.md
+++ b/docs/mcp/tools/observability.md
@@ -15,7 +15,7 @@ Read-only observability tools use `readOnlyHint=True`. The async export mutation
 | **Pipe for AI agent logs** | `repo_uuid` — the pipe **UUID** | `get_pipe` with numeric `pipe_id`; use `pipe.uuid` as `repo_uuid`. |
 | **Pipe for automation logs (all rules)** | `repo_id` — pipe id as **string** (numeric id is fine) | Same id you see in the Pipefy URL / `get_pipe` → `pipe.id`. |
 | **Single automation logs** | `automation_id` — **not** the pipe id | `get_automations` with `pipe_id` lists rules and their `id` values. |
-| **Organization for usage queries** | `organization_uuid` — org **UUID** | `get_organization(organization_id)` returns the `uuid` directly. Alternatively: `execute_graphql` with `pipe(id: $id) { organization { uuid } }`. |
+| **Organization for usage queries** | `organization_uuid` — **UUID or numeric org id** | `get_organization(organization_id)` returns the `uuid`; a numeric org id also works (resolved server-side). |
 | **Organization for credit dashboard** | `organization_uuid` in the tool | **UUID** or **numeric org id** (string); numeric ids are resolved server-side before calling the API. |
 | **Organization for execution metrics** | `organization_id` on `get_automation_execution_metrics` | Numeric org id (same as URLs / exports); optional `automation_ids` from `get_automations`. |
 | **Organization for export** | `organization_id` on `export_automation_jobs` | Numeric org id (as used in URLs / exports); differs from the usage tools’ UUID parameter name. |
@@ -38,8 +38,8 @@ Empty lists (`totalCount: 0`) are valid: the pipe or automation may have no rece
 `get_automation_logs` **cannot** be called with a pipe id alone. If you guess an `automation_id` from `get_automations`, that rule may have **zero** log rows while another rule on the same pipe has rows — use `get_automation_logs_by_repo` first when exploring.
 
 **Org usage and credits**  
-1. `get_agents_usage` and `get_automations_usage` need the org **UUID** and ISO8601 `filter_date_from` / `filter_date_to` values.  
-2. `get_ai_credit_usage` accepts org UUID **or** numeric org id; `period` is `current_month`, `last_month`, or `last_3_months`.  
+1. `get_agents_usage` and `get_automations_usage` take the org **UUID or numeric org id** and ISO8601 `filter_date_from` / `filter_date_to` values.  
+2. `get_ai_credit_usage` also accepts org UUID **or** numeric org id; `period` is `current_month`, `last_month`, or `last_3_months`.  
 3. **`get_automations_usage` `usage`** is an **execution count** (runs), not AI credits. **`get_agents_usage` `usage`** aligns with AI credit consumption for agents — compare with `get_ai_credit_usage` for the dashboard view, not with automation run totals.
 
 **Per-automation execution metrics (rolling window)**  
@@ -74,8 +74,8 @@ Empty lists (`totalCount: 0`) are valid: the pipe or automation may have no rece
 
 | Tool | Read-only | Role |
 |------|-----------|------|
-| `get_agents_usage` | Yes | AI agent usage stats for an org within a date range. `filter_date_from` / `filter_date_to` (ISO8601). Optional `filters`, `search`, `sort`. Returns total **AI credits** consumed and per-agent breakdown. Requires org **UUID** (see Identifiers). |
-| `get_automations_usage` | Yes | Automation usage stats for an org. Same date-range and filter inputs as `get_agents_usage`. Returns total **execution count** and per-automation breakdown (not the same unit as AI credits). Requires org **UUID**. |
+| `get_agents_usage` | Yes | AI agent usage stats for an org within a date range. `filter_date_from` / `filter_date_to` (ISO8601). Optional `filters`, `search`, `sort`. Returns total **AI credits** consumed and per-agent breakdown. Takes org **UUID or numeric** (see Identifiers). |
+| `get_automations_usage` | Yes | Automation usage stats for an org. Same date-range and filter inputs as `get_agents_usage`. Returns total **execution count** and per-automation breakdown (not the same unit as AI credits). Takes org **UUID or numeric**. |
 | `get_ai_credit_usage` | Yes | AI credit dashboard for an org: credit limit, total consumption, per-resource breakdown (AI Agents vs Assistants), addon status. `organization_uuid` may be the org UUID or the **numeric organization id** (string). `period`: `current_month`, `last_month`, or `last_3_months`. |
 | `get_automation_execution_metrics` | Yes | Per-automation rolling-window metrics (`totalRuns`, `successRate`, `failureRate`, `averageDuration`, `lastRun`). Uses numeric `organization_id`; optional `automation_ids` / filters / sort; paginated (`first` ≤ 50, `after`). Partial success returns `partial_errors` for denied ids. |
 

--- a/docs/mcp/tools/observability.md
+++ b/docs/mcp/tools/observability.md
@@ -8,7 +8,7 @@ Read-only observability tools use `readOnlyHint=True`. The async export mutation
 
 ## Identifiers (avoid mixing pipe vs automation vs org)
 
-> Full cross-tool map: [identifiers.md](identifiers.md).
+> Full cross-tool map: [identifiers.md](identifiers.md#observability).
 
 | Concept | What observability tools expect | How to obtain it |
 |--------|--------------------------------|------------------|

--- a/docs/mcp/tools/pipes-and-cards.md
+++ b/docs/mcp/tools/pipes-and-cards.md
@@ -12,6 +12,8 @@ Read, create, update, and delete pipes, phases, phase fields, labels, cards, and
 
 ### Pipefy IDs (type safety)
 
+Which **form** each tool wants (slug vs `internal_id` vs uuid vs numeric id) is the canonical [Identifiers map](identifiers.md); this section covers string-vs-int type safety and coercion.
+
 Pipefy’s GraphQL API uses **string** IDs for pipes, phases, cards, and most other nodes.
 
 - **Prefer string arguments** when calling tools (e.g. `card_id: "1332881010"`, `pipe_id: "306996634"`). This matches API responses (`get_pipe`, `get_card`, `create_card`, etc.).

--- a/docs/mcp/tools/pipes-and-cards.md
+++ b/docs/mcp/tools/pipes-and-cards.md
@@ -12,7 +12,7 @@ Read, create, update, and delete pipes, phases, phase fields, labels, cards, and
 
 ### Pipefy IDs (type safety)
 
-Which **form** each tool wants (slug vs `internal_id` vs uuid vs numeric id) is the canonical [Identifiers map](identifiers.md); this section covers string-vs-int type safety and coercion.
+Which **form** each tool wants (slug vs `internal_id` vs uuid vs numeric id) is the canonical [Identifiers map](identifiers.md#field-references-slug-vs-internal_id); this section covers string-vs-int type safety and coercion.
 
 Pipefy’s GraphQL API uses **string** IDs for pipes, phases, cards, and most other nodes.
 

--- a/docs/mcp/tools/portal.md
+++ b/docs/mcp/tools/portal.md
@@ -35,7 +35,7 @@ Integration tests (`pytest -m integration -k portal`) need **`PIPEFY_PORTAL_ORG_
 
 ## Identifiers
 
-> Full cross-tool map: [identifiers.md](identifiers.md).
+> Full cross-tool map: [identifiers.md](identifiers.md#organization-portal-relations-reports).
 
 | Concept | Tool parameter | Notes |
 |--------|----------------|-------|

--- a/docs/mcp/tools/portal.md
+++ b/docs/mcp/tools/portal.md
@@ -35,6 +35,8 @@ Integration tests (`pytest -m integration -k portal`) need **`PIPEFY_PORTAL_ORG_
 
 ## Identifiers
 
+> Full cross-tool map: [identifiers.md](identifiers.md).
+
 | Concept | Tool parameter | Notes |
 |--------|----------------|-------|
 | **Organization for list/create** | `organization_uuid` on `list_portals`, `create_portal` | Organization **UUID** or **numeric org id** (string or unquoted integer via MCP). Numeric ids resolve to UUID via public GraphQL before the Interfaces call. |

--- a/skills/ai-agents/pipefy-ai-agents/SKILL.md
+++ b/skills/ai-agents/pipefy-ai-agents/SKILL.md
@@ -322,3 +322,4 @@ Per behavior you can pass `template_params` (or `placeholders`) with `str → st
 - [skills/automations/pipefy-automations/SKILL.md](../../automations/pipefy-automations/SKILL.md) — traditional automations and AI automations (different from AI agents).
 - [skills/observability/pipefy-observability/SKILL.md](../../observability/pipefy-observability/SKILL.md) — agent execution logs and credit usage.
 - [skills/introspection/pipefy-introspection/SKILL.md](../../introspection/pipefy-introspection/SKILL.md) — Recipe 2 inspects full behavior config via `execute_graphql`.
+- `docs/mcp/tools/identifiers.md` — canonical map of which tool/argument expects slug vs `internal_id` vs uuid vs numeric id (AI agents scope by `repo_uuid` = pipe UUID).

--- a/skills/ai-agents/pipefy-ai-agents/SKILL.md
+++ b/skills/ai-agents/pipefy-ai-agents/SKILL.md
@@ -322,4 +322,4 @@ Per behavior you can pass `template_params` (or `placeholders`) with `str → st
 - [skills/automations/pipefy-automations/SKILL.md](../../automations/pipefy-automations/SKILL.md) — traditional automations and AI automations (different from AI agents).
 - [skills/observability/pipefy-observability/SKILL.md](../../observability/pipefy-observability/SKILL.md) — agent execution logs and credit usage.
 - [skills/introspection/pipefy-introspection/SKILL.md](../../introspection/pipefy-introspection/SKILL.md) — Recipe 2 inspects full behavior config via `execute_graphql`.
-- `docs/mcp/tools/identifiers.md` — canonical map of which tool/argument expects slug vs `internal_id` vs uuid vs numeric id (AI agents scope by `repo_uuid` = pipe UUID).
+- `docs/mcp/tools/identifiers.md#ai-agents-and-knowledge-bases` — canonical map of which tool/argument expects slug vs `internal_id` vs uuid vs numeric id (AI agents scope by `repo_uuid` = pipe UUID).

--- a/skills/automations/pipefy-automations/SKILL.md
+++ b/skills/automations/pipefy-automations/SKILL.md
@@ -222,4 +222,4 @@ Use this pattern for approvals, financial decisions, content publication, and an
 - [skills/observability/pipefy-observability/SKILL.md](../../observability/pipefy-observability/SKILL.md) — execution logs and usage stats.
 - [skills/introspection/pipefy-introspection/SKILL.md](../../introspection/pipefy-introspection/SKILL.md) — discover trigger and action types via raw schema.
 - [skills/process-design/pipefy-process-design/SKILL.md](../../process-design/pipefy-process-design/SKILL.md) — Orchestration patterns (agentic + human validation).
-- `docs/mcp/tools/identifiers.md` — canonical map of which tool/argument expects slug vs `internal_id` vs uuid vs numeric id (`field_address` and `field_map[].fieldId` want internal_id).
+- `docs/mcp/tools/identifiers.md#field-references-slug-vs-internal_id` — canonical map of which tool/argument expects slug vs `internal_id` vs uuid vs numeric id (`field_address` and `field_map[].fieldId` want internal_id).

--- a/skills/automations/pipefy-automations/SKILL.md
+++ b/skills/automations/pipefy-automations/SKILL.md
@@ -222,3 +222,4 @@ Use this pattern for approvals, financial decisions, content publication, and an
 - [skills/observability/pipefy-observability/SKILL.md](../../observability/pipefy-observability/SKILL.md) — execution logs and usage stats.
 - [skills/introspection/pipefy-introspection/SKILL.md](../../introspection/pipefy-introspection/SKILL.md) — discover trigger and action types via raw schema.
 - [skills/process-design/pipefy-process-design/SKILL.md](../../process-design/pipefy-process-design/SKILL.md) — Orchestration patterns (agentic + human validation).
+- `docs/mcp/tools/identifiers.md` — canonical map of which tool/argument expects slug vs `internal_id` vs uuid vs numeric id (`field_address` and `field_map[].fieldId` want internal_id).

--- a/skills/observability/pipefy-observability/SKILL.md
+++ b/skills/observability/pipefy-observability/SKILL.md
@@ -15,6 +15,8 @@ Monitor AI agent and automation execution, usage stats, credit consumption, and 
 
 ## Identifiers reference
 
+Full cross-tool map: `docs/mcp/tools/identifiers.md`.
+
 | Concept | What tools expect | How to obtain |
 |---------|-------------------|---------------|
 | **Pipe for AI agent logs** | `repo_uuid` — the pipe **UUID** | `get_pipe` with numeric `pipe_id`; use `pipe.uuid`. |

--- a/skills/observability/pipefy-observability/SKILL.md
+++ b/skills/observability/pipefy-observability/SKILL.md
@@ -15,7 +15,7 @@ Monitor AI agent and automation execution, usage stats, credit consumption, and 
 
 ## Identifiers reference
 
-Full cross-tool map: `docs/mcp/tools/identifiers.md`.
+Full cross-tool map: `docs/mcp/tools/identifiers.md#observability`.
 
 | Concept | What tools expect | How to obtain |
 |---------|-------------------|---------------|

--- a/skills/observability/pipefy-observability/SKILL.md
+++ b/skills/observability/pipefy-observability/SKILL.md
@@ -21,7 +21,7 @@ Full cross-tool map: `docs/mcp/tools/identifiers.md#observability`.
 |---------|-------------------|---------------|
 | **Pipe for AI agent logs** | `repo_uuid` — the pipe **UUID** | `get_pipe` with numeric `pipe_id`; use `pipe.uuid`. |
 | **Automation for logs** | `automation_id` — numeric | `get_automations pipe_id=...` |
-| **Org for usage stats** | `organization_id` — numeric | Known from account setup or `get_organization`. |
+| **Org for usage stats** | `organization_uuid` — UUID **or** numeric org id | `get_organization` returns the `uuid`; a numeric id also works (resolved server-side). Execution-metrics / export take numeric `organization_id`. |
 
 ---
 

--- a/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
+++ b/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
@@ -233,3 +233,4 @@ Read `pageInfo.hasNextPage` and `pageInfo.endCursor` from the response; pass `af
 - `skills/relations/` — link pipes and cards across workflows.
 - `skills/automations/` — add automation rules to a pipe.
 - `skills/introspection/` — discover field types and mutation signatures.
+- `docs/mcp/tools/identifiers.md` — canonical map of which tool/argument expects slug vs `internal_id` vs uuid vs numeric id (e.g. `update_card_field` uses a field slug).

--- a/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
+++ b/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
@@ -233,4 +233,4 @@ Read `pageInfo.hasNextPage` and `pageInfo.endCursor` from the response; pass `af
 - `skills/relations/` — link pipes and cards across workflows.
 - `skills/automations/` — add automation rules to a pipe.
 - `skills/introspection/` — discover field types and mutation signatures.
-- `docs/mcp/tools/identifiers.md` — canonical map of which tool/argument expects slug vs `internal_id` vs uuid vs numeric id (e.g. `update_card_field` uses a field slug).
+- `docs/mcp/tools/identifiers.md#field-references-slug-vs-internal_id` — canonical map of which tool/argument expects slug vs `internal_id` vs uuid vs numeric id (e.g. `update_card_field` uses a field slug).


### PR DESCRIPTION
## Motivation
Closes #390.

Pipefy exposes several identifier forms — slug, `internal_id`, uuid, numeric id — and different tools expect different ones. The guidance was scattered across per-area docs and skills with no single source of truth, so agents learned which id each tool wants by trial and error (wrong-id errors, extra round-trips). The sharpest traps: the same pipe is addressed by five different argument names (`pipe_id`, `repo_id`, `source_repo_id`, `repo_uuid`, `pipe_uuid`) in two different forms, and a handful of `*_uuid` arguments also accept a numeric id.

## Outcome
Adds `docs/mcp/tools/identifiers.md`: a canonical map keyed on tool/argument, covering the four forms, the five names for a pipe side by side, the UUID-named-accepts-numeric exceptions, the field-reference slug-vs-`internal_id` rule, and a per-area quick reference.

The map is wired in as the single source of truth: the docs index and the cross-cutting IDs section now point at it, AGENTS.md lists it, and the per-area Identifiers subsections (observability, knowledge-bases, llm-providers, portal), the pipes-and-cards and automations discussions, and the identifier-heavy skills link to it rather than each keeping a partial list.

Documentation only — no tool or CLI behavior changes.
