### PR TITLE
feat: add list_organizations tool and `pipefy org list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **MCP / CLI**: `list_organizations` (`pipefy org list`) — list the organizations the caller can access with no id required, the zero-knowledge entry point for discovery. Returns `id`, `uuid`, `name`, `planName`, `role`, `membersCount`, `pipesCount`, `createdAt` per org; an empty result is valid (not an error). Read-only and remote-safe. Closes #383.
 - **Docs / skills**: hosted MCP (`mcp.pipefy.com`) install snippet on the root README front door; first-time agent checklist [`pipefy-toolkit-setup`](skills/onboarding/pipefy-toolkit-setup/SKILL.md) (path choice / ask-your-agent / verify — commands stay in `README.md#installation`, per #246).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Open-source toolkit for **Pipefy** developers: a Model Context Protocol (MCP) se
 
 | Component | Package / path | Purpose |
 |-----------|----------------|---------|
-| **MCP server** | `pipefy-mcp-server` | Exposes **185** tools to MCP clients (Cursor, Claude Desktop, Claude Code, and others). |
+| **MCP server** | `pipefy-mcp-server` | Exposes **186** tools to MCP clients (Cursor, Claude Desktop, Claude Code, and others). |
 | **CLI** | `pipefy-cli` | Terminal commands aligned with MCP capabilities; see [`docs/parity.md`](docs/parity.md). |
 | **SDK** | `pipefy` | Vendor GraphQL client, services, and models shared by MCP and CLI. |
 | **Skills** | [`skills/`](skills/) | Markdown playbooks (Anthropic Skills format) for common Pipefy workflows. |
@@ -157,7 +157,7 @@ Deprecation and semver (post-1.0): [`docs/DEPRECATION.md`](docs/DEPRECATION.md).
 
 ## MCP server
 
-The server registers **185 tools** across fourteen domains. Canonical names: `PIPEFY_TOOL_NAMES` in [`packages/mcp/src/pipefy_mcp/tools/registry.py`](packages/mcp/src/pipefy_mcp/tools/registry.py).
+The server registers **186 tools** across fourteen domains. Canonical names: `PIPEFY_TOOL_NAMES` in [`packages/mcp/src/pipefy_mcp/tools/registry.py`](packages/mcp/src/pipefy_mcp/tools/registry.py).
 
 Tool descriptions and `Args:` blocks come from Python docstrings (what MCP clients show to models). Per-area reference docs cover parameters, edge cases, and cross-cutting behavior.
 
@@ -176,7 +176,7 @@ Tool descriptions and `Args:` blocks come from Python docstrings (what MCP clien
 | **Observability** | 11 | Logs, usage, credits, execution metrics, job exports. | [docs](docs/mcp/tools/observability.md) |
 | **Members, email & webhooks** | 12 | Membership, inbox email, webhooks. | [docs](docs/mcp/tools/members-email-webhooks.md) |
 | **Service accounts** | 2 | Create and delete organization service accounts (OAuth2 machine identities); attach them to pipes with `add_service_account_to_pipe`. | [docs](docs/mcp/tools/service-accounts.md) |
-| **Organization** | 1 | Organization metadata. | [docs](docs/mcp/tools/organization.md) |
+| **Organization** | 2 | Organization metadata and discovery. | [docs](docs/mcp/tools/organization.md) |
 | **Portals** | 20 | Portal read/CRUD, pages, elements, sub-portals (publish/unpublish). | [docs](docs/mcp/tools/portal.md) |
 | **Introspection** | 5 | Schema discovery and raw GraphQL. | [docs](docs/mcp/tools/introspection.md) |
 

--- a/docs/mcp/tools/organization.md
+++ b/docs/mcp/tools/organization.md
@@ -1,26 +1,21 @@
 # Organization
 
-Fetch organization details directly by ID. **1 tool.**
+Discover the organizations you can access, or fetch one by ID. **2 tools.**
 
 ---
 
 | Tool | Read-only | Role |
 |------|-----------|------|
-| `get_organization` | Yes | Fetches org details: `id`, `uuid`, `name`, `planName`, `role`, `membersCount`, `pipesCount`, `createdAt`. |
+| `list_organizations` | Yes | Lists organizations the caller can access — no id required. Each entry has `id`, `uuid`, `name`, `planName`, `role`, `membersCount`, `pipesCount`, `createdAt`. |
+| `get_organization` | Yes | Fetches one org's details by ID: `id`, `uuid`, `name`, `planName`, `role`, `membersCount`, `pipesCount`, `createdAt`. |
 
-**`organization_id`** matches GraphQL: use a **string** (e.g. `"123456789"` — numeric segment from `https://app.pipefy.com/organizations/<org_id>/...` or from `search_pipes`). Unquoted JSON integers are coerced to the same string form. See [Pipefy IDs in pipes & cards](pipes-and-cards.md#pipefy-ids-type-safety).
+**`organization_id`** (for `get_organization`) matches GraphQL: use a **string** (e.g. `"123456789"` — numeric segment from `https://app.pipefy.com/organizations/<org_id>/...` or from `list_organizations` / `search_pipes`). Unquoted JSON integers are coerced to the same string form. See [Pipefy IDs in pipes & cards](pipes-and-cards.md#pipefy-ids-type-safety).
 
-## Why a dedicated tool?
+## Discovering organizations
 
-The organization ID is required by many tools (reports, automations, observability) but previously had no direct fetch path. Agents had to derive it through multi-step workarounds:
+`list_organizations` is the zero-knowledge entry point: it answers "which organizations do I have access to?" with no id required, so it is the natural first call when onboarding to a session. The API scopes the result to the caller's own access, and an empty list means the caller belongs to no organization. Use the returned `id` / `uuid` for the tools that require one (reports, automations, observability, portals).
 
-1. `search_pipes` or `get_pipe` to find a pipe in the org
-2. Extract the org ID from the pipe response
-3. Use the org ID in the actual tool call
-
-`get_organization` eliminates this pattern. If you already know the org ID (from a prior `search_pipes` call or the Pipefy URL), use it directly.
-
-## Discovering the org ID
+Other paths to an org id, when you already have context:
 
 - From `search_pipes`: the response groups pipes by organization; each org includes `id` and `name`.
 - From the Pipefy URL: the org ID is the numeric segment in `https://app.pipefy.com/organizations/<org_id>/...`.

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -2,7 +2,7 @@
 
 This matrix is the source of truth for **MCP tool ↔ `pipefy` CLI** coverage. Update it whenever MCP tools or CLI commands are added, renamed, or removed.
 
-**Registry source:** `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` (must stay in sync with this table: **185** tools).
+**Registry source:** `PIPEFY_TOOL_NAMES` in `packages/mcp/src/pipefy_mcp/tools/registry.py` (must stay in sync with this table: **186** tools).
 
 **Later CLI coverage:** areas such as attachments, field conditions, email, audit export, traditional automations, exports/usage, introspection, and raw GraphQL appear as **shipped** below when the matching Typer commands exist in `packages/cli`.
 
@@ -159,6 +159,7 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | `introspect_query` | `pipefy introspect query` | shipped | — |
 | `introspect_type` | `pipefy introspect type` | shipped | — |
 | `invite_members` | `pipefy member invite` | shipped | — |
+| `list_organizations` | `pipefy org list` | shipped | Lists organizations the caller can access; no id required. |
 | `list_portals` | `pipefy portal list` | shipped | `--organization-uuid`; at most one main portal per org. |
 | `move_card_to_phase` | `pipefy card move` | shipped | (`--phase`). |
 | `publish_sub_portal` | `pipefy portal sub-portal publish` | shipped | internal_api `updateSubPortalElement` on a templated `forms` element; check `subPortals[].published` via `get_portal`. |
@@ -222,6 +223,6 @@ for n in m.body:
             print(len(v.args[0].elts))"
 ```
 
-Expect **185** tool names in `PIPEFY_TOOL_NAMES` and **185** data rows in the parity table (excluding the header rows).
+Expect **186** tool names in `PIPEFY_TOOL_NAMES` and **186** data rows in the parity table (excluding the header rows).
 
 When adding or removing an MCP tool, update **this file** and `PIPEFY_TOOL_NAMES` in the same change set.

--- a/packages/cli/src/pipefy_cli/commands/org.py
+++ b/packages/cli/src/pipefy_cli/commands/org.py
@@ -27,6 +27,19 @@ def _optional_org_id(value: str | None) -> str | None:
     return validate_positional_id(value)
 
 
+@org_app.command("list")
+def org_list(
+    ctx: typer.Context,
+    json_out: bool = typer.Option(False, "--json", "-j"),
+) -> None:
+    """List the organizations you can access (``list_organizations``)."""
+
+    async def factory(client: PipefyClient):
+        return await client.list_organizations()
+
+    run_cli_command(ctx, json_out, factory)
+
+
 @org_app.command("get", context_settings=ID_POSITIONAL_CONTEXT_SETTINGS)
 def org_get(
     ctx: typer.Context,

--- a/packages/cli/src/pipefy_cli/commands/org.py
+++ b/packages/cli/src/pipefy_cli/commands/org.py
@@ -16,8 +16,8 @@ org_app = typer.Typer(help="Organization operations.", no_args_is_help=True)
 
 _MISSING_ORG_ID = (
     "Missing organization id. Pass ORGANIZATION_ID as the first argument, set "
-    "PIPEFY_ORG_ID in the environment, or obtain an id from "
-    "`pipefy pipe list --json` (organizations[].id)."
+    "PIPEFY_ORG_ID in the environment, or list the organizations you can "
+    "access with `pipefy org list --json` and copy an `id`."
 )
 
 

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -2366,7 +2366,8 @@ Usage: pipefy org [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ get   Fetch organization details (``get_organization``).                     │
+│ list   List the organizations you can access (``list_organizations``).       │
+│ get    Fetch organization details (``get_organization``).                    │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP org/get
@@ -2379,6 +2380,16 @@ Usage: pipefy org get [OPTIONS] [ORGANIZATION_ID]
 │                                           PIPEFY_ORG_ID is set (see          │
 │                                           docs/config.md).                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json  -j                                                                   │
+│ --help            Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+### HELP org/list
+Usage: pipefy org list [OPTIONS]
+
+ List the organizations you can access (``list_organizations``).
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --json  -j                                                                   │
 │ --help            Show this message and exit.                                │

--- a/packages/cli/tests/test_org_commands.py
+++ b/packages/cli/tests/test_org_commands.py
@@ -60,7 +60,7 @@ def test_org_get_missing_id_and_env_exits_2(
     result = runner.invoke(app, ["org", "get", "--json"])
     assert result.exit_code == 2
     assert "PIPEFY_ORG_ID" in (result.stderr or "")
-    assert "pipe list" in (result.stderr or "")
+    assert "org list" in (result.stderr or "")
 
 
 def test_org_list_returns_accessible_orgs(

--- a/packages/cli/tests/test_org_commands.py
+++ b/packages/cli/tests/test_org_commands.py
@@ -61,3 +61,26 @@ def test_org_get_missing_id_and_env_exits_2(
     assert result.exit_code == 2
     assert "PIPEFY_ORG_ID" in (result.stderr or "")
     assert "pipe list" in (result.stderr or "")
+
+
+def test_org_list_returns_accessible_orgs(
+    runner, clean_pipefy_env, saved_cwd, monkeypatch
+):
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_ID", "cid")
+    monkeypatch.setenv("PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET", "sec")
+
+    payload = [
+        {"id": "111", "name": "Org One", "role": "admin"},
+        {"id": "222", "name": "Org Two", "role": "member"},
+    ]
+    mock_client = MagicMock()
+    mock_client.list_organizations = AsyncMock(return_value=payload)
+
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        result = runner.invoke(app, ["org", "list", "--json"])
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert json.loads(result.stdout) == payload
+    mock_client.list_organizations.assert_awaited_once_with()

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # pipefy-mcp-server
 
-MCP server for Pipefy — **185 tools** for AI agents (Cursor, Claude Desktop, Claude Code, Codex, and any MCP-compatible client). Depends on [`pipefy`](../sdk/README.md) for all GraphQL and API logic.
+MCP server for Pipefy — **186 tools** for AI agents (Cursor, Claude Desktop, Claude Code, Codex, and any MCP-compatible client). Depends on [`pipefy`](../sdk/README.md) for all GraphQL and API logic.
 
 ## Install
 
@@ -108,7 +108,7 @@ This form also works as a per-project `.mcp.json` if your team shares a clone. C
 
 ## Tools
 
-**185 tools** across fourteen domains (including **Portals**) — see the root [`README.md`](../../README.md#mcp-server) for the full table with per-area links. Deep reference: [`docs/mcp/tools/`](../../docs/mcp/tools/cross-cutting.md) (start with [`cross-cutting.md`](../../docs/mcp/tools/cross-cutting.md)); portals: [`portal.md`](../../docs/mcp/tools/portal.md).
+**186 tools** across fourteen domains (including **Portals**) — see the root [`README.md`](../../README.md#mcp-server) for the full table with per-area links. Deep reference: [`docs/mcp/tools/`](../../docs/mcp/tools/cross-cutting.md) (start with [`cross-cutting.md`](../../docs/mcp/tools/cross-cutting.md)); portals: [`portal.md`](../../docs/mcp/tools/portal.md).
 
 ## Development
 

--- a/packages/mcp/src/pipefy_mcp/tools/organization_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/organization_tools.py
@@ -41,3 +41,27 @@ class OrganizationTools:
             except Exception as exc:  # noqa: BLE001
                 return build_error_payload(str(exc))
             return build_success_payload(result, include_parsed=True)
+
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=True),
+            meta=REMOTE,
+        )
+        async def list_organizations(ctx: Context) -> dict:
+            """List the Pipefy organizations you can access.
+
+            The zero-knowledge entry point for discovery: answers "which
+            organizations do I have access to?" with no id required. Use it to
+            obtain the ``id`` / ``uuid`` other tools need (reports, automations,
+            observability, portals). Each entry has id, uuid, name, plan, your
+            role in it, members count, pipes count, and creation date. An empty
+            list means you belong to no organization.
+
+            The response includes both ``result`` (pretty-printed JSON string)
+            and ``data`` (parsed dict) for convenience.
+            """
+            client = get_pipefy_client(ctx)
+            try:
+                result = await client.list_organizations()
+            except Exception as exc:  # noqa: BLE001
+                return build_error_payload(str(exc))
+            return build_success_payload({"organizations": result}, include_parsed=True)

--- a/packages/mcp/src/pipefy_mcp/tools/registry.py
+++ b/packages/mcp/src/pipefy_mcp/tools/registry.py
@@ -171,6 +171,7 @@ PIPEFY_TOOL_NAMES = frozenset(
         "introspect_query",
         "introspect_type",
         "invite_members",
+        "list_organizations",
         "list_portals",
         "move_card_to_phase",
         "publish_sub_portal",

--- a/packages/mcp/tests/tools/test_organization_tools.py
+++ b/packages/mcp/tests/tools/test_organization_tools.py
@@ -19,6 +19,7 @@ from tools.conftest import build_tool_test_server
 def mock_org_client():
     client = MagicMock(PipefyClient)
     client.get_organization = AsyncMock()
+    client.list_organizations = AsyncMock()
     return client
 
 
@@ -90,6 +91,59 @@ async def test_get_organization_transport_error(
     )
     async with org_session as session:
         result = await session.call_tool("get_organization", {"organization_id": "123"})
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    err = payload.get("error")
+    assert isinstance(err, dict) and "message" in err
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("org_session", [None], indirect=True)
+async def test_list_organizations_success(
+    org_session, mock_org_client, extract_payload
+):
+    mock_org_client.list_organizations = AsyncMock(
+        return_value=[
+            {"id": "123", "uuid": "abc", "name": "My Org", "role": "admin"},
+            {"id": "456", "uuid": "def", "name": "Other Org", "role": "member"},
+        ]
+    )
+    async with org_session as session:
+        result = await session.call_tool("list_organizations", {})
+    assert result.isError is False
+    mock_org_client.list_organizations.assert_awaited_once_with()
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert "My Org" in payload["result"]
+    assert [o["name"] for o in payload["data"]["organizations"]] == [
+        "My Org",
+        "Other Org",
+    ]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("org_session", [None], indirect=True)
+async def test_list_organizations_empty(org_session, mock_org_client, extract_payload):
+    mock_org_client.list_organizations = AsyncMock(return_value=[])
+    async with org_session as session:
+        result = await session.call_tool("list_organizations", {})
+    assert result.isError is False
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload["data"]["organizations"] == []
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("org_session", [None], indirect=True)
+async def test_list_organizations_transport_error(
+    org_session, mock_org_client, extract_payload
+):
+    mock_org_client.list_organizations = AsyncMock(
+        side_effect=TransportQueryError("failed", errors=[{"message": "timeout"}])
+    )
+    async with org_session as session:
+        result = await session.call_tool("list_organizations", {})
     assert result.isError is False
     payload = extract_payload(result)
     assert payload["success"] is False

--- a/packages/mcp/tests/tools/test_remote_profile.py
+++ b/packages/mcp/tests/tools/test_remote_profile.py
@@ -22,6 +22,7 @@ REMOTE_SEED = frozenset(
         "create_ipaas_connection",
         "search_pipes",
         "get_organization",
+        "list_organizations",
         "get_pipe",
         "get_card",
         "get_cards",

--- a/packages/sdk/src/pipefy_sdk/client.py
+++ b/packages/sdk/src/pipefy_sdk/client.py
@@ -1768,6 +1768,10 @@ class PipefyClient:
         """
         return await self._organization_service.get_organization(organization_id)
 
+    async def list_organizations(self) -> list[dict[str, Any]]:
+        """List the organizations the caller can access (no id required)."""
+        return await self._organization_service.list_organizations()
+
     async def get_advanced_automations_token(self, pipe_id: str | int) -> str:
         """Mint a short-lived advanced-automations (iPaaS) access token for a pipe.
 

--- a/packages/sdk/src/pipefy_sdk/queries/organization_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/organization_queries.py
@@ -19,6 +19,24 @@ GET_ORGANIZATION_QUERY = gql(
     """
 )
 
+LIST_ORGANIZATIONS_QUERY = gql(
+    """
+    query ListOrganizations {
+        organizations {
+            id
+            uuid
+            name
+            planName
+            role
+            membersCount
+            pipesCount
+            createdAt
+        }
+    }
+    """
+)
+
 __all__ = [
     "GET_ORGANIZATION_QUERY",
+    "LIST_ORGANIZATIONS_QUERY",
 ]

--- a/packages/sdk/src/pipefy_sdk/services/organization_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/organization_service.py
@@ -7,6 +7,7 @@ from typing import Any
 from pipefy_sdk.graphql_executor import GraphQLExecutor
 from pipefy_sdk.queries.organization_queries import (
     GET_ORGANIZATION_QUERY,
+    LIST_ORGANIZATIONS_QUERY,
 )
 
 
@@ -30,3 +31,13 @@ class OrganizationService:
             msg = f"Organization '{organization_id}' was not found."
             raise ValueError(msg)
         return org
+
+    async def list_organizations(self) -> list[dict[str, Any]]:
+        """List the organizations the caller can access.
+
+        Needs no id: the API scopes the result to the caller's own access. An
+        empty list is a valid answer (the caller belongs to no organization), so
+        unlike ``get_organization`` this does not raise on an empty result.
+        """
+        data = await self._executor.execute_query(LIST_ORGANIZATIONS_QUERY, {})
+        return data.get("organizations") or []

--- a/packages/sdk/tests/services/pipefy/test_organization_service.py
+++ b/packages/sdk/tests/services/pipefy/test_organization_service.py
@@ -5,6 +5,7 @@ from _shared.mock_clients import mock_executor
 
 from pipefy_sdk.queries.organization_queries import (
     GET_ORGANIZATION_QUERY,
+    LIST_ORGANIZATIONS_QUERY,
 )
 from pipefy_sdk.services.organization_service import OrganizationService
 
@@ -59,3 +60,28 @@ async def test_get_organization_uses_correct_query_and_variables():
     query_used, variables = executor.execute_query.call_args[0]
     assert query_used is GET_ORGANIZATION_QUERY
     assert variables == {"id": "456"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_list_organizations_returns_accessible_orgs():
+    """Listing returns every accessible org, querying with no variables."""
+    orgs = [
+        {"id": "123", "uuid": "abc", "name": "My Org", "role": "admin"},
+        {"id": "456", "uuid": "def", "name": "Other Org", "role": "member"},
+    ]
+    service, executor = _make_service({"organizations": orgs})
+    result = await service.list_organizations()
+
+    query_used, variables = executor.execute_query.call_args[0]
+    assert query_used is LIST_ORGANIZATIONS_QUERY
+    assert variables == {}
+    assert result == orgs
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_list_organizations_empty_is_not_an_error():
+    """No accessible orgs returns an empty list, not a raise (unlike get)."""
+    service, _ = _make_service({"organizations": None})
+    assert await service.list_organizations() == []

--- a/skills/introspection/pipefy-introspection/SKILL.md
+++ b/skills/introspection/pipefy-introspection/SKILL.md
@@ -10,7 +10,7 @@ tags: [pipefy, introspection, graphql, schema, fallback]
 
 # Introspection & Raw GraphQL
 
-Schema discovery, organization info, and a fallback executor. **6 MCP tools.**
+Schema discovery, organization info, and a fallback executor. **7 MCP tools.**
 
 This is **Tier 2** in the resolution strategy: when a dedicated MCP tool fails or doesn't exist, use introspection to understand the API, then `execute_graphql` to run the operation directly.
 
@@ -30,6 +30,7 @@ This is **Tier 2** in the resolution strategy: when a dedicated MCP tool fails o
 | `search_schema` | `pipefy introspect schema search` | Yes | Keyword search on type names/descriptions. Optional `kind` filter. |
 | `execute_graphql` | `pipefy graphql exec` | No | Execute arbitrary GraphQL (`--yes` required for mutations). |
 | `get_organization` | `pipefy org get` | Yes | Load organization info (name, plan, UUID, member count, pipe count). |
+| `list_organizations` | `pipefy org list` | Yes | List organizations the caller can access — no id required. The zero-knowledge entry point for org discovery. |
 
 ---
 
@@ -173,9 +174,11 @@ introspect_type('CreateAutomationInput')    # see all inputFields
 
 Compare with the tool's primary arguments to know which keys are additive via `extra_input`.
 
-### Recipe 5 — Get organization ID from a pipe
+### Recipe 5 — Discover organization IDs
 
-Several tools need `organization_id` but the user only has a pipe ID:
+To answer "which organizations do I have access to?" with nothing in hand, call `list_organizations` — it needs no id and returns each org's `id`, `uuid`, `name`, and your role. That is the entry point; reach for the GraphQL fallbacks below only when you already have a pipe.
+
+When the user only has a pipe ID and needs its `organization_id`:
 
 ```
 execute_graphql query='query($id: ID!) { pipe(id: $id) { organization { id uuid name } } }' variables='{"id":"<pipe-id>"}'

--- a/skills/introspection/pipefy-introspection/SKILL.md
+++ b/skills/introspection/pipefy-introspection/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use this skill when you need to discover GraphQL type shapes, mutation
   signatures, enum values, or execute arbitrary GraphQL as a fallback.
   This is the first fallback tier (Tier 2) when dedicated MCP tools fail
-  or don't exist for an operation. 6 MCP tools.
+  or don't exist for an operation. 7 MCP tools.
 tags: [pipefy, introspection, graphql, schema, fallback]
 ---
 

--- a/skills/onboarding/pipefy-toolkit-setup/SKILL.md
+++ b/skills/onboarding/pipefy-toolkit-setup/SKILL.md
@@ -71,7 +71,7 @@ Setup is outside the Pipefy MCP tool surface. After auth succeeds, verify with:
 4. **Verify**
 
    - Shell (local / plugin / CLI): `pipefy --version`
-   - MCP: call `get_organization` (or another read-only tool the user allows)
+   - MCP: call `list_organizations` (needs no id — the natural first read; confirms the credential works and surfaces the org ids other tools need) or another read-only tool the user allows
    - Confirm exactly one `pipefy` MCP registration for the path you chose (hosted vs plugin)
 
 ## Success criteria

--- a/skills/onboarding/pipefy-toolkit-setup/SKILL.md
+++ b/skills/onboarding/pipefy-toolkit-setup/SKILL.md
@@ -45,6 +45,7 @@ Setup is outside the Pipefy MCP tool surface. After auth succeeds, verify with:
 
 | Tool (MCP) | CLI equivalent | Read-only |
 |------------|----------------|-----------|
+| `list_organizations` | `pipefy org list` | Yes |
 | `get_organization` | `pipefy org get` | Yes |
 
 ## Steps


### PR DESCRIPTION
## Motivation
Closes #383.

The most common onboarding question — "which organizations do I have access to?" — had no matching tool. `get_organization` requires an id you don't yet have, so agents fell back to raw `execute_graphql` and guessed the fields wrong twice (`plan` doesn't exist on `Organization`; `OrganizationMember` has no `id`). Discovery should not require schema spelunking.

## Outcome
Adds `list_organizations` (MCP) and `pipefy org list` (CLI): a read that needs no id and returns the organizations the caller can access — the zero-knowledge entry point for discovery. Each entry carries `id`, `uuid`, `name`, `planName`, `role`, `membersCount`, `pipesCount`, `createdAt`. An empty result is a valid answer (no raise), unlike `get_organization`.

## Proven contract
- Root `organizations` query takes no required args and is scoped to the caller by the API (`accessible_by(current_ability, :show)`) — a per-request identity concern the hosted profile already handles, so the tool is on the remote seed (`meta=REMOTE` + `REMOTE_SEED`).
- Field forms match the schema and the issue's reported gotchas: `planName` (not `plan`), and members carry no `id` (so none is selected). `id`/`uuid` are numeric-id/uuid strings.
- Read-only; governed entirely by API permissions.

## Docs & skills
Parity matrix (+row, count 185→186), README counts, `organization.md` reframed around discovery, introspection skill "Recipe 5" now leads with `list_organizations` (was the exact GraphQL workaround this issue documents), onboarding first-read.

## Testing
Offline: full non-integration suite (3810 passed), `lint-imports`, skills ref lint, version lockstep, ruff/format, CLI help golden regenerated.

Live (CLI, authenticated as a real user against the live API):

| # | Scenario | Expected | Observed | Verdict |
|---|----------|----------|----------|---------|
| 1 | `pipefy org list --json` | accessible orgs with id/uuid/name/planName/role/membersCount/pipesCount/createdAt | 45 orgs, every field populated | ✅ |
| 2 | Test org present | org `300514213` with its uuid/role/counts | uuid `341c1327-…c3970d`, role `super_admin`, 1440 members, 951 pipes | ✅ |
| 3 | Non-JSON render | Rich table, all columns | rendered | ✅ |
| 4 | `planName` (not `plan`); no member `id` selected | matches schema | confirmed in payload | ✅ |
| 5 | Empty access returns `[]`, not an error | empty list | unit-covered (`test_list_organizations_empty_is_not_an_error`) | ✅ |

The MCP `list_organizations` tool wraps the same `client.list_organizations()` verified above and is covered by offline MCP tool tests (success / empty / transport-error); it becomes callable after an MCP server restart.
