### PR TITLE
Require a 2xx S3 PUT before recording the upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - **Installer**: Claude Code next-steps print `/pipefy:pipefy-login` (and the full plugin slash sequence) instead of the stale `/pipefy-login` label.
+- **SDK**: the attachment upload's S3 PUT now requires a 2xx status instead of merely "not 4xx/5xx", so a 3xx no longer reads as a completed upload. The PUT does not follow redirects (re-sending the body to the `Location` host would ship file bytes to an unvalidated destination), so a wrong-region 301/307 used to pass the check and the card or table-record field was then updated with a storage path the bytes never reached. It now fails as `step=s3_upload` with the status attached, leaving the field untouched. Closes #511.
 
 ## [0.3.0-beta.1] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - **Installer**: Claude Code next-steps print `/pipefy:pipefy-login` (and the full plugin slash sequence) instead of the stale `/pipefy-login` label.
-- **SDK**: the attachment upload's S3 PUT now requires a 2xx status instead of merely "not 4xx/5xx", so a 3xx no longer reads as a completed upload. The PUT does not follow redirects (re-sending the body to the `Location` host would ship file bytes to an unvalidated destination), so a wrong-region 301/307 used to pass the check and the card or table-record field was then updated with a storage path the bytes never reached. It now fails as `step=s3_upload` with the status attached, leaving the field untouched. Closes #511.
+- **SDK**: both S3 upload legs — the attachment pipeline and the knowledge-base document upload — now require a 2xx PUT status instead of merely "not 4xx/5xx", so a 3xx no longer reads as a completed upload. Neither PUT follows redirects (re-sending the body to the `Location` host would ship file bytes to an unvalidated destination), so a wrong-region 301/307 used to pass the check: the card or table-record field was then updated with a storage path the bytes never reached, and the knowledge base registered a document URL for an object that was never written. Both now fail at `step=s3_upload` with the status attached, before the field update or the create mutation runs. Closes #511.
 
 ## [0.3.0-beta.1] - 2026-07-20
 

--- a/packages/sdk/src/pipefy_sdk/services/attachment_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/attachment_service.py
@@ -324,9 +324,8 @@ class AttachmentService:
                 f"S3 upload failed: {exc}", step="s3_upload"
             ) from exc
         status = put_result.get("status_code", 0)
-        # Only 2xx means the object was stored. A 3xx is a rejection, not a hop to
-        # chase: the PUT is not redirect-following, and re-sending the body to the
-        # Location host would ship file bytes to an unvalidated destination.
+        # Only 2xx stored the object. A 3xx is rejected, not followed: re-sending the
+        # body to the Location host would bypass the upload URL allow-list.
         if not isinstance(status, int) or not 200 <= status < 300:
             body_snippet = put_result.get("body_snippet")
             raise AttachmentUploadError(

--- a/packages/sdk/src/pipefy_sdk/services/attachment_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/attachment_service.py
@@ -324,7 +324,10 @@ class AttachmentService:
                 f"S3 upload failed: {exc}", step="s3_upload"
             ) from exc
         status = put_result.get("status_code", 0)
-        if not isinstance(status, int) or status >= 400:
+        # Only 2xx means the object was stored. A 3xx is a rejection, not a hop to
+        # chase: the PUT is not redirect-following, and re-sending the body to the
+        # Location host would ship file bytes to an unvalidated destination.
+        if not isinstance(status, int) or not 200 <= status < 300:
             body_snippet = put_result.get("body_snippet")
             raise AttachmentUploadError(
                 f"S3 upload failed with HTTP {status}.",

--- a/packages/sdk/src/pipefy_sdk/services/knowledge_base_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/knowledge_base_service.py
@@ -652,9 +652,8 @@ class KnowledgeBaseService:
                 f"S3 upload failed: {exc}", step="s3_upload"
             ) from exc
         status = put_result.get("status_code", 0)
-        # Only 2xx means the object was stored. A 3xx is a rejection, not a hop to
-        # chase: the PUT is not redirect-following, and re-sending the body to the
-        # Location host would ship file bytes to an unvalidated destination.
+        # Only 2xx stored the object. A 3xx is rejected, not followed: re-sending the
+        # body to the Location host would bypass the upload URL allow-list.
         if not isinstance(status, int) or not 200 <= status < 300:
             body_snippet = put_result.get("body_snippet")
             raise KnowledgeBaseDocumentUploadError(

--- a/packages/sdk/src/pipefy_sdk/services/knowledge_base_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/knowledge_base_service.py
@@ -652,7 +652,10 @@ class KnowledgeBaseService:
                 f"S3 upload failed: {exc}", step="s3_upload"
             ) from exc
         status = put_result.get("status_code", 0)
-        if not isinstance(status, int) or status >= 400:
+        # Only 2xx means the object was stored. A 3xx is a rejection, not a hop to
+        # chase: the PUT is not redirect-following, and re-sending the body to the
+        # Location host would ship file bytes to an unvalidated destination.
+        if not isinstance(status, int) or not 200 <= status < 300:
             body_snippet = put_result.get("body_snippet")
             raise KnowledgeBaseDocumentUploadError(
                 f"S3 upload failed with HTTP {status}.",

--- a/packages/sdk/tests/services/test_attachment_service.py
+++ b/packages/sdk/tests/services/test_attachment_service.py
@@ -200,6 +200,31 @@ async def test_httpx_s3_uploader_forbidden_includes_body_snippet():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.parametrize("status", [301, 307])
+async def test_httpx_s3_uploader_does_not_follow_redirects(status):
+    """A 3xx surfaces as-is (httpx does not follow it) and carries no snippet.
+
+    Re-sending the body to the ``Location`` host would ship file bytes to an
+    unvalidated destination, so the status reaches the service to be rejected.
+    """
+    url = "https://bucket.s3.amazonaws.com/orgs/o1/uploads/u1/report.pdf?sig=1"
+    with respx.mock:
+        route = respx.put(url).mock(
+            return_value=httpx.Response(
+                status,
+                headers={"location": "https://bucket.s3.eu-west-1.amazonaws.com/x"},
+                text="<?xml version='1.0'?><Error><Code>PermanentRedirect</Code></Error>",
+            )
+        )
+        uploader = HttpxS3Uploader(allowed_host_pattern=_ALLOWED_UPLOAD_HOST_RE)
+        result = await uploader.put(url=url, bytes_=b"%PDF", content_type=None)
+
+    assert route.call_count == 1
+    assert result == {"status_code": status}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_httpx_s3_uploader_sets_content_type_header():
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -435,6 +460,60 @@ async def test_upload_attachment_s3_http_error_carries_snippet_and_status(tmp_pa
     assert ctx.value.step == "s3_upload"
     assert ctx.value.body_snippet == "<Error/>"
     assert ctx.value.status_code == 403
+    service._card_service.update_card_field.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [200, 201, 204])
+async def test_upload_attachment_accepts_2xx_and_updates_field(tmp_path, status):
+    """Every 2xx means the bytes landed, so the field update proceeds."""
+    service, _ = _make_service(s3_status=status)
+    attachment = _build_attachment(tmp_path, name="a.bin")
+
+    await service.upload_attachment(
+        attachment,
+        organization_id="org-1",
+        target=CardTarget(card_id="c1", field_id="f"),
+    )
+
+    service._card_service.update_card_field.assert_awaited_once_with(
+        "c1", "f", ["bucket/key"]
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [301, 302, 303, 307, 308, 404, 500])
+@pytest.mark.parametrize(
+    "target",
+    [
+        CardTarget(card_id="c1", field_id="f"),
+        TableRecordTarget(table_record_id="tr-9", field_id="f"),
+    ],
+    ids=["card", "table_record"],
+)
+async def test_upload_attachment_non_2xx_rejects_and_leaves_field_untouched(
+    tmp_path, status, target
+):
+    """A redirect never stored the bytes, so it must fail like a 4xx/5xx does.
+
+    The field must keep its previous value rather than gain a storage path
+    pointing at an object that was never written.
+    """
+    service, _ = _make_service(s3_status=status)
+    attachment = _build_attachment(tmp_path, name="a.bin")
+
+    with pytest.raises(AttachmentUploadError) as ctx:
+        await service.upload_attachment(
+            attachment, organization_id="org-1", target=target
+        )
+
+    assert ctx.value.step == "s3_upload"
+    assert ctx.value.status_code == status
+    assert ctx.value.body_snippet is None
+    service._card_service.update_card_field.assert_not_called()
+    service._table_service.set_table_record_field_value.assert_not_called()
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/test_knowledge_base_service.py
+++ b/packages/sdk/tests/services/test_knowledge_base_service.py
@@ -6,6 +6,9 @@ import pytest
 from _shared.mock_clients import mock_executor
 
 from pipefy_sdk.graphql_executor import GraphQLResult
+from pipefy_sdk.queries.knowledge_base_queries import (
+    CREATE_AI_KNOWLEDGE_BASE_DOCUMENT_MUTATION,
+)
 from pipefy_sdk.services import knowledge_base_service as kb_module
 from pipefy_sdk.services.knowledge_base_service import (
     MAX_KB_DESCRIPTION_LENGTH,
@@ -59,6 +62,15 @@ def _create_flow_executor():
             {"createAiKnowledgeBaseDocument": {"knowledgeBaseDocument": DOCUMENT_FULL}},
         ]
     )
+
+
+def _create_document_calls(executor):
+    """The document-create mutation calls: the consumer of a successful PUT."""
+    return [
+        call
+        for call in executor.execute_query.await_args_list
+        if call.args[0] is CREATE_AI_KNOWLEDGE_BASE_DOCUMENT_MUTATION
+    ]
 
 
 PLAIN_TEXT_NODE = {
@@ -633,8 +645,7 @@ class TestCreateDocument:
         assert exc_info.value.step == "s3_upload"
         assert exc_info.value.status_code == 403
         assert exc_info.value.body_snippet == "AccessDenied"
-        # the create mutation (third call) never ran
-        assert executor.execute_query.await_count == 2
+        assert _create_document_calls(executor) == []
 
     @pytest.mark.anyio
     async def test_s3_put_exception_tagged_s3_upload(self, tmp_path):
@@ -663,6 +674,58 @@ class TestCreateDocument:
         assert "connection reset by peer" in str(exc_info.value)
         # the create mutation (third call) never ran
         assert executor.execute_query.await_count == 2
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("status", [301, 302, 303, 307, 308, 404, 500])
+    async def test_non_2xx_put_never_reaches_the_create_mutation(
+        self, tmp_path, status
+    ):
+        """A redirect never stored the PDF, so it must fail like a 4xx/5xx does.
+
+        Registering the document would point the knowledge base at an object
+        that was never written.
+        """
+        executor = mock_executor(
+            side_effect=[
+                {"pipe": {"organization": {"id": "300514213"}}},
+                {
+                    "createPresignedUrl": {
+                        "url": _UPLOAD_URL,
+                        "downloadUrl": _DOWNLOAD_URL,
+                    }
+                },
+            ]
+        )
+        uploader = _FakeUploader(result={"status_code": status})
+        service = KnowledgeBaseService(executor=executor, s3_uploader=uploader)
+        pdf = _write_pdf(tmp_path)
+
+        with pytest.raises(KnowledgeBaseDocumentUploadError) as exc_info:
+            await service.create_ai_knowledge_base_document(
+                "p", name="n", description="d", file_path=pdf
+            )
+
+        assert exc_info.value.step == "s3_upload"
+        assert exc_info.value.status_code == status
+        assert exc_info.value.body_snippet is None
+        assert _create_document_calls(executor) == []
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("status", [200, 201, 204])
+    async def test_2xx_put_proceeds_to_the_create_mutation(self, tmp_path, status):
+        """Every 2xx means the bytes landed, so the document is registered."""
+        executor = _create_flow_executor()
+        service = KnowledgeBaseService(
+            executor=executor, s3_uploader=_FakeUploader(result={"status_code": status})
+        )
+        pdf = _write_pdf(tmp_path)
+
+        result = await service.create_ai_knowledge_base_document(
+            "p", name="n", description="d", file_path=pdf
+        )
+
+        assert result == DOCUMENT_FULL
+        assert len(_create_document_calls(executor)) == 1
 
     @pytest.mark.anyio
     async def test_create_mutation_failure_tagged_kb_create(self, tmp_path):


### PR DESCRIPTION
## Motivation

Both S3 upload legs in the SDK treated every status below 400 as a completed upload, so a 3xx passed the check and the pipeline proceeded on bytes that were never transferred.

On the attachment path the card or table-record field was updated with a storage path pointing at an object that does not exist. On the knowledge-base path `createAiKnowledgeBaseDocument` registered a document against that same never-written object. Both failures are silent and lossy: the caller sees success, the record holds a key, and nothing downstream re-checks.

The status is reachable rather than hypothetical — S3 answers 301 (`PermanentRedirect`) and 307 when a request reaches the wrong regional endpoint. Neither PUT follows redirects, since both go through `HttpxS3Uploader` and `httpx.AsyncClient` defaults `follow_redirects=False`, so the 3xx genuinely surfaces at the gate rather than being resolved beneath it.

## Outcome

Both gates now require a 2xx instead of "not 4xx/5xx". A 3xx fails at `step="s3_upload"` with `status_code` populated, before the field update or the create mutation runs.

Rejecting rather than following is the point: a presigned PUT carries the file bytes, and chasing the `Location` would re-send them to a host the uploader's allow-list only ever checked on the original URL.

Closes #511.

## Notes

Strict 2xx over a `200/201/204` allow-list — a presigned single-object PUT succeeds with 200, and the allow-list's other members belong to different operations. Two independent one-line gates rather than a shared helper, since the modules raise different exception types and two call sites do not pay for the abstraction.

4xx/5xx are unchanged on both paths, including the `body_snippet` capture. A 3xx carries `status_code` with `body_snippet` left `None`, since a redirect has no meaningful error body. Both error contracts are otherwise unchanged, so the MCP and CLI envelopes need no adjustment.

Does not affect `create_attachment_presigned_url` (#506), which mints and returns a target without transferring bytes. SDK-internal throughout — no tool added or removed, no CLI surface change.
