### PR TITLE
docs(release): drop the last cross-refs to the removed alpha subcommand

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -253,9 +253,9 @@ def _apply_prepare(bump_arg: str, target: str, *, stamp: bool = True) -> str:
     ``alpha_pr`` delegates to); callers own the preflight and confirmation.
     Returns the version bump_version actually wrote.
 
-    ``stamp=False`` leaves ``## [Unreleased]`` intact — what the alpha flow
-    needs, since consecutive alphas share one accumulating section (see
-    ``alpha``).
+    ``stamp=False`` leaves ``## [Unreleased]`` intact — what an alpha needs,
+    since consecutive alphas share one accumulating section that the eventual
+    beta promotion stamps in full.
     """
     # bump_version.py owns the transform; run its CLI so the file set and lock
     # refresh live in exactly one place.

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -214,7 +214,7 @@ def test_alpha_target_is_ahead_of_a_released_beta() -> None:
     # sorts above main's already-released beta rather than below it.
     assert _release._target_ahead_of_main("0.5.0-alpha.1", "0.4.0-beta.2")
     # And an alpha on the same core as that beta does not -- PEP 440 puts
-    # 0.4.0a1 below 0.4.0b2, which is why `alpha` guards on this.
+    # 0.4.0a1 below 0.4.0b2, which is why the release flows guard on this.
     assert not _release._target_ahead_of_main("0.4.0-alpha.1", "0.4.0-beta.2")
 
 
@@ -264,7 +264,7 @@ def test_tag_and_publish_refuses_a_track_branch_mismatch(monkeypatch) -> None:
 def test_release_pr_refuses_an_alpha_target(bump: str, monkeypatch) -> None:
     # On an alpha line, `prerelease` computes the next alpha. Without this gate
     # release_pr would stamp `## [Unreleased]` into an alpha heading and aim the
-    # commit at main -- breaking the contract that only `alpha` cuts alphas.
+    # commit at main -- breaking the contract that only `alpha-pr` cuts alphas.
     monkeypatch.setattr(_release, "working_tree_clean", lambda: True)
     monkeypatch.setattr(_release, "run", lambda *a, **k: None)
     monkeypatch.setattr(_release, "_dev_unreleased_body", lambda: "- a thing")


### PR DESCRIPTION
## Motivation

The non-blocking item from the #556 approval: `_apply_prepare`'s stamp note ended with a `(see `alpha`)` cross-reference to a subcommand that no longer exists. It was the one pointer a reader would follow to understand why `stamp=False` exists, and it led nowhere.

Sweeping for the same pattern turned up two more that the review did not catch, both in `tests/test_release.py` — comments crediting the ahead-of-main guard and the "only one flow cuts alphas" contract to `alpha` rather than `alpha-pr`. Those guards now live in the shared `release_pr` path.

## Outcome

No comment, docstring, or doc in the release tooling names a subcommand that argparse does not register. The stamp note states its reason directly rather than pointing at a symbol, which is what made it rot in the first place.

`prerelease_track`'s docstring deliberately keeps its `alpha` mentions: there the word names the PEP 440 track, not the subcommand.

Comment-only, so there is no CHANGELOG entry — no behavior changed, and the existing `## [Unreleased]` bullet already describes the shipped contract. Adding one would only put noise in the next alpha's release body, since that body is `## [Unreleased]`.
