### PR TITLE
fix(ai-agents): active lifecycle — inactive create + update preserve (#520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **AI agents (active lifecycle)**: create can start inactive (`create_ai_agent(active=false)` / `pipefy agent create --inactive`) by sending `disabledAt` on create and the chained update so the second step does not revive; routine update preserves `disabledAt` (use `toggle_ai_agent_status` / `pipefy agent toggle` to activate or deactivate); create/update success payloads expose `disabled_at` and `active`. Skills document the contract. (#520)
+
 ### Added
 
 - **Skills**: thin `pipefy-building` router (`skills/building/pipefy-building/`) maps build/configure intent to the correct domain skill; catalog and authoring domain list include `building`. Consulting-only `pipefy-process-design` links execution asks to the router instead of growing a delivery playbook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **AI agents (active lifecycle)**: create can start inactive (`create_ai_agent(active=false)` / `pipefy agent create --inactive`) by sending `disabledAt` on create and the chained update so the second step does not revive; routine update preserves `disabledAt` (use `toggle_ai_agent_status` / `pipefy agent toggle` to activate or deactivate); create/update success payloads expose `disabled_at` and `active`. Skills document the contract. (#520)
+- **AI agents (active lifecycle)**: create can start inactive (`create_ai_agent(active=false)` / `pipefy agent create --inactive`) by sending `disabledAt` on create and the chained update so the second step does not revive; routine update preserves `disabledAt` (optional `disabled_at` / `--disabled-at` pass-through skips the re-read; use `toggle_ai_agent_status` / `pipefy agent toggle` to activate or deactivate); create/update success payloads expose `disabled_at` and `active`; partial-failure envelopes surface shell `disabled_at` and a toggle recovery hint. Skills document the contract. (#520)
 
 ### Added
 

--- a/docs/mcp/tools/automations-and-ai.md
+++ b/docs/mcp/tools/automations-and-ai.md
@@ -159,7 +159,7 @@ On **create**, if the caller omits `condition`, the MCP layer supplies `DEFAULT_
 | Tool | Read-only | Role |
 |------|-----------|------|
 | `create_ai_agent` | No | Creates and configures an AI agent with `instruction` (= Pipefy UI "Description") and 1–5 `behaviors` in one call. `repo_uuid` is the pipe UUID from `get_pipe`. Optional: `data_source_ids`; optional `active` (default `true`; `false` = inactive-on-create via `disabled_at`). Success payload includes `disabled_at` / `active`. |
-| `update_ai_agent` | No | Replaces full agent config; send the complete `behaviors` list (1-5). Preserves disabled status — use `toggle_ai_agent_status` to activate or deactivate. Success payload includes `disabled_at` / `active`. |
+| `update_ai_agent` | No | Replaces full agent config; send the complete `behaviors` list (1-5). Preserves disabled status (optional `disabled_at` pass-through from `get_ai_agent` skips the re-read). Use `toggle_ai_agent_status` to activate or deactivate. Success payload includes `disabled_at` / `active`. |
 | `toggle_ai_agent_status` | No | Enable/disable without resending configuration. |
 
 **Tip:** Pipefy UI **Description** maps to the API/tool field `instruction` (agent-level purpose). The per-behavior prompt in the UI maps to `actionParams.aiBehaviorParams.instruction` on each behavior (behavior-level).

--- a/docs/mcp/tools/automations-and-ai.md
+++ b/docs/mcp/tools/automations-and-ai.md
@@ -158,8 +158,8 @@ On **create**, if the caller omits `condition`, the MCP layer supplies `DEFAULT_
 
 | Tool | Read-only | Role |
 |------|-----------|------|
-| `create_ai_agent` | No | Creates and configures an AI agent with `instruction` (= Pipefy UI "Description") and 1–5 `behaviors` in one call. `repo_uuid` is the pipe UUID from `get_pipe`. Optional: `data_source_ids`. |
-| `update_ai_agent` | No | Replaces full agent config; send the complete `behaviors` list (1-5). |
+| `create_ai_agent` | No | Creates and configures an AI agent with `instruction` (= Pipefy UI "Description") and 1–5 `behaviors` in one call. `repo_uuid` is the pipe UUID from `get_pipe`. Optional: `data_source_ids`; optional `active` (default `true`; `false` = inactive-on-create via `disabled_at`). Success payload includes `disabled_at` / `active`. |
+| `update_ai_agent` | No | Replaces full agent config; send the complete `behaviors` list (1-5). Preserves disabled status — use `toggle_ai_agent_status` to activate or deactivate. Success payload includes `disabled_at` / `active`. |
 | `toggle_ai_agent_status` | No | Enable/disable without resending configuration. |
 
 **Tip:** Pipefy UI **Description** maps to the API/tool field `instruction` (agent-level purpose). The per-behavior prompt in the UI maps to `actionParams.aiBehaviorParams.instruction` on each behavior (behavior-level).

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -29,7 +29,7 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | `add_service_account_to_pipe` | `pipefy member add-service-account` | shipped | Attaches an existing org service account to a pipe by email (iPaaS setup); role defaults to `admin`; wraps `inviteMembers`. The MCP tool verifies membership afterwards (errors if absent); the CLI returns the raw invite result (inspect `inviteMembers.errors`). |
 | `call_ipaas_tool` | — | deferred | iPaaS (Advanced Automations) tool invocation; MCP-first surface, CLI twin considered once agent usage settles. |
 | `clone_pipe` | `pipefy pipe clone` | shipped | optional `--org`. |
-| `create_ai_agent` | `pipefy agent create` | shipped | AI Agents domain; post-v0.1 CLI unless explicitly rescoped. |
+| `create_ai_agent` | `pipefy agent create` | shipped | AI Agents domain; `--active/--inactive` (default active) mirrors MCP `active`; inactive sets `disabled_at` on create + chained update. |
 | `create_ai_automation` | `pipefy ai-automation create` | shipped | AI Automations domain; post-v0.1 CLI unless explicitly rescoped. |
 | `create_ai_knowledge_base_data_lookup` | `pipefy kb data-lookup create` | shipped | Knowledge bases; pipe-scoped (`--pipe-uuid`, `--name`, `--description` <=900, `--source-repo-id` numeric pipe ID, `--output-fields` JSON array 1-30, `--conditions` JSON array, optional `--search-query`). Conditions are typed client-side (static needs a string value; AI-filled needs the input trio). CLI gates on the read-access probe. |
 | `create_ai_knowledge_base_document` | `pipefy kb document create` | shipped | Knowledge bases; one-shot PDF upload (presigned URL, S3 PUT, create mutation). Pipe-scoped (`--pipe-uuid`, `--file`, `--name`, `--description` <=900, all required). `.pdf` and 20 MiB cap enforced client-side; step-tagged errors (`file_read`/`presigned_url`/`s3_upload`/`kb_create`). CLI gates on the read-access probe. Indexing is asynchronous. |
@@ -179,7 +179,7 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | `sort_portal_pages` | `pipefy portal page sort` | shipped | `--portal-uuid` plus ordered ids via `--page-ids` or `--ids-json`. |
 | `toggle_ai_agent_status` | `pipefy agent toggle` | shipped | AI Agents domain. |
 | `unpublish_sub_portal` | `pipefy portal sub-portal unpublish` | shipped | internal_api `updateSubPortalElement(subPortalUuid: null)`; sets `subPortals[].published` to false. |
-| `update_ai_agent` | `pipefy agent update` | shipped | AI Agents domain. |
+| `update_ai_agent` | `pipefy agent update` | shipped | AI Agents domain; preserves disabled state (use `toggle` / `toggle_ai_agent_status` to change active). |
 | `update_ai_automation` | `pipefy ai-automation update` | shipped | AI Automations domain. |
 | `update_ai_knowledge_base_data_lookup` | `pipefy kb data-lookup update` | shipped | Knowledge bases; full-replacement update (`--id`, `--pipe-uuid`, required `--source-repo-id`/`--output-fields`/`--conditions` every call; omitted `--search-query` clears it; only `--name`/`--description` are partial). CLI gates on the read-access probe. |
 | `update_ai_knowledge_base_document` | `pipefy kb document update` | shipped | Knowledge bases; metadata-only partial update (`--id`, `--pipe-uuid`, optional `--name`/`--description`, at least one); no file replacement. CLI gates on the read-access probe. |

--- a/docs/parity.md
+++ b/docs/parity.md
@@ -179,7 +179,7 @@ For **database records**, `find_records` result nodes may use **`fields`** while
 | `sort_portal_pages` | `pipefy portal page sort` | shipped | `--portal-uuid` plus ordered ids via `--page-ids` or `--ids-json`. |
 | `toggle_ai_agent_status` | `pipefy agent toggle` | shipped | AI Agents domain. |
 | `unpublish_sub_portal` | `pipefy portal sub-portal unpublish` | shipped | internal_api `updateSubPortalElement(subPortalUuid: null)`; sets `subPortals[].published` to false. |
-| `update_ai_agent` | `pipefy agent update` | shipped | AI Agents domain; preserves disabled state (use `toggle` / `toggle_ai_agent_status` to change active). |
+| `update_ai_agent` | `pipefy agent update` | shipped | AI Agents domain; preserves disabled state (optional `disabled_at` / `--disabled-at` pass-through); use `toggle` / `toggle_ai_agent_status` to change active. |
 | `update_ai_automation` | `pipefy ai-automation update` | shipped | AI Automations domain. |
 | `update_ai_knowledge_base_data_lookup` | `pipefy kb data-lookup update` | shipped | Knowledge bases; full-replacement update (`--id`, `--pipe-uuid`, required `--source-repo-id`/`--output-fields`/`--conditions` every call; omitted `--search-query` clears it; only `--name`/`--description` are partial). CLI gates on the read-access probe. |
 | `update_ai_knowledge_base_document` | `pipefy kb document update` | shipped | Knowledge bases; metadata-only partial update (`--id`, `--pipe-uuid`, optional `--name`/`--description`, at least one); no file replacement. CLI gates on the read-access probe. |

--- a/packages/cli/src/pipefy_cli/commands/agent.py
+++ b/packages/cli/src/pipefy_cli/commands/agent.py
@@ -177,7 +177,7 @@ def agent_create(
             behaviors=validated.behaviors,
             data_source_ids=validated.data_source_ids,
             disabled_at=validated.disabled_at,
-            preserve_disabled_at=not active,
+            preserve_disabled_at=False,
         )
         update_result = await client.update_ai_agent(update_input)
         result_disabled_at = update_result.get("disabled_at")
@@ -217,6 +217,14 @@ def agent_update(
         "--data-sources",
         help="Optional JSON array of knowledge-source id strings.",
     ),
+    disabled_at: str | None = typer.Option(
+        None,
+        "--disabled-at",
+        help=(
+            "Optional ISO-8601 disabledAt from agent get. Pass through to skip the "
+            "preserve re-read; omit to let the SDK preserve."
+        ),
+    ),
     strict_unknown: bool = typer.Option(
         True,
         "--strict/--no-strict",
@@ -229,9 +237,10 @@ def agent_update(
 ) -> None:
     """Replace AI agent configuration (``update_ai_agent``).
 
-    Full-replace of behaviors; does not reactivate a disabled agent. Use
-    ``pipefy agent toggle`` to change active status. Confirm status from the
-    response ``disabled_at`` / ``active`` fields. To re-read via ``agent get``,
+    Full-replace of behaviors; does not intentionally reactivate a disabled agent.
+    Pass ``--disabled-at`` from ``agent get`` (``disabledAt``) to preserve without an
+    extra read. Use ``pipefy agent toggle`` to change active status. Confirm status
+    from the response ``disabled_at`` / ``active`` fields. To re-read via ``agent get``,
     use agent ``disabledAt`` (null means active).
     """
     behavior_list = _parse_behaviors_json(behaviors)
@@ -252,6 +261,7 @@ def agent_update(
             instruction=inst,
             behaviors=expanded,
             data_source_ids=data_source_ids,
+            disabled_at=disabled_at.strip() if disabled_at else None,
         )
     except ValidationError as exc:
         raise typer.BadParameter(str(exc)) from exc

--- a/packages/cli/src/pipefy_cli/commands/agent.py
+++ b/packages/cli/src/pipefy_cli/commands/agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 import typer
@@ -109,6 +110,14 @@ def agent_create(
         "--data-sources",
         help="Optional JSON array of knowledge-source id strings.",
     ),
+    active: bool = typer.Option(
+        True,
+        "--active/--inactive",
+        help=(
+            "Create enabled (default) or inactive. --inactive sets disabled_at on "
+            "create and the chained update so the second step does not revive."
+        ),
+    ),
     strict_unknown: bool = typer.Option(
         True,
         "--strict/--no-strict",
@@ -121,7 +130,12 @@ def agent_create(
         False, "--json", "-j", help="Print machine-readable JSON to stdout."
     ),
 ) -> None:
-    """Create and configure an AI agent (``create_ai_agent`` + ``update_ai_agent`` chain)."""
+    """Create and configure an AI agent (``create_ai_agent`` + ``update_ai_agent`` chain).
+
+    Agents are active by default. Pass ``--inactive`` to start disabled. Confirm
+    status from the response ``disabled_at`` / ``active`` fields. To change status
+    later, use ``pipefy agent toggle`` (routine update preserves disabled state).
+    """
     behavior_list = _parse_behaviors_json(behaviors)
     ds_raw = parse_json_value(data_sources, "--data-sources") if data_sources else None
     data_source_ids: list[str] = []
@@ -131,6 +145,7 @@ def agent_create(
         data_source_ids = list(ds_raw)
 
     inst = normalize_pipefy_ai_instruction_tokens(instruction.strip())
+    disabled_at = None if active else datetime.now(timezone.utc).isoformat()
     try:
         expanded = expand_behaviors_placeholders(behavior_list)
         validated = CreateAiAgentInput(
@@ -139,6 +154,7 @@ def agent_create(
             instruction=inst,
             behaviors=expanded,
             data_source_ids=data_source_ids,
+            disabled_at=disabled_at,
         )
     except ValidationError as exc:
         raise typer.BadParameter(str(exc)) from exc
@@ -160,12 +176,17 @@ def agent_create(
             instruction=validated.instruction,
             behaviors=validated.behaviors,
             data_source_ids=validated.data_source_ids,
+            disabled_at=validated.disabled_at,
+            preserve_disabled_at=not active,
         )
-        await client.update_ai_agent(update_input)
+        update_result = await client.update_ai_agent(update_input)
+        result_disabled_at = update_result.get("disabled_at")
         out: dict[str, Any] = {
             "success": True,
             "agent_uuid": agent_uuid,
             "message": f"Created agent {agent_uuid}",
+            "disabled_at": result_disabled_at,
+            "active": update_result.get("active", result_disabled_at is None),
         }
         if pre.get("warnings"):
             out["preflight"] = pre
@@ -206,7 +227,12 @@ def agent_update(
     ),
     json_out: bool = typer.Option(False, "--json", "-j"),
 ) -> None:
-    """Replace AI agent configuration (``update_ai_agent``)."""
+    """Replace AI agent configuration (``update_ai_agent``).
+
+    Full-replace of behaviors; does not reactivate a disabled agent. Use
+    ``pipefy agent toggle`` to change active status. Confirm status from the
+    response ``disabled_at`` / ``active`` fields (or re-read via ``agent get``).
+    """
     behavior_list = _parse_behaviors_json(behaviors)
     ds_raw = parse_json_value(data_sources, "--data-sources") if data_sources else None
     data_source_ids: list[str] = []

--- a/packages/cli/src/pipefy_cli/commands/agent.py
+++ b/packages/cli/src/pipefy_cli/commands/agent.py
@@ -231,7 +231,8 @@ def agent_update(
 
     Full-replace of behaviors; does not reactivate a disabled agent. Use
     ``pipefy agent toggle`` to change active status. Confirm status from the
-    response ``disabled_at`` / ``active`` fields (or re-read via ``agent get``).
+    response ``disabled_at`` / ``active`` fields. To re-read via ``agent get``,
+    use agent ``disabledAt`` (null means active).
     """
     behavior_list = _parse_behaviors_json(behaviors)
     ds_raw = parse_json_value(data_sources, "--data-sources") if data_sources else None

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -230,10 +230,11 @@ Usage: pipefy agent update [OPTIONS]
 
  Replace AI agent configuration (``update_ai_agent``).
 
- Full-replace of behaviors; does not reactivate a disabled agent. Use ``pipefy
- agent toggle`` to change active status. Confirm status from the response
- ``disabled_at`` / ``active`` fields. To re-read via ``agent get``, use agent
- ``disabledAt`` (null means active).
+ Full-replace of behaviors; does not intentionally reactivate a disabled agent.
+ Pass ``--disabled-at`` from ``agent get`` (``disabledAt``) to preserve without
+ an extra read. Use ``pipefy agent toggle`` to change active status. Confirm
+ status from the response ``disabled_at`` / ``active`` fields. To re-read via
+ ``agent get``, use agent ``disabledAt`` (null means active).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --uuid                             TEXT  Agent UUID. [required]           │
@@ -248,6 +249,10 @@ Usage: pipefy agent update [OPTIONS]
 │                                             [required]                       │
 │    --data-sources                     TEXT  Optional JSON array of           │
 │                                             knowledge-source id strings.     │
+│    --disabled-at                      TEXT  Optional ISO-8601 disabledAt     │
+│                                             from agent get. Pass through to  │
+│                                             skip the preserve re-read; omit  │
+│                                             to let the SDK preserve.         │
 │    --strict            --no-strict          Pre-flight strictness: --strict  │
 │                                             (default) blocks on unknown      │
 │                                             actionType values; --no-strict   │

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -97,6 +97,10 @@ Usage: pipefy agent create [OPTIONS]
  Create and configure an AI agent (``create_ai_agent`` + ``update_ai_agent``
  chain).
 
+ Agents are active by default. Pass ``--inactive`` to start disabled. Confirm
+ status from the response ``disabled_at`` / ``active`` fields. To change status
+ later, use ``pipefy agent toggle`` (routine update preserves disabled state).
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --repo-uuid                        TEXT  Pipe UUID. [required]            │
 │ *  --name          -n                 TEXT  Agent display name. [required]   │
@@ -110,6 +114,12 @@ Usage: pipefy agent create [OPTIONS]
 │                                             [required]                       │
 │    --data-sources                     TEXT  Optional JSON array of           │
 │                                             knowledge-source id strings.     │
+│    --active            --inactive           Create enabled (default) or      │
+│                                             inactive. --inactive sets        │
+│                                             disabled_at on create and the    │
+│                                             chained update so the second     │
+│                                             step does not revive.            │
+│                                             [default: active]                │
 │    --strict            --no-strict          Pre-flight strictness: when      │
 │                                             --strict (default), unknown      │
 │                                             actionType values block; with    │
@@ -219,6 +229,10 @@ Usage: pipefy agent toggle [OPTIONS] UUID
 Usage: pipefy agent update [OPTIONS]
 
  Replace AI agent configuration (``update_ai_agent``).
+
+ Full-replace of behaviors; does not reactivate a disabled agent. Use ``pipefy
+ agent toggle`` to change active status. Confirm status from the response
+ ``disabled_at`` / ``active`` fields (or re-read via ``agent get``).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --uuid                             TEXT  Agent UUID. [required]           │

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -232,7 +232,8 @@ Usage: pipefy agent update [OPTIONS]
 
  Full-replace of behaviors; does not reactivate a disabled agent. Use ``pipefy
  agent toggle`` to change active status. Confirm status from the response
- ``disabled_at`` / ``active`` fields (or re-read via ``agent get``).
+ ``disabled_at`` / ``active`` fields. To re-read via ``agent get``, use agent
+ ``disabledAt`` (null means active).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --uuid                             TEXT  Agent UUID. [required]           │

--- a/packages/cli/tests/test_cli_agent_automation_smoke.py
+++ b/packages/cli/tests/test_cli_agent_automation_smoke.py
@@ -370,8 +370,12 @@ def test_agent_create_happy_path_chains_create_then_update(
     """``agent create`` runs preflight, then ``create_ai_agent`` + ``update_ai_agent``."""
     oauth_env("ag-create-ok")
     mock_client = MagicMock()
-    mock_client.create_ai_agent = AsyncMock(return_value={"agent_uuid": "uuid-1"})
-    mock_client.update_ai_agent = AsyncMock(return_value={})
+    mock_client.create_ai_agent = AsyncMock(
+        return_value={"agent_uuid": "uuid-1", "disabled_at": None}
+    )
+    mock_client.update_ai_agent = AsyncMock(
+        return_value={"agent_uuid": "uuid-1", "disabled_at": None}
+    )
 
     preflight_ok = {
         "success": True,
@@ -420,9 +424,15 @@ def test_agent_create_happy_path_chains_create_then_update(
         "success": True,
         "agent_uuid": "uuid-1",
         "message": "Created agent uuid-1",
+        "disabled_at": None,
+        "active": True,
     }
     mock_client.create_ai_agent.assert_awaited_once()
+    create_arg = mock_client.create_ai_agent.call_args.args[0]
+    assert create_arg.disabled_at is None
     mock_client.update_ai_agent.assert_awaited_once()
+    update_arg = mock_client.update_ai_agent.call_args.args[0]
+    assert update_arg.disabled_at is None
 
 
 def test_agent_update_invokes_field_ref_resolution_via_facade(

--- a/packages/cli/tests/test_cli_agent_lifecycle.py
+++ b/packages/cli/tests/test_cli_agent_lifecycle.py
@@ -1,0 +1,286 @@
+"""CLI lifecycle tests for AI agent active/disabled create and update."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from pipefy_cli.main import app
+
+_AGENT_BEHAVIOR = {
+    "name": "move on create",
+    "event_id": "card_created",
+    "actionParams": {
+        "aiBehaviorParams": {
+            "instruction": "Summarize the card.",
+            "actionsAttributes": [
+                {
+                    "name": "Move",
+                    "actionType": "move_card",
+                    "metadata": {"destinationPhaseId": "2"},
+                }
+            ],
+        }
+    },
+}
+
+_PREFLIGHT_OK = {
+    "success": True,
+    "valid": True,
+    "problems": [],
+    "warnings": [],
+    "message": "All behaviors passed validation.",
+}
+
+
+def test_agent_create_default_sets_preserve_disabled_at_false_on_update_chain(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    """Default ``agent create`` passes ``preserve_disabled_at=False`` on chained update."""
+    oauth_env("ag-create-active")
+    mock_client = MagicMock()
+    mock_client.create_ai_agent = AsyncMock(
+        return_value={
+            "agent_uuid": "active-uuid",
+            "disabled_at": "2026-08-04T12:00:00+00:00",
+            "active": False,
+        }
+    )
+    mock_client.update_ai_agent = AsyncMock(
+        return_value={
+            "agent_uuid": "active-uuid",
+            "disabled_at": None,
+            "active": True,
+        }
+    )
+
+    with (
+        patch(
+            "pipefy_cli.commands._common.get_authenticated_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "pipefy_cli.commands.agent.validate_ai_agent_behaviors_sdk",
+            new=AsyncMock(return_value=_PREFLIGHT_OK),
+        ),
+        patch(
+            "pipefy_sdk.client.resolve_and_populate_field_refs",
+            new=AsyncMock(side_effect=lambda _c, behaviors: behaviors),
+        ),
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "agent",
+                "create",
+                "--repo-uuid",
+                "repo-uuid-1",
+                "--pipe",
+                "1",
+                "--name",
+                "Active Agent",
+                "--instruction",
+                "Be helpful.",
+                "--behaviors",
+                json.dumps([_AGENT_BEHAVIOR]),
+                "--json",
+            ],
+        )
+
+    assert r.exit_code == 0, r.stderr
+    body = json.loads(r.stdout)
+    assert body["agent_uuid"] == "active-uuid"
+    assert body["disabled_at"] is None
+    assert body["active"] is True
+
+    create_arg = mock_client.create_ai_agent.call_args.args[0]
+    assert create_arg.disabled_at is None
+    update_arg = mock_client.update_ai_agent.call_args.args[0]
+    assert update_arg.disabled_at is None
+    assert update_arg.preserve_disabled_at is False
+
+
+def test_agent_create_inactive_sets_disabled_at_on_create_and_update_chain(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    """``agent create --inactive`` sets the same ``disabled_at`` on create + chained update."""
+    oauth_env("ag-create-inactive")
+    stub_disabled_at = "2026-08-04T13:00:00+00:00"
+    mock_client = MagicMock()
+    mock_client.create_ai_agent = AsyncMock(
+        return_value={
+            "agent_uuid": "inactive-uuid",
+            "disabled_at": stub_disabled_at,
+            "active": False,
+        }
+    )
+    mock_client.update_ai_agent = AsyncMock(
+        return_value={
+            "agent_uuid": "inactive-uuid",
+            "disabled_at": stub_disabled_at,
+            "active": False,
+        }
+    )
+
+    with (
+        patch(
+            "pipefy_cli.commands._common.get_authenticated_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "pipefy_cli.commands.agent.validate_ai_agent_behaviors_sdk",
+            new=AsyncMock(return_value=_PREFLIGHT_OK),
+        ),
+        patch(
+            "pipefy_sdk.client.resolve_and_populate_field_refs",
+            new=AsyncMock(side_effect=lambda _c, behaviors: behaviors),
+        ),
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "agent",
+                "create",
+                "--repo-uuid",
+                "repo-uuid-1",
+                "--pipe",
+                "1",
+                "--name",
+                "Inactive Agent",
+                "--instruction",
+                "Be helpful.",
+                "--behaviors",
+                json.dumps([_AGENT_BEHAVIOR]),
+                "--inactive",
+                "--json",
+            ],
+        )
+
+    assert r.exit_code == 0, r.stderr
+    body = json.loads(r.stdout)
+    assert body["agent_uuid"] == "inactive-uuid"
+    assert body["disabled_at"] == stub_disabled_at
+    assert body["active"] is False
+
+    create_arg = mock_client.create_ai_agent.call_args.args[0]
+    assert create_arg.disabled_at is not None
+    datetime.fromisoformat(create_arg.disabled_at)
+    update_arg = mock_client.update_ai_agent.call_args.args[0]
+    assert update_arg.disabled_at == create_arg.disabled_at
+    assert update_arg.preserve_disabled_at is True
+
+
+def test_agent_update_json_exposes_active_when_disabled_at_null(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    """``agent update --json`` exposes ``disabled_at`` null and ``active`` true from SDK."""
+    oauth_env("ag-update-active-json")
+    mock_client = MagicMock()
+    mock_client.update_ai_agent = AsyncMock(
+        return_value={
+            "agent_uuid": "active-uuid",
+            "message": "AI Agent updated successfully. UUID: active-uuid",
+            "disabled_at": None,
+            "active": True,
+        }
+    )
+
+    with (
+        patch(
+            "pipefy_cli.commands._common.get_authenticated_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "pipefy_cli.commands.agent.validate_ai_agent_behaviors_sdk",
+            new=AsyncMock(return_value=_PREFLIGHT_OK),
+        ),
+        patch(
+            "pipefy_sdk.client.resolve_and_populate_field_refs",
+            new=AsyncMock(side_effect=lambda _c, behaviors: behaviors),
+        ),
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "agent",
+                "update",
+                "--uuid",
+                "active-uuid",
+                "--repo-uuid",
+                "repo-uuid-1",
+                "--pipe",
+                "1",
+                "--name",
+                "Active Agent",
+                "--instruction",
+                "Be helpful.",
+                "--behaviors",
+                json.dumps([_AGENT_BEHAVIOR]),
+                "--json",
+            ],
+        )
+
+    assert r.exit_code == 0, r.stderr
+    body = json.loads(r.stdout)
+    assert body["disabled_at"] is None
+    assert body["active"] is True
+
+
+def test_agent_update_json_exposes_active_false_when_disabled(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    """``agent update --json`` exposes ``disabled_at`` and ``active`` false from SDK."""
+    oauth_env("ag-update-inactive-json")
+    stub_disabled_at = "2026-01-15T12:00:00+00:00"
+    mock_client = MagicMock()
+    mock_client.update_ai_agent = AsyncMock(
+        return_value={
+            "agent_uuid": "inactive-uuid",
+            "message": "AI Agent updated successfully. UUID: inactive-uuid",
+            "disabled_at": stub_disabled_at,
+            "active": False,
+        }
+    )
+
+    with (
+        patch(
+            "pipefy_cli.commands._common.get_authenticated_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "pipefy_cli.commands.agent.validate_ai_agent_behaviors_sdk",
+            new=AsyncMock(return_value=_PREFLIGHT_OK),
+        ),
+        patch(
+            "pipefy_sdk.client.resolve_and_populate_field_refs",
+            new=AsyncMock(side_effect=lambda _c, behaviors: behaviors),
+        ),
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "agent",
+                "update",
+                "--uuid",
+                "inactive-uuid",
+                "--repo-uuid",
+                "repo-uuid-1",
+                "--pipe",
+                "1",
+                "--name",
+                "Inactive Agent",
+                "--instruction",
+                "Be helpful.",
+                "--behaviors",
+                json.dumps([_AGENT_BEHAVIOR]),
+                "--json",
+            ],
+        )
+
+    assert r.exit_code == 0, r.stderr
+    body = json.loads(r.stdout)
+    assert body["disabled_at"] == stub_disabled_at
+    assert body["active"] is False

--- a/packages/cli/tests/test_cli_agent_lifecycle.py
+++ b/packages/cli/tests/test_cli_agent_lifecycle.py
@@ -170,7 +170,7 @@ def test_agent_create_inactive_sets_disabled_at_on_create_and_update_chain(
     datetime.fromisoformat(create_arg.disabled_at)
     update_arg = mock_client.update_ai_agent.call_args.args[0]
     assert update_arg.disabled_at == create_arg.disabled_at
-    assert update_arg.preserve_disabled_at is True
+    assert update_arg.preserve_disabled_at is False
 
 
 def test_agent_update_json_exposes_active_when_disabled_at_null(
@@ -281,6 +281,68 @@ def test_agent_update_json_exposes_active_false_when_disabled(
         )
 
     assert r.exit_code == 0, r.stderr
+    body = json.loads(r.stdout)
+    assert body["disabled_at"] == stub_disabled_at
+    assert body["active"] is False
+
+
+def test_agent_update_passes_disabled_at_when_provided(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    """``agent update --disabled-at`` pass-through skips inventing a preserve re-read."""
+    oauth_env("ag-update-disabled-at")
+    stub_disabled_at = "2026-01-15T12:00:00+00:00"
+    mock_client = MagicMock()
+    mock_client.update_ai_agent = AsyncMock(
+        return_value={
+            "agent_uuid": "agent-uuid",
+            "message": "AI Agent updated successfully. UUID: agent-uuid",
+            "disabled_at": stub_disabled_at,
+            "active": False,
+        }
+    )
+
+    with (
+        patch(
+            "pipefy_cli.commands._common.get_authenticated_client",
+            return_value=mock_client,
+        ),
+        patch(
+            "pipefy_cli.commands.agent.validate_ai_agent_behaviors_sdk",
+            new=AsyncMock(return_value=_PREFLIGHT_OK),
+        ),
+        patch(
+            "pipefy_sdk.client.resolve_and_populate_field_refs",
+            new=AsyncMock(side_effect=lambda _c, behaviors: behaviors),
+        ),
+    ):
+        r = runner.invoke(
+            app,
+            [
+                "agent",
+                "update",
+                "--uuid",
+                "agent-uuid",
+                "--name",
+                "Updated",
+                "--repo-uuid",
+                "repo-456",
+                "--instruction",
+                "Do things",
+                "--pipe",
+                "1",
+                "--behaviors",
+                json.dumps([_AGENT_BEHAVIOR]),
+                "--disabled-at",
+                stub_disabled_at,
+                "--json",
+            ],
+        )
+
+    assert r.exit_code == 0, r.stderr
+    update_arg = mock_client.update_ai_agent.call_args.args[0]
+    assert update_arg.disabled_at == stub_disabled_at
+    assert update_arg.preserve_disabled_at is True
     body = json.loads(r.stdout)
     assert body["disabled_at"] == stub_disabled_at
     assert body["active"] is False

--- a/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -182,7 +182,9 @@ class AiAgentTools:
             Pass ``active=False`` to create inactive (sets ``disabled_at`` on create and the
             chained update so the second step does not revive). Confirm status from the
             response ``disabled_at`` / ``active`` fields - no extra get required. To change
-            status later, use ``toggle_ai_agent_status`` (not ``update_ai_agent``).
+            status later, use ``toggle_ai_agent_status`` (not ``update_ai_agent``). An agent
+            with no active behavior is disabled by the API regardless of this flag
+            (``BehaviorInput.active`` defaults to true).
 
             Discovery workflow (call these tools first):
               1. ``get_pipe(pipe_id)`` → obtain ``uuid`` (use as ``repo_uuid``) and phase IDs.
@@ -350,7 +352,7 @@ class AiAgentTools:
                 behaviors=validated.behaviors,
                 data_source_ids=validated.data_source_ids,
                 disabled_at=validated.disabled_at,
-                preserve_disabled_at=not active,
+                preserve_disabled_at=False,
             )
             try:
                 update_result = await client.update_ai_agent(update_input)
@@ -372,6 +374,7 @@ class AiAgentTools:
                 return build_create_agent_partial_failure(
                     agent_uuid=agent_uuid,
                     error=error_text,
+                    disabled_at=create_result.get("disabled_at"),
                 )
 
             msg = f"AI Agent created and configured successfully. UUID: {agent_uuid}"
@@ -393,6 +396,7 @@ class AiAgentTools:
             instruction: str,
             behaviors: list[dict],
             data_source_ids: list[str] | None = None,
+            disabled_at: str | None = None,
         ) -> dict:
             """Update an AI Agent — replaces the entire config (all-or-nothing save).
 
@@ -401,10 +405,12 @@ class AiAgentTools:
             one action (same constraint and shape as ``create_ai_agent`` — see its docstring for the
             full behavior dict example, discovery workflow, and constraints).
 
-            Active lifecycle: a routine update never reactivates (or deactivates) the agent.
-            ``disabled_at`` is preserved by the SDK when omitted. Use ``toggle_ai_agent_status``
-            to activate or deactivate. Confirm status from the response ``disabled_at`` /
-            ``active`` fields.
+            Active lifecycle: a routine update does not intentionally reactivate or deactivate the
+            agent. Pass ``disabled_at`` from a prior ``get_ai_agent`` (agent ``disabledAt``) to
+            preserve without an extra read; when omitted, the SDK re-reads and re-sends. Use
+            ``toggle_ai_agent_status`` to activate or deactivate. Confirm status from the response
+            ``disabled_at`` / ``active`` fields. An agent with no active behavior is disabled by the
+            API regardless of preserve (``BehaviorInput.active`` defaults to true).
 
             To modify an existing agent: call ``get_ai_agent`` first, edit the returned config,
             and send the full payload back. The server replaces ``referenceId`` and appends
@@ -454,6 +460,8 @@ class AiAgentTools:
                     (same interpolation as ``create_ai_agent``).
                     Discover via: ``get_automation_events(pipe_id)`` and ``get_phase_fields(phase_id)``.
                 data_source_ids: Optional list of data source IDs.
+                disabled_at: Optional ISO-8601 ``disabledAt`` from ``get_ai_agent``. Pass through to
+                    skip the preserve re-read and avoid a toggle race. Omit to let the SDK preserve.
             """
             client = get_pipefy_client(ctx)
             await ctx.debug(
@@ -479,6 +487,7 @@ class AiAgentTools:
                     instruction=instruction,
                     behaviors=behaviors_expanded,
                     data_source_ids=data_source_ids or [],
+                    disabled_at=disabled_at,
                 )
             except ValidationError as exc:
                 return build_ai_tool_error(str(exc))
@@ -521,8 +530,9 @@ class AiAgentTools:
 
             Set active=true to activate or active=false to deactivate.
             Does not require resending the agent configuration.
-            Use this tool to change active status; ``update_ai_agent`` never
-            reactivates or deactivates an agent.
+            Use this tool to change active status; ``update_ai_agent`` preserves
+            disabled state and is not the activation path (an update whose behaviors
+            all carry ``active: false`` can still deactivate via the API).
 
             Args:
                 uuid: UUID of the agent to enable/disable.

--- a/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from mcp.server.mcpserver import Context, MCPServer
 from mcp.types import ToolAnnotations
 from pipefy_sdk import (
@@ -164,6 +166,7 @@ class AiAgentTools:
             instruction: str,
             behaviors: list[dict],
             data_source_ids: list[str] | None = None,
+            active: bool = True,
         ) -> dict:
             """Create an AI Agent and configure it in one call (GraphQL create + update).
 
@@ -173,6 +176,13 @@ class AiAgentTools:
 
             Each behavior must also include ``actionParams.aiBehaviorParams.actionsAttributes`` with
             at least one action; otherwise the API rejects the update.
+
+            Active lifecycle: default ``active=True`` creates an enabled agent. The chained
+            configure update omits ``disabledAt`` so the API clears its default disabled shell.
+            Pass ``active=False`` to create inactive (sets ``disabled_at`` on create and the
+            chained update so the second step does not revive). Confirm status from the
+            response ``disabled_at`` / ``active`` fields - no extra get required. To change
+            status later, use ``toggle_ai_agent_status`` (not ``update_ai_agent``).
 
             Discovery workflow (call these tools first):
               1. ``get_pipe(pipe_id)`` → obtain ``uuid`` (use as ``repo_uuid``) and phase IDs.
@@ -287,12 +297,14 @@ class AiAgentTools:
                     Discover via: ``get_automation_events(pipe_id)`` for ``event_id`` and
                     ``get_phase_fields(phase_id)`` for ``triggerFieldIds`` / ``destinationPhaseId``.
                 data_source_ids: Optional knowledge-source IDs (same as ``update_ai_agent``).
+                active: When True (default), create enabled. When False, create inactive by
+                    setting ``disabled_at`` (ISO-8601 UTC) on create and the chained update.
             """
             client = get_pipefy_client(ctx)
             await ctx.debug(
                 f"create_ai_agent: name={name}, repo_uuid={repo_uuid}, "
                 f"instruction_len={len(instruction)}, behaviors_count={len(behaviors)}, "
-                f"data_source_ids={data_source_ids!r}"
+                f"data_source_ids={data_source_ids!r}, active={active}"
             )
             if not name or not name.strip():
                 return build_ai_tool_error("name must not be blank")
@@ -305,6 +317,7 @@ class AiAgentTools:
                 behaviors_expanded = expand_behaviors_placeholders(behaviors)
             except ValueError as exc:
                 return build_ai_tool_error(str(exc))
+            disabled_at = None if active else datetime.now(timezone.utc).isoformat()
             try:
                 validated = CreateAiAgentInput(
                     name=name,
@@ -312,6 +325,7 @@ class AiAgentTools:
                     instruction=instruction,
                     behaviors=behaviors_expanded,
                     data_source_ids=data_source_ids or [],
+                    disabled_at=disabled_at,
                 )
             except ValidationError as exc:
                 return build_ai_tool_error(str(exc))
@@ -335,9 +349,11 @@ class AiAgentTools:
                 instruction=validated.instruction,
                 behaviors=validated.behaviors,
                 data_source_ids=validated.data_source_ids,
+                disabled_at=validated.disabled_at,
+                preserve_disabled_at=not active,
             )
             try:
-                await client.update_ai_agent(update_input)
+                update_result = await client.update_ai_agent(update_input)
             except Exception as exc:  # noqa: BLE001
                 try:
                     resolved = await resolve_and_populate_field_refs(
@@ -359,7 +375,11 @@ class AiAgentTools:
                 )
 
             msg = f"AI Agent created and configured successfully. UUID: {agent_uuid}"
-            return build_create_agent_success(agent_uuid=agent_uuid, message=msg)
+            return build_create_agent_success(
+                agent_uuid=agent_uuid,
+                message=msg,
+                disabled_at=update_result.get("disabled_at"),
+            )
 
         @mcp.tool(
             annotations=ToolAnnotations(readOnlyHint=False),
@@ -380,6 +400,11 @@ class AiAgentTools:
             Each behavior must include ``actionParams.aiBehaviorParams.actionsAttributes`` with at least
             one action (same constraint and shape as ``create_ai_agent`` — see its docstring for the
             full behavior dict example, discovery workflow, and constraints).
+
+            Active lifecycle: a routine update never reactivates (or deactivates) the agent.
+            ``disabled_at`` is preserved by the SDK when omitted. Use ``toggle_ai_agent_status``
+            to activate or deactivate. Confirm status from the response ``disabled_at`` /
+            ``active`` fields.
 
             To modify an existing agent: call ``get_ai_agent`` first, edit the returned config,
             and send the full payload back. The server replaces ``referenceId`` and appends
@@ -480,6 +505,7 @@ class AiAgentTools:
             return build_update_agent_success(
                 agent_uuid=result["agent_uuid"],
                 message=result["message"],
+                disabled_at=result.get("disabled_at"),
             )
 
         @mcp.tool(
@@ -491,10 +517,12 @@ class AiAgentTools:
             uuid: str,
             active: bool,
         ) -> dict:
-            """Enable or disable an AI Agent.
+            """Enable or disable an AI Agent (explicit activation path).
 
             Set active=true to activate or active=false to deactivate.
             Does not require resending the agent configuration.
+            Use this tool to change active status; ``update_ai_agent`` never
+            reactivates or deactivates an agent.
 
             Args:
                 uuid: UUID of the agent to enable/disable.

--- a/packages/mcp/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -18,7 +18,7 @@ from pipefy_sdk.ai_pipe_validation import (
     validate_behaviors_against_pipe,
 )
 from pydantic import ValidationError
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from pipefy_mcp.core.tool_error_envelope import (
     ToolErrorDetail,
@@ -99,6 +99,8 @@ class CreateAgentPartialFailurePayload(TypedDict):
     success: Literal[False]
     agent_uuid: str
     error: ToolErrorDetail
+    disabled_at: NotRequired[str | None]
+    active: NotRequired[bool]
 
 
 def build_create_automation_success(
@@ -255,17 +257,34 @@ def build_validate_prompt_payload(
     }
 
 
+_PARTIAL_FAILURE_DISABLED_HINT = (
+    " The agent shell is disabled until you call toggle_ai_agent_status after a "
+    "successful update_ai_agent recovery (routine update preserves disabled_at)."
+)
+
+
 def build_create_agent_partial_failure(
-    *, agent_uuid: str, error: str
+    *,
+    agent_uuid: str,
+    error: str,
+    disabled_at: str | None = None,
 ) -> CreateAgentPartialFailurePayload:
     """Create OK but follow-up update failed — surface UUID for recovery.
 
     Args:
         agent_uuid: Agent UUID from ``createAiAgent`` (retry update or delete).
         error: Why the chained update failed.
+        disabled_at: Disable timestamp from the create response, when present.
+            Empty create often stamps ``disabledAt``; recovery via update preserves
+            it, so callers must toggle to activate.
     """
-    body: dict[str, Any] = tool_error(error)
+    message = error
+    if disabled_at is not None:
+        message = f"{error}{_PARTIAL_FAILURE_DISABLED_HINT}"
+    body: dict[str, Any] = tool_error(message)
     body["agent_uuid"] = agent_uuid
+    body["disabled_at"] = disabled_at
+    body["active"] = disabled_at is None
     return cast(CreateAgentPartialFailurePayload, body)
 
 

--- a/packages/mcp/src/pipefy_mcp/tools/ai_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_tool_helpers.py
@@ -129,28 +129,50 @@ def build_update_automation_success(
     return {"success": True, "automation_id": automation_id, "message": message}
 
 
-def build_create_agent_success(*, agent_uuid: str, message: str) -> dict[str, Any]:
+def build_create_agent_success(
+    *,
+    agent_uuid: str,
+    message: str,
+    disabled_at: str | None = None,
+) -> dict[str, Any]:
     """Successful AI agent create.
 
     Args:
         agent_uuid: New agent UUID from the API.
         message: Short summary for the client.
+        disabled_at: ISO-8601 disable timestamp from the API, or None when active.
     """
+    data = {
+        "agent_uuid": agent_uuid,
+        "disabled_at": disabled_at,
+        "active": disabled_at is None,
+    }
     if is_unified_envelope_enabled():
-        return tool_success(data={"agent_uuid": agent_uuid}, message=message)
-    return {"success": True, "agent_uuid": agent_uuid, "message": message}
+        return tool_success(data=data, message=message)
+    return {"success": True, "message": message, **data}
 
 
-def build_update_agent_success(*, agent_uuid: str, message: str) -> dict[str, Any]:
+def build_update_agent_success(
+    *,
+    agent_uuid: str,
+    message: str,
+    disabled_at: str | None = None,
+) -> dict[str, Any]:
     """Successful AI agent update.
 
     Args:
         agent_uuid: Target agent UUID.
         message: Short summary for the client.
+        disabled_at: ISO-8601 disable timestamp from the API, or None when active.
     """
+    data = {
+        "agent_uuid": agent_uuid,
+        "disabled_at": disabled_at,
+        "active": disabled_at is None,
+    }
     if is_unified_envelope_enabled():
-        return tool_success(data={"agent_uuid": agent_uuid}, message=message)
-    return {"success": True, "agent_uuid": agent_uuid, "message": message}
+        return tool_success(data=data, message=message)
+    return {"success": True, "message": message, **data}
 
 
 def build_toggle_agent_status_success(*, message: str) -> dict[str, Any]:

--- a/packages/mcp/tests/tools/test_ai_agent_lifecycle.py
+++ b/packages/mcp/tests/tools/test_ai_agent_lifecycle.py
@@ -138,6 +138,7 @@ class TestCreateAiAgentLifecycle:
         assert isinstance(update_arg, UpdateAiAgentInput)
         assert update_arg.disabled_at == create_arg.disabled_at
         assert update_arg.disabled_at is not None
+        assert update_arg.preserve_disabled_at is False
         payload = extract_payload(result)
         assert payload["success"] is True
         if envelope_flag:

--- a/packages/mcp/tests/tools/test_ai_agent_lifecycle.py
+++ b/packages/mcp/tests/tools/test_ai_agent_lifecycle.py
@@ -1,0 +1,193 @@
+"""Lifecycle tests for AI agent active/disabled create and update."""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from _mcp_compat import (
+    create_connected_server_and_client_session as create_client_session,
+)
+from _shared.ai_agent_test_payloads import minimal_behavior_dict
+from pipefy_sdk.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
+
+from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
+from tools.conftest import build_tool_test_server
+
+
+@pytest.fixture
+def mock_pipefy_client():
+    client = MagicMock()
+    client.create_ai_agent = AsyncMock()
+    client.update_ai_agent = AsyncMock()
+    client.toggle_ai_agent_status = AsyncMock()
+    client.get_ai_agent = AsyncMock()
+    client.get_ai_agents = AsyncMock()
+    client.delete_ai_agent = AsyncMock()
+    client.get_pipe = AsyncMock()
+    client.get_pipe_relations = AsyncMock()
+    client.get_pipe_members = AsyncMock(return_value={"pipe": {"members": []}})
+    client.get_phase_allowed_move_targets = AsyncMock()
+    client.get_phase_fields = AsyncMock(return_value={"fields": []})
+    return client
+
+
+@pytest.fixture
+def mcp_server(mock_pipefy_client):
+    return build_tool_test_server(
+        "AI Agent Lifecycle Tools Test", AiAgentTools.register, mock_pipefy_client
+    )
+
+
+@pytest.fixture
+def client_session(mcp_server):
+    return create_client_session(
+        mcp_server,
+        read_timeout_seconds=timedelta(seconds=10),
+        raise_exceptions=True,
+    )
+
+
+@pytest.mark.anyio
+class TestCreateAiAgentLifecycle:
+    async def test_create_active_sets_preserve_disabled_at_false_on_update_chain(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+        envelope_flag,
+    ):
+        """Default/active create omits preserve so configure update can clear API default."""
+        mock_pipefy_client.create_ai_agent.return_value = {
+            "agent_uuid": "active-uuid",
+            "message": "created",
+            "disabled_at": "2026-08-04T12:00:00+00:00",
+            "active": False,
+        }
+        mock_pipefy_client.update_ai_agent.return_value = {
+            "agent_uuid": "active-uuid",
+            "message": "updated",
+            "disabled_at": None,
+            "active": True,
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {
+                    "name": "Active Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Purpose",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
+            )
+        assert result.is_error is False
+        create_arg = mock_pipefy_client.create_ai_agent.call_args[0][0]
+        assert isinstance(create_arg, CreateAiAgentInput)
+        assert create_arg.disabled_at is None
+        update_arg = mock_pipefy_client.update_ai_agent.call_args[0][0]
+        assert isinstance(update_arg, UpdateAiAgentInput)
+        assert update_arg.disabled_at is None
+        assert update_arg.preserve_disabled_at is False
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        if envelope_flag:
+            assert payload["data"]["agent_uuid"] == "active-uuid"
+            assert payload["data"]["disabled_at"] is None
+            assert payload["data"]["active"] is True
+        else:
+            assert payload["agent_uuid"] == "active-uuid"
+            assert payload["disabled_at"] is None
+            assert payload["active"] is True
+
+    async def test_create_inactive_sets_disabled_at_on_create_and_update_chain(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+        envelope_flag,
+    ):
+        stub_disabled_at = "2026-08-04T13:00:00+00:00"
+        mock_pipefy_client.create_ai_agent.return_value = {
+            "agent_uuid": "inactive-uuid",
+            "message": "created",
+            "disabled_at": stub_disabled_at,
+            "active": False,
+        }
+        mock_pipefy_client.update_ai_agent.return_value = {
+            "agent_uuid": "inactive-uuid",
+            "message": "updated",
+            "disabled_at": stub_disabled_at,
+            "active": False,
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_ai_agent",
+                {
+                    "name": "Inactive Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Purpose",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                    "active": False,
+                },
+            )
+        assert result.is_error is False
+        create_arg = mock_pipefy_client.create_ai_agent.call_args[0][0]
+        assert isinstance(create_arg, CreateAiAgentInput)
+        assert create_arg.disabled_at is not None
+        datetime.fromisoformat(create_arg.disabled_at)
+        update_arg = mock_pipefy_client.update_ai_agent.call_args[0][0]
+        assert isinstance(update_arg, UpdateAiAgentInput)
+        assert update_arg.disabled_at == create_arg.disabled_at
+        assert update_arg.disabled_at is not None
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        if envelope_flag:
+            assert payload["data"]["agent_uuid"] == "inactive-uuid"
+            assert payload["data"]["disabled_at"] == stub_disabled_at
+            assert payload["data"]["active"] is False
+        else:
+            assert payload["agent_uuid"] == "inactive-uuid"
+            assert payload["disabled_at"] == stub_disabled_at
+            assert payload["active"] is False
+
+
+@pytest.mark.anyio
+class TestUpdateAiAgentLifecycle:
+    async def test_update_preserves_inactive_status_in_success_payload(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+        envelope_flag,
+    ):
+        """Routine update does not inject reactivation; returns disabled_at from SDK."""
+        stub_disabled_at = "2026-01-15T12:00:00+00:00"
+        mock_pipefy_client.update_ai_agent.return_value = {
+            "agent_uuid": "agent-uuid",
+            "message": "AI Agent updated successfully. UUID: agent-uuid",
+            "disabled_at": stub_disabled_at,
+            "active": False,
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "Updated Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Do things",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                },
+            )
+        assert result.is_error is False
+        update_arg = mock_pipefy_client.update_ai_agent.call_args[0][0]
+        assert isinstance(update_arg, UpdateAiAgentInput)
+        assert update_arg.disabled_at is None
+        assert update_arg.preserve_disabled_at is True
+        payload = extract_payload(result)
+        assert payload["success"] is True
+        if envelope_flag:
+            assert payload["data"]["disabled_at"] == stub_disabled_at
+            assert payload["data"]["active"] is False
+        else:
+            assert payload["disabled_at"] == stub_disabled_at
+            assert payload["active"] is False

--- a/packages/mcp/tests/tools/test_ai_agent_tools.py
+++ b/packages/mcp/tests/tools/test_ai_agent_tools.py
@@ -257,9 +257,12 @@ class TestCreateAiAgent:
         mock_pipefy_client,
         extract_payload,
     ):
+        stub_disabled_at = "2026-08-04T12:00:00+00:00"
         mock_pipefy_client.create_ai_agent.return_value = {
             "agent_uuid": "created-uuid",
             "message": "AI Agent created successfully. UUID: created-uuid",
+            "disabled_at": stub_disabled_at,
+            "active": False,
         }
         mock_pipefy_client.update_ai_agent.side_effect = ValueError("update failed")
         async with client_session as session:
@@ -276,8 +279,46 @@ class TestCreateAiAgent:
         payload = extract_payload(result)
         assert payload["success"] is False
         assert payload["agent_uuid"] == "created-uuid"
+        assert payload["disabled_at"] == stub_disabled_at
+        assert payload["active"] is False
         assert "error" in payload
-        assert "update failed" in tool_error_message(payload)
+        err_msg = tool_error_message(payload)
+        assert "update failed" in err_msg
+        assert "toggle_ai_agent_status" in err_msg
+        assert "disabled" in err_msg.lower()
+
+    async def test_update_passes_disabled_at_when_provided(
+        self,
+        client_session,
+        mock_pipefy_client,
+        extract_payload,
+    ):
+        stub_disabled_at = "2026-01-15T12:00:00+00:00"
+        mock_pipefy_client.update_ai_agent.return_value = {
+            "agent_uuid": "agent-uuid",
+            "message": "AI Agent updated successfully. UUID: agent-uuid",
+            "disabled_at": stub_disabled_at,
+            "active": False,
+        }
+        async with client_session as session:
+            result = await session.call_tool(
+                "update_ai_agent",
+                {
+                    "uuid": "agent-uuid",
+                    "name": "Updated Agent",
+                    "repo_uuid": "repo-456",
+                    "instruction": "Do things",
+                    "behaviors": [minimal_behavior_dict(name="B1")],
+                    "disabled_at": stub_disabled_at,
+                },
+            )
+        assert result.is_error is False
+        update_arg = mock_pipefy_client.update_ai_agent.call_args[0][0]
+        assert isinstance(update_arg, UpdateAiAgentInput)
+        assert update_arg.disabled_at == stub_disabled_at
+        assert update_arg.preserve_disabled_at is True
+        payload = extract_payload(result)
+        assert payload["success"] is True
 
     async def test_graphql_error_extracts_messages(
         self,

--- a/packages/mcp/tests/tools/test_ai_agent_tools.py
+++ b/packages/mcp/tests/tools/test_ai_agent_tools.py
@@ -17,7 +17,7 @@ from _shared.fixture_ids import (
     make_pipe_id,
 )
 from pipefy_sdk import PipefyGraphQLError
-from pipefy_sdk.models.ai_agent import UpdateAiAgentInput
+from pipefy_sdk.models.ai_agent import CreateAiAgentInput, UpdateAiAgentInput
 
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.ai_agent_tools import AiAgentTools
@@ -71,10 +71,12 @@ class TestCreateAiAgent:
         mock_pipefy_client.create_ai_agent.return_value = {
             "agent_uuid": "abc-123",
             "message": "created",
+            "disabled_at": None,
         }
         mock_pipefy_client.update_ai_agent.return_value = {
             "agent_uuid": "abc-123",
             "message": "updated",
+            "disabled_at": None,
         }
         async with client_session as session:
             result = await session.call_tool(
@@ -92,6 +94,9 @@ class TestCreateAiAgent:
         update_arg = mock_pipefy_client.update_ai_agent.call_args[0][0]
         assert isinstance(update_arg, UpdateAiAgentInput)
         assert update_arg.data_source_ids == []
+        create_arg = mock_pipefy_client.create_ai_agent.call_args[0][0]
+        assert isinstance(create_arg, CreateAiAgentInput)
+        assert create_arg.disabled_at is None
 
     async def test_service_error_returns_error_payload(
         self,
@@ -203,10 +208,12 @@ class TestCreateAiAgent:
         mock_pipefy_client.create_ai_agent.return_value = {
             "agent_uuid": "new-uuid",
             "message": "created",
+            "disabled_at": None,
         }
         mock_pipefy_client.update_ai_agent.return_value = {
             "agent_uuid": "new-uuid",
             "message": "updated",
+            "disabled_at": None,
         }
         behaviors = [minimal_behavior_dict(name="B1")]
         async with client_session as session:
@@ -237,8 +244,12 @@ class TestCreateAiAgent:
         assert payload["success"] is True
         if envelope_flag:
             assert payload["data"]["agent_uuid"] == "new-uuid"
+            assert payload["data"]["disabled_at"] is None
+            assert payload["data"]["active"] is True
         else:
             assert payload["agent_uuid"] == "new-uuid"
+            assert payload["disabled_at"] is None
+            assert payload["active"] is True
 
     async def test_partial_failure_returns_uuid_and_error(
         self,
@@ -397,6 +408,7 @@ class TestUpdateAiAgent:
         mock_pipefy_client.update_ai_agent.return_value = {
             "agent_uuid": "agent-uuid",
             "message": "AI Agent updated successfully. UUID: agent-uuid",
+            "disabled_at": None,
         }
         async with client_session as session:
             result = await session.call_tool(
@@ -410,11 +422,16 @@ class TestUpdateAiAgent:
                 },
             )
         assert result.is_error is False
+        update_arg = mock_pipefy_client.update_ai_agent.call_args[0][0]
+        assert isinstance(update_arg, UpdateAiAgentInput)
+        assert update_arg.disabled_at is None
         payload = extract_payload(result)
         assert payload == {
             "success": True,
             "agent_uuid": "agent-uuid",
             "message": "AI Agent updated successfully. UUID: agent-uuid",
+            "disabled_at": None,
+            "active": True,
         }
         assert isinstance(payload["message"], str)
         assert isinstance(payload["agent_uuid"], str)

--- a/packages/mcp/tests/tools/test_ai_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_ai_tool_helpers.py
@@ -52,11 +52,17 @@ def test_build_create_agent_success_parametrized_flag(envelope_flag):
     if envelope_flag:
         assert out == {
             "success": True,
-            "data": {"agent_uuid": "abc"},
+            "data": {"agent_uuid": "abc", "disabled_at": None, "active": True},
             "message": "ok",
         }
     else:
-        assert out == {"success": True, "agent_uuid": "abc", "message": "ok"}
+        assert out == {
+            "success": True,
+            "agent_uuid": "abc",
+            "disabled_at": None,
+            "active": True,
+            "message": "ok",
+        }
 
 
 @pytest.mark.unit
@@ -65,11 +71,17 @@ def test_build_update_agent_success_parametrized_flag(envelope_flag):
     if envelope_flag:
         assert out == {
             "success": True,
-            "data": {"agent_uuid": "u1"},
+            "data": {"agent_uuid": "u1", "disabled_at": None, "active": True},
             "message": "updated",
         }
     else:
-        assert out == {"success": True, "agent_uuid": "u1", "message": "updated"}
+        assert out == {
+            "success": True,
+            "agent_uuid": "u1",
+            "disabled_at": None,
+            "active": True,
+            "message": "updated",
+        }
 
 
 @pytest.mark.unit

--- a/packages/mcp/tests/tools/test_ai_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_ai_tool_helpers.py
@@ -5,6 +5,7 @@ from _shared.fixture_ids import make_pipe_id
 from pipefy_sdk import PipefyGraphQLError
 
 from pipefy_mcp.tools.ai_tool_helpers import (
+    build_create_agent_partial_failure,
     build_create_agent_success,
     build_create_automation_success,
     build_delete_agent_success,
@@ -44,6 +45,21 @@ def _make_behaviors(*specs):
 
 
 # --- Unified-envelope / legacy-shape parity for AI success builders ---
+
+
+@pytest.mark.unit
+def test_build_create_agent_partial_failure_includes_disabled_hint():
+    out = build_create_agent_partial_failure(
+        agent_uuid="u1",
+        error="update failed",
+        disabled_at="2026-08-04T12:00:00+00:00",
+    )
+    assert out["success"] is False
+    assert out["agent_uuid"] == "u1"
+    assert out["disabled_at"] == "2026-08-04T12:00:00+00:00"
+    assert out["active"] is False
+    assert "toggle_ai_agent_status" in out["error"]["message"]
+    assert "update failed" in out["error"]["message"]
 
 
 @pytest.mark.unit

--- a/packages/sdk/src/pipefy_sdk/models/ai_agent.py
+++ b/packages/sdk/src/pipefy_sdk/models/ai_agent.py
@@ -416,7 +416,7 @@ class CreateAiAgentInput(BaseModel):
         description="List of behaviors (1 to MAX_BEHAVIORS)",
     )
     data_source_ids: list[str] = Field(default_factory=list)
-    disabled_at: str | None = None
+    disabled_at: NonBlankStr | None = None
 
 
 class UpdateAiAgentInput(BaseModel):
@@ -440,5 +440,5 @@ class UpdateAiAgentInput(BaseModel):
     )
     instruction: str | None = None
     data_source_ids: list[str] = Field(default_factory=list)
-    disabled_at: str | None = None
+    disabled_at: NonBlankStr | None = None
     preserve_disabled_at: bool = True

--- a/packages/sdk/src/pipefy_sdk/models/ai_agent.py
+++ b/packages/sdk/src/pipefy_sdk/models/ai_agent.py
@@ -405,7 +405,7 @@ class BehaviorInput(BaseModel):
 
 
 class CreateAiAgentInput(BaseModel):
-    """Validated input for create-and-configure flow: create mutation uses name and repo_uuid only."""
+    """Validated input for create-and-configure: name/repo_uuid plus optional disabled_at for inactive create."""
 
     name: NonBlankStr
     repo_uuid: NonBlankStr
@@ -416,10 +416,18 @@ class CreateAiAgentInput(BaseModel):
         description="List of behaviors (1 to MAX_BEHAVIORS)",
     )
     data_source_ids: list[str] = Field(default_factory=list)
+    disabled_at: str | None = None
 
 
 class UpdateAiAgentInput(BaseModel):
-    """Validated input for updating an AI Agent."""
+    """Validated input for updating an AI Agent.
+
+    When ``preserve_disabled_at`` is True (default) and ``disabled_at`` is None,
+    the adapter fetches the current agent and re-sends ``disabledAt`` if set
+    (routine update must not clear a disabled agent). When False and
+    ``disabled_at`` is None, ``disabledAt`` is omitted from the payload so the
+    API can clear/activate (used by the create-active configure chain).
+    """
 
     uuid: NonBlankStr
     name: NonBlankStr
@@ -431,3 +439,5 @@ class UpdateAiAgentInput(BaseModel):
     )
     instruction: str | None = None
     data_source_ids: list[str] = Field(default_factory=list)
+    disabled_at: str | None = None
+    preserve_disabled_at: bool = True

--- a/packages/sdk/src/pipefy_sdk/models/ai_agent.py
+++ b/packages/sdk/src/pipefy_sdk/models/ai_agent.py
@@ -422,11 +422,12 @@ class CreateAiAgentInput(BaseModel):
 class UpdateAiAgentInput(BaseModel):
     """Validated input for updating an AI Agent.
 
-    When ``preserve_disabled_at`` is True (default) and ``disabled_at`` is None,
-    the adapter fetches the current agent and re-sends ``disabledAt`` if set
-    (routine update must not clear a disabled agent). When False and
-    ``disabled_at`` is None, ``disabledAt`` is omitted from the payload so the
-    API can clear/activate (used by the create-active configure chain).
+    Prefer passing ``disabled_at`` from a prior ``get_ai_agent`` read (pass-through;
+    skips the preserve re-read). When ``preserve_disabled_at`` is True (default) and
+    ``disabled_at`` is None, the adapter fetches the current agent and re-sends
+    ``disabledAt`` if set (routine update must not clear a disabled agent). When
+    False and ``disabled_at`` is None, ``disabledAt`` is omitted from the payload so
+    the API can clear a default disabled shell (create-active configure chain).
     """
 
     uuid: NonBlankStr

--- a/packages/sdk/src/pipefy_sdk/queries/ai_agent_queries.py
+++ b/packages/sdk/src/pipefy_sdk/queries/ai_agent_queries.py
@@ -113,6 +113,7 @@ CREATE_AI_AGENT_MUTATION = gql(
                 repoUuid
                 instruction
                 dataSourceIds
+                disabledAt
             }
         }
     }
@@ -139,6 +140,7 @@ UPDATE_AI_AGENT_MUTATION = gql(
                 repoUuid
                 instruction
                 dataSourceIds
+                disabledAt
                 behaviors {
                     id
                     name

--- a/packages/sdk/src/pipefy_sdk/services/ai_agent_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/ai_agent_service.py
@@ -54,11 +54,22 @@ def inject_reference_ids(behaviors: list[dict[str, Any]]) -> list[dict[str, Any]
     return result
 
 
-def resolve_update_disabled_at(provided: str | None, current: str | None) -> str | None:
-    """Choose ``disabledAt`` for updateAiAgent; never clear (activation is toggle-only)."""
+def resolve_update_disabled_at(
+    *,
+    provided: str | None,
+    preserve: bool,
+    current: str | None,
+) -> str | None:
+    """Choose ``disabledAt`` for updateAiAgent.
+
+    Prefer an explicit ``provided`` value (pass-through). When omitted, re-send
+    ``current`` only if ``preserve`` is True; otherwise omit so the API can clear
+    a default disabled shell (create-active configure step). Activation remains
+    toggle-only — this helper never invents a clear beyond omitting the key.
+    """
     if provided is not None:
         return provided
-    if current:
+    if preserve:
         return current
     return None
 
@@ -120,12 +131,16 @@ class AiAgentService:
         ]
         behaviors_with_refs = inject_reference_ids(behaviors_raw)
 
-        disabled_at = agent_input.disabled_at
+        current_disabled_at: str | None = None
         if agent_input.disabled_at is None and agent_input.preserve_disabled_at:
             current = await self.get_agent(agent_input.uuid)
             raw = current.get("disabledAt")
             current_disabled_at = raw if isinstance(raw, str) else None
-            disabled_at = resolve_update_disabled_at(None, current_disabled_at)
+        disabled_at = resolve_update_disabled_at(
+            provided=agent_input.disabled_at,
+            preserve=agent_input.preserve_disabled_at,
+            current=current_disabled_at,
+        )
 
         agent_payload: dict[str, Any] = {
             "name": agent_input.name,

--- a/packages/sdk/src/pipefy_sdk/services/ai_agent_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/ai_agent_service.py
@@ -54,6 +54,15 @@ def inject_reference_ids(behaviors: list[dict[str, Any]]) -> list[dict[str, Any]
     return result
 
 
+def resolve_update_disabled_at(provided: str | None, current: str | None) -> str | None:
+    """Choose ``disabledAt`` for updateAiAgent; never clear (activation is toggle-only)."""
+    if provided is not None:
+        return provided
+    if current:
+        return current
+    return None
+
+
 class AiAgentService:
     """Service for AI Agent CRUD via GraphQL."""
 
@@ -69,12 +78,14 @@ class AiAgentService:
         Raises:
             ValueError: When API response is missing agent.uuid.
         """
-        variables = {
-            "agent": {
-                "name": agent_input.name,
-                "repoUuid": agent_input.repo_uuid,
-            }
+        agent_payload: dict[str, Any] = {
+            "name": agent_input.name,
+            "repoUuid": agent_input.repo_uuid,
         }
+        if agent_input.disabled_at is not None:
+            agent_payload["disabledAt"] = agent_input.disabled_at
+
+        variables = {"agent": agent_payload}
 
         response = await self._executor.execute_query(
             CREATE_AI_AGENT_MUTATION, variables
@@ -90,6 +101,8 @@ class AiAgentService:
         return {
             "agent_uuid": agent_uuid,
             "message": f"AI Agent created successfully. UUID: {agent_uuid}",
+            "disabled_at": agent.get("disabledAt"),
+            "active": agent.get("disabledAt") is None,
         }
 
     async def update_agent(self, agent_input: UpdateAiAgentInput) -> AgentServiceResult:
@@ -107,15 +120,26 @@ class AiAgentService:
         ]
         behaviors_with_refs = inject_reference_ids(behaviors_raw)
 
+        disabled_at = agent_input.disabled_at
+        if agent_input.disabled_at is None and agent_input.preserve_disabled_at:
+            current = await self.get_agent(agent_input.uuid)
+            raw = current.get("disabledAt")
+            current_disabled_at = raw if isinstance(raw, str) else None
+            disabled_at = resolve_update_disabled_at(None, current_disabled_at)
+
+        agent_payload: dict[str, Any] = {
+            "name": agent_input.name,
+            "repoUuid": agent_input.repo_uuid,
+            "instruction": agent_input.instruction or "",
+            "dataSourceIds": agent_input.data_source_ids,
+            "behaviors": behaviors_with_refs,
+        }
+        if disabled_at is not None:
+            agent_payload["disabledAt"] = disabled_at
+
         variables = {
             "uuid": agent_input.uuid,
-            "agent": {
-                "name": agent_input.name,
-                "repoUuid": agent_input.repo_uuid,
-                "instruction": agent_input.instruction or "",
-                "dataSourceIds": agent_input.data_source_ids,
-                "behaviors": behaviors_with_refs,
-            },
+            "agent": agent_payload,
         }
 
         response = await self._executor.execute_query(
@@ -132,6 +156,8 @@ class AiAgentService:
         return {
             "agent_uuid": agent_uuid,
             "message": f"AI Agent updated successfully. UUID: {agent_uuid}",
+            "disabled_at": agent.get("disabledAt"),
+            "active": agent.get("disabledAt") is None,
         }
 
     async def toggle_agent_status(

--- a/packages/sdk/src/pipefy_sdk/services/types.py
+++ b/packages/sdk/src/pipefy_sdk/services/types.py
@@ -40,6 +40,8 @@ class AiAgentGraphPayload(TypedDict, total=False):
 class AgentServiceResult(TypedDict):
     agent_uuid: str
     message: str
+    disabled_at: str | None
+    active: bool  # True when disabled_at is None
 
 
 class AutomationServiceResult(TypedDict):

--- a/packages/sdk/tests/models/test_ai_agent.py
+++ b/packages/sdk/tests/models/test_ai_agent.py
@@ -143,6 +143,32 @@ def test_create_ai_agent_input_accepts_data_source_ids():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("disabled_at", ["", "   ", "\n\t  "])
+def test_create_ai_agent_input_rejects_blank_disabled_at(disabled_at):
+    with pytest.raises(ValidationError):
+        CreateAiAgentInput(
+            name="My Agent",
+            repo_uuid="repo-123",
+            instruction="Purpose",
+            behaviors=[_make_behavior()],
+            disabled_at=disabled_at,
+        )
+
+
+@pytest.mark.unit
+def test_create_ai_agent_input_accepts_iso_disabled_at():
+    stamp = "2026-08-04T12:00:00+00:00"
+    inp = CreateAiAgentInput(
+        name="My Agent",
+        repo_uuid="repo-123",
+        instruction="Purpose",
+        behaviors=[_make_behavior()],
+        disabled_at=stamp,
+    )
+    assert inp.disabled_at == stamp
+
+
+@pytest.mark.unit
 def test_behavior_input_requires_name_and_event_id():
     inp = BehaviorInput.model_validate(minimal_behavior_dict())
     assert inp.name == "Test Behavior"
@@ -304,6 +330,31 @@ def test_update_ai_agent_input_optional_instruction_defaults_none():
         behaviors=[_make_behavior()],
     )
     assert inp.instruction is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("disabled_at", ["", "   ", "\n\t  "])
+def test_update_ai_agent_input_rejects_blank_disabled_at(disabled_at):
+    with pytest.raises(ValidationError):
+        UpdateAiAgentInput(
+            uuid="agent-123",
+            name="My Agent",
+            repo_uuid="repo-456",
+            behaviors=[_make_behavior()],
+            disabled_at=disabled_at,
+        )
+
+
+@pytest.mark.unit
+def test_update_ai_agent_input_strips_disabled_at_whitespace():
+    inp = UpdateAiAgentInput(
+        uuid="agent-123",
+        name="My Agent",
+        repo_uuid="repo-456",
+        behaviors=[_make_behavior()],
+        disabled_at="  2026-08-04T12:00:00+00:00  ",
+    )
+    assert inp.disabled_at == "2026-08-04T12:00:00+00:00"
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/test_ai_agent_service.py
+++ b/packages/sdk/tests/services/test_ai_agent_service.py
@@ -24,10 +24,47 @@ from pipefy_sdk.queries.ai_agent_queries import (
 from pipefy_sdk.services.ai_agent_service import (
     AiAgentService,
     inject_reference_ids,
+    resolve_update_disabled_at,
 )
 from pipefy_sdk.utils.relay import unwrap_relay_connection_nodes
 
 UUID_PATTERN = re.compile(r"%\{action:([a-f0-9-]{36})\}")
+
+
+@pytest.mark.unit
+def test_resolve_update_disabled_at_prefers_provided():
+    assert (
+        resolve_update_disabled_at(
+            provided="2026-01-01T00:00:00Z",
+            preserve=True,
+            current="2026-02-01T00:00:00Z",
+        )
+        == "2026-01-01T00:00:00Z"
+    )
+
+
+@pytest.mark.unit
+def test_resolve_update_disabled_at_preserves_current_when_omitted():
+    assert (
+        resolve_update_disabled_at(
+            provided=None,
+            preserve=True,
+            current="2026-07-15T09:30:00Z",
+        )
+        == "2026-07-15T09:30:00Z"
+    )
+
+
+@pytest.mark.unit
+def test_resolve_update_disabled_at_omits_when_not_preserving():
+    assert (
+        resolve_update_disabled_at(
+            provided=None,
+            preserve=False,
+            current="2026-07-15T09:30:00Z",
+        )
+        is None
+    )
 
 
 @pytest.mark.unit

--- a/packages/sdk/tests/services/test_ai_agent_service.py
+++ b/packages/sdk/tests/services/test_ai_agent_service.py
@@ -300,6 +300,8 @@ async def test_create_agent_returns_success_format():
     assert result == {
         "agent_uuid": "xyz-789",
         "message": "AI Agent created successfully. UUID: xyz-789",
+        "disabled_at": None,
+        "active": True,
     }
 
 
@@ -308,7 +310,10 @@ async def test_create_agent_returns_success_format():
 async def test_update_agent_calls_execute_query_with_correct_variables():
     """update_agent calls execute_query with updateAiAgent mutation and correct variables."""
     service, executor = _create_mock_service(
-        {"updateAiAgent": {"agent": {"uuid": "agent-uuid"}}}
+        side_effect=[
+            {"aiAgent": {"uuid": "agent-uuid", "disabledAt": None}},
+            {"updateAiAgent": {"agent": {"uuid": "agent-uuid", "disabledAt": None}}},
+        ]
     )
     inp = UpdateAiAgentInput(
         uuid="agent-uuid",
@@ -321,18 +326,161 @@ async def test_update_agent_calls_execute_query_with_correct_variables():
 
     result = await service.update_agent(inp)
 
-    executor.execute_query.assert_called_once()
-    call_args = executor.execute_query.call_args
-    variables = call_args[0][1]
+    assert executor.execute_query.await_count == 2
+    variables = executor.execute_query.call_args_list[1][0][1]
 
     assert variables["uuid"] == "agent-uuid"
     assert variables["agent"]["name"] == "Updated Agent"
     assert variables["agent"]["repoUuid"] == "repo-456"
     assert variables["agent"]["instruction"] == "Do things"
     assert variables["agent"]["dataSourceIds"] == ["ds1"]
+    assert "disabledAt" not in variables["agent"]
     assert len(variables["agent"]["behaviors"]) == 1
     assert result["agent_uuid"] == "agent-uuid"
+    assert result["disabled_at"] is None
+    assert result["active"] is True
     assert "AI Agent updated successfully" in result["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_agent_includes_disabled_at_when_provided():
+    """update_agent sends disabledAt in the agent payload when input.disabled_at is set."""
+    disabled_at = "2026-08-01T12:00:00Z"
+    service, executor = _create_mock_service(
+        {"updateAiAgent": {"agent": {"uuid": "agent-uuid", "disabledAt": disabled_at}}}
+    )
+    inp = UpdateAiAgentInput(
+        uuid="agent-uuid",
+        name="Updated Agent",
+        repo_uuid="repo-456",
+        instruction="Do things",
+        behaviors=[minimal_behavior_dict(name="B1")],
+        disabled_at=disabled_at,
+    )
+
+    result = await service.update_agent(inp)
+
+    executor.execute_query.assert_called_once()
+    variables = executor.execute_query.call_args[0][1]
+    assert variables["agent"]["disabledAt"] == disabled_at
+    assert result["disabled_at"] == disabled_at
+    assert result["active"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_agent_preserves_current_disabled_at_when_omitted():
+    """When disabled_at is omitted, update_agent re-sends the current disabledAt."""
+    disabled_at = "2026-07-15T09:30:00Z"
+    service, executor = _create_mock_service(
+        side_effect=[
+            {"aiAgent": {"uuid": "agent-uuid", "disabledAt": disabled_at}},
+            {
+                "updateAiAgent": {
+                    "agent": {"uuid": "agent-uuid", "disabledAt": disabled_at}
+                }
+            },
+        ]
+    )
+    inp = UpdateAiAgentInput(
+        uuid="agent-uuid",
+        name="Updated Agent",
+        repo_uuid="repo-456",
+        instruction="Do things",
+        behaviors=[minimal_behavior_dict(name="B1")],
+    )
+
+    result = await service.update_agent(inp)
+
+    assert executor.execute_query.await_count == 2
+    get_query, get_vars = executor.execute_query.call_args_list[0][0]
+    assert get_query is GET_AI_AGENT_QUERY
+    assert get_vars == {"uuid": "agent-uuid"}
+    update_vars = executor.execute_query.call_args_list[1][0][1]
+    assert update_vars["agent"]["disabledAt"] == disabled_at
+    assert result["disabled_at"] == disabled_at
+    assert result["active"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_update_agent_omits_disabled_at_when_preserve_disabled_false():
+    """preserve_disabled_at=False skips get and omits disabledAt so the API can activate."""
+    service, executor = _create_mock_service(
+        {"updateAiAgent": {"agent": {"uuid": "agent-uuid", "disabledAt": None}}}
+    )
+    inp = UpdateAiAgentInput(
+        uuid="agent-uuid",
+        name="Updated Agent",
+        repo_uuid="repo-456",
+        instruction="Do things",
+        behaviors=[minimal_behavior_dict(name="B1")],
+        disabled_at=None,
+        preserve_disabled_at=False,
+    )
+
+    result = await service.update_agent(inp)
+
+    executor.execute_query.assert_called_once()
+    variables = executor.execute_query.call_args[0][1]
+    assert "disabledAt" not in variables["agent"]
+    assert result["disabled_at"] is None
+    assert result["active"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_agent_includes_disabled_at_when_provided():
+    """create_agent sends disabledAt when input.disabled_at is set (inactive create)."""
+    disabled_at = "2026-08-04T10:00:00Z"
+    service, executor = _create_mock_service(
+        {
+            "createAiAgent": {
+                "agent": {"uuid": "new-uuid-123", "disabledAt": disabled_at}
+            }
+        }
+    )
+    inp = CreateAiAgentInput(
+        name="My Agent",
+        repo_uuid="repo-456",
+        instruction="Purpose",
+        behaviors=[minimal_behavior_dict(name="B")],
+        disabled_at=disabled_at,
+    )
+
+    result = await service.create_agent(inp)
+
+    variables = executor.execute_query.call_args[0][1]
+    assert variables["agent"]["disabledAt"] == disabled_at
+    assert result["disabled_at"] == disabled_at
+    assert result["active"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_agent_returns_disabled_at_from_response():
+    """create_agent maps agent.disabledAt from the mutation response."""
+    service, _ = _create_mock_service(
+        {
+            "createAiAgent": {
+                "agent": {"uuid": "xyz-789", "disabledAt": "2026-01-01T00:00:00Z"}
+            }
+        }
+    )
+    inp = CreateAiAgentInput(
+        name="Test",
+        repo_uuid="repo-1",
+        instruction="Purpose",
+        behaviors=[minimal_behavior_dict(name="B")],
+        disabled_at="2026-01-01T00:00:00Z",
+    )
+
+    result = await service.create_agent(inp)
+
+    assert result["agent_uuid"] == "xyz-789"
+    assert result["disabled_at"] == "2026-01-01T00:00:00Z"
+    assert result["active"] is False
 
 
 @pytest.mark.unit
@@ -340,7 +488,10 @@ async def test_update_agent_calls_execute_query_with_correct_variables():
 async def test_update_agent_calls_inject_reference_ids():
     """update_agent calls inject_reference_ids before building the payload."""
     service, _ = _create_mock_service(
-        {"updateAiAgent": {"agent": {"uuid": "agent-uuid"}}}
+        side_effect=[
+            {"aiAgent": {"uuid": "agent-uuid", "disabledAt": None}},
+            {"updateAiAgent": {"agent": {"uuid": "agent-uuid"}}},
+        ]
     )
     inp = UpdateAiAgentInput(
         uuid="agent-uuid",
@@ -409,7 +560,12 @@ async def test_create_agent_missing_uuid_returns_clear_error():
 @pytest.mark.asyncio
 async def test_update_agent_missing_uuid_returns_clear_error():
     """update_agent returns clear error when API response missing agent.uuid."""
-    service, _ = _create_mock_service({"updateAiAgent": {"agent": {}}})
+    service, _ = _create_mock_service(
+        side_effect=[
+            {"aiAgent": {"uuid": "agent-uuid", "disabledAt": None}},
+            {"updateAiAgent": {"agent": {}}},
+        ]
+    )
     inp = UpdateAiAgentInput(
         uuid="agent-uuid",
         name="Agent",

--- a/skills/ai-agents/pipefy-ai-agents/SKILL.md
+++ b/skills/ai-agents/pipefy-ai-agents/SKILL.md
@@ -23,15 +23,24 @@ For traditional automations and AI automations (prompt-driven), see [skills/auto
 |------------|-----|-----------|---------|
 | `get_ai_agents` | `pipefy agent list` | Yes | List AI agents for a pipe (`repo_uuid` = pipe UUID, not numeric `id`). |
 | `get_ai_agent` | `pipefy agent get` | Yes | Full agent config including behaviors. |
-| `create_ai_agent` | `pipefy agent create` | No | Create a new conversational agent. |
-| `update_ai_agent` | `pipefy agent update` | No | **Full-replace** (not patch). Always send complete `behaviors`. |
+| `create_ai_agent` | `pipefy agent create` | No | Create a new conversational agent (active by default; `active=false` / `--inactive` to start disabled). |
+| `update_ai_agent` | `pipefy agent update` | No | **Full-replace** (not patch). Always send complete `behaviors`. Preserves disabled state. |
 | `delete_ai_agent` | `pipefy agent delete` | No | **(Two-step destructive)** |
-| `toggle_ai_agent_status` | `pipefy agent toggle` | No | Enable/disable the agent (e.g. `--inactive`). |
+| `toggle_ai_agent_status` | `pipefy agent toggle` | No | Explicit activate/deactivate (e.g. `--inactive`). |
 | `validate_ai_agent_behaviors` | `pipefy agent validate-behaviors` | Yes | **Pre-flight check before create/update.** |
 
 The read tools (`get_ai_agents`, `get_ai_agent`, `validate_ai_agent_behaviors`) and the write tools (`create`/`update`/`delete`/`toggle`) are all remote-safe: available under the hosted (`profile=remote`) surface.
 
 Execution logs live in [skills/observability/](../../observability/pipefy-observability/SKILL.md) (`get_ai_agent_logs`, `get_ai_agent_log_details`).
+
+---
+
+## Active lifecycle
+
+- Agents are **active by default**. Create-active clears the API default disabled shell via the configure update (omits `disabledAt`). Create-inactive (`active=false` / `--inactive`) sets `disabled_at` explicitly on create and the chained update.
+- Routine `update_ai_agent` / `pipefy agent update` **preserves** disabled state — it does not reactivate.
+- Explicit activate/deactivate: `toggle_ai_agent_status` / `pipefy agent toggle` (`--active` / `--inactive`).
+- After create/update, confirm status from the response `disabled_at` / `active` fields (or re-read via `get_ai_agent` / `pipefy agent get`). Never assume inactive without that confirmation.
 
 ---
 
@@ -181,21 +190,21 @@ Inside `actionParams.aiBehaviorParams` a behavior may also carry:
 
 ### 7 — Create the agent
 
-`create_ai_agent` with `name`, `repo_uuid`, `instruction`, and `behaviors`. One-call creation is preferred — avoids partial agent shells. Agents are **active by default**.
+`create_ai_agent` with `name`, `repo_uuid`, `instruction`, and `behaviors`. One-call creation is preferred — avoids partial agent shells. Agents are **active by default**; pass `active=false` (MCP) or `--inactive` (CLI) to start disabled (see [Active lifecycle](#active-lifecycle)).
 
-The **CLI** `agent create` / `agent update` require `--pipe` (numeric pipe id) and run `validate_ai_agent_behaviors` automatically as a pre-flight, blocking the write when `problems` are found and surfacing `warnings` under a `preflight` key. The MCP tools do **not** auto-preflight, so call `validate_ai_agent_behaviors` yourself (step 6) before `create_ai_agent` / `update_ai_agent`. CLI flags: `--repo-uuid`, `--name`, `--instruction`, `--behaviors` (JSON array), `--data-sources` (JSON array); `agent validate-behaviors` instead takes `--data-source-id` (repeatable).
+The **CLI** `agent create` / `agent update` require `--pipe` (numeric pipe id) and run `validate_ai_agent_behaviors` automatically as a pre-flight, blocking the write when `problems` are found and surfacing `warnings` under a `preflight` key. The MCP tools do **not** auto-preflight, so call `validate_ai_agent_behaviors` yourself (step 6) before `create_ai_agent` / `update_ai_agent`. CLI flags: `--repo-uuid`, `--name`, `--instruction`, `--behaviors` (JSON array), `--data-sources` (JSON array), `--active` / `--inactive`; `agent validate-behaviors` instead takes `--data-source-id` (repeatable).
 
 On create/update, slug `fieldId` values are resolved to numeric `internal_id`, `%{field:<slug>}` is rewritten to `%{field:<internal_id>}`, and `referencedFieldIds` is auto-populated when applicable.
 
 ### 8 — Handle responses
 
-- **Success with `agent_uuid`** → done.
-- **Partial failure (UUID returned, behaviors rejected)** → call `update_ai_agent` with the **full required payload**: `uuid`, `repo_uuid` (same pipe UUID used on create), `name`, `instruction`, and complete `behaviors` (full-replace, not patch). Do NOT create a second agent.
+- **Success with `agent_uuid`** → confirm `disabled_at` / `active` on the response (active when `disabled_at` is null).
+- **Partial failure (UUID returned, behaviors rejected)** → call `update_ai_agent` with the **full required payload**: `uuid`, `repo_uuid` (same pipe UUID used on create), `name`, `instruction`, and complete `behaviors` (full-replace, not patch). Do NOT create a second agent. Update preserves disabled state; use `toggle_ai_agent_status` if you need to change it.
 - **Failure without UUID** → validation or API error. Trust the hint text in the enriched error.
 
 ### 9 — Verify
 
-`get_ai_agent(uuid)` to confirm behaviors match expectations **and** to re-read active status / `disabledAt`. Do not treat the create/update write alone as proof the agent is enabled — re-read status after every write.
+`get_ai_agent(uuid)` to confirm behaviors match expectations **and** to re-read active status / `disabled_at` when the write response is unclear. Prefer the create/update response `disabled_at` / `active` fields when present; never assume inactive without that confirmation.
 
 ---
 
@@ -302,13 +311,13 @@ Per behavior you can pass `template_params` (or `placeholders`) with `str → st
 
 ## Success criteria
 
-- `get_ai_agent` returns the agent with `status: active`.
+- Create/update response (or `get_ai_agent`) shows the expected `disabled_at` / `active` (active when `disabled_at` is null).
 - `validate_ai_agent_behaviors` reports no errors before creation.
 - Agent appears in the Pipefy UI under the pipe's AI settings.
 
 ## Failure modes
 
-- **`update_ai_agent` is full-replace, not patch.** Fetch existing behaviors with `get_ai_agent` first, merge, then update — otherwise existing behaviors are silently dropped.
+- **`update_ai_agent` is full-replace, not patch.** Fetch existing behaviors with `get_ai_agent` first, merge, then update — otherwise existing behaviors are silently dropped. Update never reactivates a disabled agent — use `toggle_ai_agent_status` / `pipefy agent toggle` for that.
 - **Behavior save is all-or-nothing (`RECORD_NOT_SAVED`).** One invalid behavior rejects the entire list. The MCP tool auto-validates the payload on failure; if structurally correct, the error indicates a pipe-level restriction (not your payload). Inform the user this pipe does not support AI agent behaviors and suggest alternatives.
 - **Partial-failure recovery.** If `create_ai_agent` returns a UUID but reports failure, call `update_ai_agent(uuid, repo_uuid, name, instruction, behaviors)` — all five are required. Reuse the create `repo_uuid`; send the full behaviors list. Do NOT create a second agent.
 - **Cross-pipe `PERMISSION_DENIED`.** Behaviors with `create_connected_card` or cross-pipe `create_card` require the service account to be a member of **both** source and destination pipes. When it is not, the API returns a bare `PERMISSION_DENIED`. Recovery: `get_pipe_members` + `invite_members` on the destination pipe.

--- a/skills/ai-agents/pipefy-ai-agents/SKILL.md
+++ b/skills/ai-agents/pipefy-ai-agents/SKILL.md
@@ -40,7 +40,7 @@ Execution logs live in [skills/observability/](../../observability/pipefy-observ
 - Agents are **active by default**. Create-active clears the API default disabled shell via the configure update (omits `disabledAt`). Create-inactive (`active=false` / `--inactive`) sets `disabled_at` explicitly on create and the chained update.
 - Routine `update_ai_agent` / `pipefy agent update` **preserves** disabled state — it does not reactivate.
 - Explicit activate/deactivate: `toggle_ai_agent_status` / `pipefy agent toggle` (`--active` / `--inactive`).
-- After create/update, confirm status from the response `disabled_at` / `active` fields (or re-read via `get_ai_agent` / `pipefy agent get`). Never assume inactive without that confirmation.
+- After create/update, confirm status from the response `disabled_at` / `active` fields when present. To re-read via `get_ai_agent` / `pipefy agent get`, use agent `disabledAt` (null means active) — get does not expose write-envelope `disabled_at` / `active`, and `behaviors[].active` is not agent enablement. Never assume inactive without that confirmation.
 
 ---
 
@@ -192,7 +192,7 @@ Inside `actionParams.aiBehaviorParams` a behavior may also carry:
 
 `create_ai_agent` with `name`, `repo_uuid`, `instruction`, and `behaviors`. One-call creation is preferred — avoids partial agent shells. Agents are **active by default**; pass `active=false` (MCP) or `--inactive` (CLI) to start disabled (see [Active lifecycle](#active-lifecycle)).
 
-The **CLI** `agent create` / `agent update` require `--pipe` (numeric pipe id) and run `validate_ai_agent_behaviors` automatically as a pre-flight, blocking the write when `problems` are found and surfacing `warnings` under a `preflight` key. The MCP tools do **not** auto-preflight, so call `validate_ai_agent_behaviors` yourself (step 6) before `create_ai_agent` / `update_ai_agent`. CLI flags: `--repo-uuid`, `--name`, `--instruction`, `--behaviors` (JSON array), `--data-sources` (JSON array), `--active` / `--inactive`; `agent validate-behaviors` instead takes `--data-source-id` (repeatable).
+The **CLI** `agent create` / `agent update` require `--pipe` (numeric pipe id) and run `validate_ai_agent_behaviors` automatically as a pre-flight, blocking the write when `problems` are found and surfacing `warnings` under a `preflight` key. The MCP tools do **not** auto-preflight, so call `validate_ai_agent_behaviors` yourself (step 6) before `create_ai_agent` / `update_ai_agent`. CLI flags: `--repo-uuid`, `--name`, `--instruction`, `--behaviors` (JSON array), `--data-sources` (JSON array); create also: `--active` / `--inactive` (update has no status flags — use `agent toggle`); `agent validate-behaviors` instead takes `--data-source-id` (repeatable).
 
 On create/update, slug `fieldId` values are resolved to numeric `internal_id`, `%{field:<slug>}` is rewritten to `%{field:<internal_id>}`, and `referencedFieldIds` is auto-populated when applicable.
 
@@ -204,7 +204,7 @@ On create/update, slug `fieldId` values are resolved to numeric `internal_id`, `
 
 ### 9 — Verify
 
-`get_ai_agent(uuid)` to confirm behaviors match expectations **and** to re-read active status / `disabled_at` when the write response is unclear. Prefer the create/update response `disabled_at` / `active` fields when present; never assume inactive without that confirmation.
+`get_ai_agent(uuid)` to confirm behaviors match expectations **and**, when the write response is unclear, re-read agent enablement via `disabledAt` (null means active). Prefer create/update response `disabled_at` / `active` when present. Do not treat `behaviors[].active` as agent enablement; never assume inactive without confirmation.
 
 ---
 
@@ -311,7 +311,7 @@ Per behavior you can pass `template_params` (or `placeholders`) with `str → st
 
 ## Success criteria
 
-- Create/update response (or `get_ai_agent`) shows the expected `disabled_at` / `active` (active when `disabled_at` is null).
+- Create/update response shows the expected `disabled_at` / `active` (active when `disabled_at` is null). If confirming via `get_ai_agent`, use agent `disabledAt` (null means active) — not write-envelope keys and not `behaviors[].active`.
 - `validate_ai_agent_behaviors` reports no errors before creation.
 - Agent appears in the Pipefy UI under the pipe's AI settings.
 
@@ -319,7 +319,7 @@ Per behavior you can pass `template_params` (or `placeholders`) with `str → st
 
 - **`update_ai_agent` is full-replace, not patch.** Fetch existing behaviors with `get_ai_agent` first, merge, then update — otherwise existing behaviors are silently dropped. Update never reactivates a disabled agent — use `toggle_ai_agent_status` / `pipefy agent toggle` for that.
 - **Behavior save is all-or-nothing (`RECORD_NOT_SAVED`).** One invalid behavior rejects the entire list. The MCP tool auto-validates the payload on failure; if structurally correct, the error indicates a pipe-level restriction (not your payload). Inform the user this pipe does not support AI agent behaviors and suggest alternatives.
-- **Partial-failure recovery.** If `create_ai_agent` returns a UUID but reports failure, call `update_ai_agent(uuid, repo_uuid, name, instruction, behaviors)` — all five are required. Reuse the create `repo_uuid`; send the full behaviors list. Do NOT create a second agent.
+- **Partial-failure recovery.** If `create_ai_agent` returns a UUID but reports failure, call `update_ai_agent(uuid, repo_uuid, name, instruction, behaviors)` — all five are required. Reuse the create `repo_uuid`; send the full behaviors list. Do NOT create a second agent. Update preserves disabled state; use `toggle_ai_agent_status` / `pipefy agent toggle` to change enablement.
 - **Cross-pipe `PERMISSION_DENIED`.** Behaviors with `create_connected_card` or cross-pipe `create_card` require the service account to be a member of **both** source and destination pipes. When it is not, the API returns a bare `PERMISSION_DENIED`. Recovery: `get_pipe_members` + `invite_members` on the destination pipe.
 - **Phase transition rule on `move_card`.** Destination must be reachable from the source phase (`cards_can_be_moved_to_phases`). Both `validate_ai_agent_behaviors` and `create_ai_agent` / `update_ai_agent` enrich this error with `valid_destinations` and a hint that transition rules are editable in the Pipefy UI only.
 - **Maximum 5 behaviors per agent.** Adding a 6th rejects the whole save.

--- a/skills/ai-agents/pipefy-ai-agents/SKILL.md
+++ b/skills/ai-agents/pipefy-ai-agents/SKILL.md
@@ -38,9 +38,9 @@ Execution logs live in [skills/observability/](../../observability/pipefy-observ
 ## Active lifecycle
 
 - Agents are **active by default**. Create-active clears the API default disabled shell via the configure update (omits `disabledAt`). Create-inactive (`active=false` / `--inactive`) sets `disabled_at` explicitly on create and the chained update.
-- Routine `update_ai_agent` / `pipefy agent update` **preserves** disabled state — it does not reactivate.
+- Routine `update_ai_agent` / `pipefy agent update` **preserves** disabled state — it does not intentionally reactivate. Prefer passing `disabled_at` from a prior `get_ai_agent` (`disabledAt`) / `pipefy agent update --disabled-at` to skip the preserve re-read; when omitted, the SDK re-reads and re-sends.
 - Explicit activate/deactivate: `toggle_ai_agent_status` / `pipefy agent toggle` (`--active` / `--inactive`).
-- After create/update, confirm status from the response `disabled_at` / `active` fields when present. To re-read via `get_ai_agent` / `pipefy agent get`, use agent `disabledAt` (null means active) — get does not expose write-envelope `disabled_at` / `active`, and `behaviors[].active` is not agent enablement. Never assume inactive without that confirmation.
+- After create/update, confirm status from the response `disabled_at` / `active` fields when present. To re-read via `get_ai_agent` / `pipefy agent get`, use agent `disabledAt` (null means active) — get does not expose write-envelope `disabled_at` / `active`, and `behaviors[].active` is not agent enablement. Never assume inactive without that confirmation. An agent with no active behavior is disabled by the API regardless of the create/update enablement flags.
 
 ---
 
@@ -199,7 +199,7 @@ On create/update, slug `fieldId` values are resolved to numeric `internal_id`, `
 ### 8 — Handle responses
 
 - **Success with `agent_uuid`** → confirm `disabled_at` / `active` on the response (active when `disabled_at` is null).
-- **Partial failure (UUID returned, behaviors rejected)** → call `update_ai_agent` with the **full required payload**: `uuid`, `repo_uuid` (same pipe UUID used on create), `name`, `instruction`, and complete `behaviors` (full-replace, not patch). Do NOT create a second agent. Update preserves disabled state; use `toggle_ai_agent_status` if you need to change it.
+- **Partial failure (UUID returned, behaviors rejected)** → call `update_ai_agent` with the **full required payload**: `uuid`, `repo_uuid` (same pipe UUID used on create), `name`, `instruction`, and complete `behaviors` (full-replace, not patch). Do NOT create a second agent. The create shell is often disabled (`disabled_at` on the partial-failure envelope); update preserves that state — call `toggle_ai_agent_status` after a successful recovery update if you need the agent active.
 - **Failure without UUID** → validation or API error. Trust the hint text in the enriched error.
 
 ### 9 — Verify


### PR DESCRIPTION
## Summary

- **Closes #520.** Path **A** (schema + live probe 2026-08-04): `AiAgentInput.disabledAt` is writable; update without it clears/revives; update with it preserves; create can send it for inactive-on-create.
- SDK: inactive create sends `disabledAt`; routine update re-sends current `disabledAt` (`preserve_disabled_at=True`); create-active chains use `preserve_disabled_at=False` so the configure update clears the API’s default disabled shell. Results expose `disabled_at` / `active`.
- MCP: `create_ai_agent(active=False)`; CLI: `pipefy agent create --inactive`. Success payloads and skill/docs document the contract; activation remains `toggle_ai_agent_status` / `pipefy agent toggle`.

## Research note (Path A)

| Finding | Evidence |
|---------|----------|
| `AiAgentInput.disabledAt: DateTime` writable | introspect 2026-08-04 |
| Empty `createAiAgent` often returns `disabledAt` set | live probe |
| Update **without** `disabledAt` clears it (revive / also activates configure step) | behavioral probe |
| Update **with** `disabledAt` preserves | behavioral probe |
| Path B (warning-only) skipped | API supports preserve/write |

## Test plan

- [x] `uv run pytest -m "not integration"` (4117+ passed after C.7)
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run python .github/workflows/scripts/lint_skill_refs.py`
- [x] Live smoke (CLI on this branch): create active → `active: true`; create `--inactive` → stays disabled after prompt update; toggle off → update → still disabled
- [ ] Optional: re-smoke via Cursor MCP after restarting the local server so `active` appears on `create_ai_agent`

## Docs / skills

- [x] `docs/parity.md` updated
- [x] `skills/ai-agents/pipefy-ai-agents/SKILL.md` Active lifecycle section
- [x] `docs/mcp/tools/automations-and-ai.md` AI agents table
- [x] `CHANGELOG.md` [Unreleased]

## Legal / contributions

- [x] Commits include DCO sign-off (`git commit -s`)