### PR TITLE
fix(release): refuse a cut when main has commits absent from dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Installer**: `install.sh` resolves the newest GitHub Release whose tag is **not** an alpha, so a staging alpha published from `dev` never becomes what a default `curl … | sh` install hands out; the public install path stays on the beta line. Alphas are also flagged as GitHub pre-releases, keeping the "Latest" badge on the newest beta. Filtering is by tag shape rather than the API's `prerelease` flag, because the whole pre-1.0 line is betas that must stay installable. `install.sh --version vX.Y.Z-alpha.N` still installs an alpha on purpose.
 
+### Fixed
+
+- **Release process**: `release-pr` (and `alpha-pr`, which delegates to it) now refuses to cut when `origin/main` carries commits absent from `origin/dev`, naming the count and prescribing the back-merge. The existing staleness guard compared version strings, so it only saw divergence that moved the version; work merged straight into `main` without a bump — a doc fix, a CI workflow — passed it unnoticed. Since the cut branches off `dev` and the released notes come from `dev`'s `## [Unreleased]` alone, those entries were stamped out of the release section and left orphaned under `## [Unreleased]` on `main`, and the resulting tag covered a combination only ever exercised by the PR merge check. The new guard runs before the branch is created, so a stale `dev` costs nothing to walk away from. `prepare` is unaffected: it runs on `main` and stamps `main`'s own section, never consulting `dev`. Closes #528.
+
 ## [0.4.0-beta.2] - 2026-07-29
 
 ### Added

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -73,6 +73,8 @@ uv run python scripts/release.py release-pr patch
 
 It reads the current version and `## [Unreleased]` from `origin/dev` (not your checked-out branch), confirms the computed target, then opens the PR. After the PR is approved and merged into `main`, cut the release from `main` with `publish` (step 4 below) — deliberately a human step, so the tag push triggers the Release workflow. `release-pr` never tags or publishes.
 
+**Precondition: `origin/dev` must contain every commit on `origin/main`.** Because the cut branches off `dev` and the released notes come from `dev`'s `## [Unreleased]` alone, anything merged straight into `main` — a doc fix, a CI workflow — would be stamped out of the release notes. `release-pr` refuses with the count and the remedy before it creates or pushes anything, so a stale `dev` costs nothing to walk away from: back-merge `main` into `dev`, then re-run. `alpha-pr` enforces the same precondition, since a staging cut that is missing what `main` already shipped does not represent what will ship.
+
 ### The bump, step by step
 
 `release-pr` automates steps 1–2 below off `dev`; they are spelled out here because the bump argument and its guards are what you actually choose. Note that `main` and `dev` both require a pull request, so a locally-prepared commit can never be pushed to either — `prepare` gives you the commit, but it still reaches the branch through a PR.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -330,6 +330,15 @@ def _target_ahead_of_main(target: str, main_version: str) -> bool:
     return Version(target) > Version(main_version)
 
 
+def _main_only_commit_count() -> int:
+    """How many commits ``origin/main`` carries that ``origin/dev`` does not."""
+    return int(
+        capture(
+            ["git", "rev-list", "--count", f"origin/{DEV_BRANCH}..origin/{MAIN_BRANCH}"]
+        )
+    )
+
+
 def _dev_unreleased_body() -> str:
     """The text under ``## [Unreleased]`` in ``origin/dev``'s CHANGELOG."""
     m = UNRELEASED_RE.search(_show_at(f"origin/{DEV_BRANCH}", "CHANGELOG.md"))
@@ -440,6 +449,19 @@ def release_pr(
             f"(v{main_version}); origin/{DEV_BRANCH} (v{current}) is behind "
             f"{MAIN_BRANCH}. Back-merge {MAIN_BRANCH} into {DEV_BRANCH} before "
             "cutting a release."
+        )
+
+    # The same staleness in the shape the version comparison cannot see: a commit
+    # merged straight into main without a bump. The released notes come from
+    # dev's `## [Unreleased]` alone, so the cut would stamp it out of them.
+    # Applies to an alpha too, which must stage what main already shipped.
+    behind = _main_only_commit_count()
+    if behind:
+        raise ReleaseError(
+            f"origin/{MAIN_BRANCH} has {behind} commit(s) not in "
+            f"origin/{DEV_BRANCH}; a cut from {DEV_BRANCH} would omit them. "
+            f"Back-merge {MAIN_BRANCH} into {DEV_BRANCH} before cutting a "
+            "release."
         )
 
     branch = f"rc-{base}/release/v{target}"

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -83,6 +83,15 @@ def test_target_ahead_of_main() -> None:
     assert not _release._target_ahead_of_main("0.3.0-beta.1", "0.3.0-beta.1")
 
 
+def test_main_only_commit_count_reads_the_rev_list_range(monkeypatch) -> None:
+    # The range must be dev..main: reversed, it would count dev's own work and
+    # block every release.
+    seen: list[list[str]] = []
+    monkeypatch.setattr(_release, "capture", lambda cmd: (seen.append(cmd), "2")[1])
+    assert _release._main_only_commit_count() == 2
+    assert seen == [["git", "rev-list", "--count", "origin/dev..origin/main"]]
+
+
 def test_release_pr_body_inlines_content() -> None:
     body = _release._release_pr_body(
         "0.3.0-beta.4", "0.3.0-beta.5", "### Added\n\n- a shipped thing"
@@ -288,6 +297,7 @@ def test_release_pr_still_allows_the_beta_promotion(monkeypatch) -> None:
         lambda ref: "0.5.0-alpha.3" if "dev" in ref else "0.4.0-beta.2",
     )
     monkeypatch.setattr(_release, "branch_exists", lambda b: False)
+    monkeypatch.setattr(_release, "_main_only_commit_count", lambda: 0)
     calls: list[list[str]] = []
     monkeypatch.setattr(_release, "run", lambda cmd, **k: calls.append(cmd))
     monkeypatch.setattr(_release, "capture", lambda cmd: "https://example/pr/1")
@@ -342,10 +352,33 @@ def _stub_release_pr_env(monkeypatch, dev: str, main: str) -> list[list[str]]:
         _release, "_version_at", lambda ref: dev if "dev" in ref else main
     )
     monkeypatch.setattr(_release, "branch_exists", lambda b: False)
+    monkeypatch.setattr(_release, "_main_only_commit_count", lambda: 0)
     monkeypatch.setattr(_release, "run", lambda cmd, **k: calls.append(cmd))
     monkeypatch.setattr(_release, "capture", lambda cmd: "https://example/pr/1")
     monkeypatch.setattr(_release, "_apply_prepare", lambda bump, target, **k: target)
     return calls
+
+
+def test_release_pr_refuses_when_main_has_commits_absent_from_dev(monkeypatch) -> None:
+    # The version guard passes here (dev's alpha sorts above main's beta), so
+    # this is the case only the commit count catches: work merged straight into
+    # main without a bump, whose notes the stamped section would omit.
+    calls = _stub_release_pr_env(monkeypatch, "0.5.0-alpha.3", "0.4.0-beta.2")
+    monkeypatch.setattr(_release, "_main_only_commit_count", lambda: 3)
+    with pytest.raises(_release.ReleaseError, match=r"has 3 commit\(s\) not in"):
+        _release.release_pr("beta", assume_yes=True)
+    # Nothing was created: the operator can walk away at no cost.
+    assert not [c for c in calls if c[:3] == ["git", "checkout", "-b"]]
+    assert not [c for c in calls if c[:2] == ["git", "push"]]
+
+
+def test_alpha_pr_refuses_when_main_has_commits_absent_from_dev(monkeypatch) -> None:
+    # alpha_pr delegates to release_pr, so the guard covers the staging cut too:
+    # an alpha missing what main already shipped does not represent what ships.
+    _stub_release_pr_env(monkeypatch, "0.5.0-alpha.3", "0.4.0-beta.2")
+    monkeypatch.setattr(_release, "_main_only_commit_count", lambda: 1)
+    with pytest.raises(_release.ReleaseError, match=r"has 1 commit\(s\) not in"):
+        _release.alpha_pr("prerelease", assume_yes=True)
 
 
 def test_alpha_pr_targets_dev_and_does_not_stamp(monkeypatch) -> None:


### PR DESCRIPTION
## Motivation

`release-pr` cuts the release branch from `origin/dev` alone, and the released notes come from `dev`'s `## [Unreleased]` section alone. The one guard against a stale `dev` compared version strings, so it only saw divergence that had moved the version. Anything merged straight into `main` without a bump — a doc fix, a CI workflow, a LICENSE — passed it unnoticed.

The result was quiet in the way that matters: nothing errored, the commits themselves survived (the release PR merges into `main`), but their entries were stamped out of the release section and left orphaned under `## [Unreleased]` on `main` afterwards. The gap only surfaced later, when someone read the notes and found a change missing. The tag also covered a combination that only the PR merge check had ever exercised.

This is not hypothetical: `origin/main` currently carries 9 commits absent from `origin/dev` (LICENSE, DCO workflow, security and conduct docs, README banner), none of which touched the version. A release cut today would have dropped all of their notes.

## Outcome

`release-pr` now refuses when `origin/main` has commits absent from `origin/dev`, naming the count and prescribing the back-merge:

```
origin/main has 9 commit(s) not in origin/dev; a cut from dev would omit them.
Back-merge main into dev before cutting a release.
```

The check runs before the branch is created and before the confirmation prompt, so a stale `dev` costs nothing to walk away from — no branch, no push, nothing to unwind. A `dev` that already contains `main` is unaffected.

`alpha-pr` enforces the same precondition, since it delegates to `release_pr`. A staging alpha that is missing what `main` already shipped does not represent what will ship, which matches the existing version guard's stated scope ("Applies to an alpha too"). The practical consequence is that alphas are blocked until someone back-merges.

`prepare` is deliberately left alone. It runs on `main`, `preflight_prepare` requires local `main` to match `origin/main`, and it stamps `main`'s own section — it never consults `dev`, so the failure mode does not exist there. Confirmed by reading the path rather than assumed.

Auto-merging `main` into the release branch was considered and rejected for the reasons in #528: it would leave `dev` still behind, move a conflict past the point of no harm, derive the bump from a tree that no longer exists, and still ship the code without its notes, since the stamp reads `dev`'s `## [Unreleased]` regardless. Forcing the back-merge first is what makes the stamp correct.

## Verification

| # | Scenario | Expected | Observed | Verdict |
|---|---|---|---|---|
| 1 | Real repo state, `main`-only commits that never moved the version | Refuse, naming the count and the remedy | `origin/main has 9 commit(s) not in origin/dev; a cut from dev would omit them. Back-merge main into dev before cutting a release.` | Pass |
| 2 | Guard fires before anything exists | No branch created, no push, tree untouched | No `rc-main/release/v0.5.0-beta.1`; working tree unchanged | Pass |
| 3 | `rev-list` range direction | `origin/dev..origin/main`; reversed, it would count `dev`'s own work and block every release | Pinned by unit test on the exact argv | Pass |
| 4 | Clean `dev`, beta promotion | Proceeds, branches off `origin/dev`, stamps the CHANGELOG | Existing suite passes unchanged | Pass |
| 5 | `alpha-pr` with `main`-only commits | Refuse via the same guard | Unit test | Pass |
| 6 | `prepare` | Unaffected — reads `main`'s own tree | Path read; no `dev` reference | Pass |

Scenarios 1 and 2 were run against the live repository, not stubs.

Gates: `pytest -m "not integration"` (4109 passed, 5 skipped), `ruff check`, `ruff format --check`, `lint-imports`, `bump_version.py verify`. Skills-lint is path-filtered to `skills/**` and is not triggered by this diff.

Closes #528.
