### PR TITLE
docs: identifier map gap-fill for labels, phases, members (#390)

### DIFF
--- a/docs/mcp/tools/identifiers.md
+++ b/docs/mcp/tools/identifiers.md
@@ -20,7 +20,7 @@ The single biggest source of wrong-id errors: the same pipe is addressed by five
 | Argument | Form | Where |
 | --- | --- | --- |
 | `pipe_id` | numeric id | pipes/cards, automations, relations, most tools |
-| `repo_id` | numeric id (string) | observability automation-by-repo logs (`get_automation_logs_by_repo`) |
+| `repo_id` | numeric id (string) | pipe or table id: email templates (`get_email_templates`), observability automation-by-repo logs (`get_automation_logs_by_repo`), optional scope on `get_automation_execution_metrics` |
 | `source_repo_id` | numeric id | knowledge-base data lookups (a UUID is accepted on create but breaks at index time — use the numeric id) |
 | `repo_uuid` | **uuid** | AI agents (`get_ai_agents`, `create_ai_agent`, …), AI agent logs |
 | `pipe_uuid` | **uuid** | knowledge-base tools; pipe report **reads** (`get_pipe_report*`) — report create/update use numeric `pipe_id` |
@@ -59,7 +59,7 @@ A field is addressed by **slug** for one-off card edits, and by **internal_id** 
 ## Per-area quick reference
 
 ### Pipes and cards
-- `get_pipe` / `get_card` / `create_card` / `move_card_to_phase`: numeric ids (`pipe_id`, `card_id`, `destination_phase_id`).
+- `get_pipe` / `get_card` / `create_card` / `move_card_to_phase`: numeric ids (`pipe_id`, `card_id`).
 - `phase_id` / `destination_phase_id`: numeric phase ids on every phase-scoped tool (`get_phase_fields`, `get_phase_cards`, `create_phase_field`, `update_phase`, `delete_phase`, `move_card_to_phase`, `create_card`, field conditions, …). Discover via `get_pipe` → `phases[].id` for workflow phases, or `get_pipe` → `startFormPhaseId` when the tool needs the start form (e.g. `get_phase_cards` / `get_phase_cards_count`).
 - Labels: `label_id` / `label_ids` (on update/delete/`update_card`) are numeric. Discover via `get_labels` or `get_pipe` → `labels[].id`.
 - Field references: see [Field references](#field-references-slug-vs-internal_id) above.

--- a/docs/mcp/tools/identifiers.md
+++ b/docs/mcp/tools/identifiers.md
@@ -20,7 +20,7 @@ The single biggest source of wrong-id errors: the same pipe is addressed by five
 | Argument | Form | Where |
 | --- | --- | --- |
 | `pipe_id` | numeric id | pipes/cards, automations, relations, most tools |
-| `repo_id` | numeric id (string) | pipe or table id: email templates (`get_email_templates`), observability automation-by-repo logs (`get_automation_logs_by_repo`), optional scope on `get_automation_execution_metrics` |
+| `repo_id` | numeric id (string) | email templates (`get_email_templates` — pipe **or table** id), observability automation-by-repo logs (`get_automation_logs_by_repo`), optional scope on `get_automation_execution_metrics` |
 | `source_repo_id` | numeric id | knowledge-base data lookups (a UUID is accepted on create but breaks at index time — use the numeric id) |
 | `repo_uuid` | **uuid** | AI agents (`get_ai_agents`, `create_ai_agent`, …), AI agent logs |
 | `pipe_uuid` | **uuid** | knowledge-base tools; pipe report **reads** (`get_pipe_report*`) — report create/update use numeric `pipe_id` |

--- a/docs/mcp/tools/identifiers.md
+++ b/docs/mcp/tools/identifiers.md
@@ -60,7 +60,14 @@ A field is addressed by **slug** for one-off card edits, and by **internal_id** 
 
 ### Pipes and cards
 - `get_pipe` / `get_card` / `create_card` / `move_card_to_phase`: numeric ids (`pipe_id`, `card_id`, `destination_phase_id`).
+- `phase_id` / `destination_phase_id`: numeric phase ids on every phase-scoped tool (`get_phase_fields`, `get_phase_cards`, `create_phase_field`, `update_phase`, `delete_phase`, `move_card_to_phase`, `create_card`, field conditions, …). Discover via `get_pipe` → `phases[].id` for workflow phases, or `get_pipe` → `startFormPhaseId` when the tool needs the start form (e.g. `get_phase_cards` / `get_phase_cards_count`).
+- Labels: `label_id` / `label_ids` (on update/delete/`update_card`) are numeric. Discover via `get_labels` or `get_pipe` → `labels[].id`.
 - Field references: see [Field references](#field-references-slug-vs-internal_id) above.
+
+### Members, email, webhooks
+- Members: `invite_members` addresses by **email** + `role_name` (not by id). `set_role(member_id)` and `remove_member_from_pipe(user_ids)` take the **user** id — `member_id` is that user id despite the name. Prefer numeric `user.id` from `get_pipe_members`; remove also accepts a user UUID.
+- Email templates: `get_email_templates(repo_id)` — `repo_id` is a numeric **pipe or table** id (not an org id). `email_template_id` is numeric; discover via `get_email_templates`.
+- Webhooks: `webhook_id` is numeric; discover via `get_webhooks(pipe_id)` → `id`.
 
 ### AI agents and knowledge bases
 - AI agent tools scope by `repo_uuid` (pipe **UUID**); the agent itself is addressed by its own `uuid`.

--- a/packages/mcp/src/pipefy_mcp/tools/member_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/member_tools.py
@@ -192,7 +192,8 @@ class MemberTools:
 
             Args:
                 pipe_id: ID of the pipe.
-                user_ids: List of user IDs to remove.
+                user_ids: User ids to remove. Prefer numeric ``user.id`` from
+                    ``get_pipe_members``; a user UUID is also accepted.
                 confirm: Set to True to execute the removal (step 2).
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
@@ -264,7 +265,8 @@ class MemberTools:
 
             Args:
                 pipe_id: ID of the pipe.
-                member_id: User ID of the member.
+                member_id: User id of the member (not a membership row id).
+                    Discover via: ``get_pipe_members`` → ``user.id``.
                 role_name: New role name (e.g. 'member', 'admin').
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """

--- a/skills/members-email-webhooks/pipefy-members-email-webhooks/SKILL.md
+++ b/skills/members-email-webhooks/pipefy-members-email-webhooks/SKILL.md
@@ -18,10 +18,10 @@ Manage pipe membership, send emails from card inboxes, read inbox replies, and m
 |------------|-----|-----------|---------|
 | `invite_members` | `pipefy member invite` | No | Invite one or more users by email + role. |
 | `add_service_account_to_pipe` | `pipefy member add-service-account` | No | Attach an existing org **service account** to a pipe by email + role (iPaaS setup). Verifies membership afterwards. |
-| `remove_member_from_pipe` | `pipefy member remove` | No | **Two-step destructive.** Warns on external emails. |
-| `set_role` | `pipefy member set-role` | No | Change a member's pipe role. |
+| `remove_member_from_pipe` | `pipefy member remove` | No | **Two-step destructive.** Remove by numeric user id (`user_ids`). |
+| `set_role` | `pipefy member set-role` | No | Change a member's pipe role (`member_id` = user id). |
 
-List existing members with `get_pipe_members` from [skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md](../../pipes-and-cards/pipefy-pipes-and-cards/SKILL.md).
+List existing members with `get_pipe_members` from [skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md](../../pipes-and-cards/pipefy-pipes-and-cards/SKILL.md). Id forms: [`docs/mcp/tools/identifiers.md`](../../../docs/mcp/tools/identifiers.md) (Members, email, webhooks).
 
 ### Steps — invite members
 
@@ -65,8 +65,8 @@ When setting up an iPaaS (Advanced Automations) flow that runs under a **service
 |------------|-----|-----------|---------|
 | `get_card_inbox_emails` | `pipefy email inbox list --card <id>` | Yes | Read emails in a card's inbox. |
 | `send_inbox_email` | `pipefy email inbox send` | No | Send an email from a card inbox. |
-| `get_email_templates` | `pipefy email template list --repo <id>` | Yes | List org-level email templates. |
-| `send_email_with_template` | `pipefy email template send` | No | Send using a template (substitutes variables). |
+| `get_email_templates` | `pipefy email template list --repo <id>` | Yes | List templates for a pipe or table (`repo_id` numeric). |
+| `send_email_with_template` | `pipefy email template send` | No | Send using a template (`email_template_id` from that list). |
 
 ### Steps — send a card inbox email
 

--- a/skills/members-email-webhooks/pipefy-members-email-webhooks/SKILL.md
+++ b/skills/members-email-webhooks/pipefy-members-email-webhooks/SKILL.md
@@ -18,10 +18,10 @@ Manage pipe membership, send emails from card inboxes, read inbox replies, and m
 |------------|-----|-----------|---------|
 | `invite_members` | `pipefy member invite` | No | Invite one or more users by email + role. |
 | `add_service_account_to_pipe` | `pipefy member add-service-account` | No | Attach an existing org **service account** to a pipe by email + role (iPaaS setup). Verifies membership afterwards. |
-| `remove_member_from_pipe` | `pipefy member remove` | No | **Two-step destructive.** Remove by numeric user id (`user_ids`). |
+| `remove_member_from_pipe` | `pipefy member remove` | No | **Two-step destructive.** Verifies afterwards and warns if the member is still present (org-level permissions can override pipe removal). |
 | `set_role` | `pipefy member set-role` | No | Change a member's pipe role (`member_id` = user id). |
 
-List existing members with `get_pipe_members` from [skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md](../../pipes-and-cards/pipefy-pipes-and-cards/SKILL.md). Id forms: [`docs/mcp/tools/identifiers.md`](../../../docs/mcp/tools/identifiers.md) (Members, email, webhooks).
+List existing members with `get_pipe_members` from [skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md](../../pipes-and-cards/pipefy-pipes-and-cards/SKILL.md). Id forms: [`docs/mcp/tools/identifiers.md#members-email-webhooks`](../../../docs/mcp/tools/identifiers.md#members-email-webhooks).
 
 ### Steps — invite members
 


### PR DESCRIPTION
## Summary
Residual gap-fill for closed [#390](https://github.com/pipefy/ai-toolkit/issues/390) (related only — **no Closes**). Extends the canonical map in `docs/mcp/tools/identifiers.md` and aligns the members-email-webhooks skill + member tool Args.

### Lines added to the map
- `phase_id` / `destination_phase_id` — numeric; discover via `get_pipe` → `phases[].id` or `startFormPhaseId` for start-form consumers
- Labels — `label_id` / `label_ids` numeric on update/delete/`update_card`; discover via `get_labels` / `get_pipe`
- Members — invite by email; `set_role(member_id)` / `remove_member_from_pipe(user_ids)` use user id (`member_id` is that user id despite the name)
- Email templates — `repo_id` = pipe or table numeric id; `email_template_id` via `get_email_templates`
- Webhooks — `webhook_id` numeric; discover via `get_webhooks`

### Also
- Skill: drop incorrect “org-level templates” / “warns on external emails” claims; link the map
- MCP: `set_role` / `remove_member_from_pipe` Args document discovery and UUID acceptance on remove

## Test plan
- [x] `uv run python .github/workflows/scripts/lint_skill_refs.py`
- [x] `uv run ruff check` / `ruff format --check` on `member_tools.py`
- [x] Disclosure grep clean on `git diff origin/dev...HEAD`
- [ ] Spot-check map bullets against live tool Args in Cursor MCP (optional)