### PR TITLE
fix(auth): delete an unreadable keychain entry on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **CLI (`pipefy auth logout`)**: a stored keychain entry that exists but cannot be parsed — stale, corrupt, or written by an older schema — is now deleted instead of being reported as `Not signed in. Nothing to do.` while surviving on disk. The decision comes from entry **presence** (`session_entry_presence` in `pipefy_auth.storage`: `present` / `absent` / `unknown`) rather than from `load_session`, which collapses all three into one `None`. Revocation needs a readable refresh token, so an unreadable entry is delete-only and stderr says the token stays valid at the IdP until natural expiry. When the presence probe itself fails and nothing is deleted, the command claims neither removal nor a clean machine and exits 1. Revoke-failure warnings, the revoke-then-delete order, and the exit-1 manual-removal hint on a rejected delete are unchanged. (#538)
 - **AI agents (active lifecycle)**: create can start inactive (`create_ai_agent(active=false)` / `pipefy agent create --inactive`) by sending `disabledAt` on create and the chained update so the second step does not revive; routine update preserves `disabledAt` (optional `disabled_at` / `--disabled-at` pass-through skips the re-read; use `toggle_ai_agent_status` / `pipefy agent toggle` to activate or deactivate); create/update success payloads expose `disabled_at` and `active`; partial-failure envelopes surface shell `disabled_at` and a toggle recovery hint. Skills document the contract. (#520)
 
 ### Added

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -161,20 +161,25 @@ The shape is stable across all sources (fields you don't have are `null` rather 
 
 POSTs the stored refresh token to the IdP's `end_session_endpoint` (advertised in the OIDC discovery document) and removes the keychain entry. Without server-side revocation the refresh token would remain valid at the IdP until natural expiry — anyone who recovered it from a backup could still mint new access tokens.
 
-The command always clears the local keychain entry once it runs, even when the IdP round-trip fails. The two non-happy paths surface a stderr warning so the user knows whether server-side revocation succeeded:
+Whether there is anything to clear is decided by the **presence** of a keychain entry, not by whether that entry parses: a stale, corrupt, or schema-drifted entry is still a credential on disk and is removed. The command always clears the local entry once it runs, even when the IdP round-trip fails. The non-happy paths surface a stderr warning so the user knows whether server-side revocation succeeded:
 
 - **Revocation network / non-2xx failure** — stderr `Could not revoke refresh token at the IdP: <reason>. Clearing local session anyway; the refresh token may remain valid at the server until natural expiry.`
 - **IdP doesn't advertise `end_session_endpoint`** — stderr `Pipefy auth server does not advertise a logout endpoint; the refresh token could not be revoked server-side. Clearing local session only.` (OIDC Discovery 1.0 makes the field optional; Keycloak ships it.)
+- **Entry present but unreadable** — revocation needs a readable refresh token, so the entry is delete-only: stdout `Removed an unreadable Pipefy session entry (<issuer>).` and stderr `The stored session entry could not be read, so its refresh token could not be revoked at the IdP; that token remains valid at the server until natural expiry.` Nothing was revoked server-side, so the unrevoked refresh token stays usable at the IdP until it expires on its own.
+- **Keychain read failed and nothing was deleted** — presence could not be established, so the command claims neither removal nor a clean machine: stderr `Could not read the keychain to check for a stored session (<issuer>), and no entry was removed. A credential may still be present; check for it manually via your OS keychain (service: 'pipefy').` and exit 1.
 
-When no session is stored, `pipefy auth logout` prints `Not signed in. Nothing to do.` and exits 0 — idempotent, matching `gh auth logout` and similar CLIs.
+When no entry is stored, `pipefy auth logout` prints `Not signed in. Nothing to do.` and exits 0 — idempotent, matching `gh auth logout` and similar CLIs.
 
 ##### Exit codes
 
 | Case | Exit |
 |------|------|
 | `PIPEFY_AUTH_URL=""` (or any other `PIPEFY_*` env var set to empty) | **2** — pydantic rejects empty values at settings load. Unset the var to fall back to the prod default. |
-| No session stored (no-op) | **0** |
+| No entry stored (no-op) | **0** |
 | Session cleared (revoke succeeded, failed, or unsupported) | **0** |
+| Unreadable entry cleared (no server-side revoke) | **0** |
+| Keychain rejected the delete | **1** — the credential may survive; the message names the manual removal step. |
+| Keychain read failed and no entry was deleted | **1** — presence unknown, so neither removal nor "nothing to do" can be claimed. |
 
 ### Pipefy issuer URLs
 
@@ -220,7 +225,7 @@ The login worked but `keyring` couldn't write the entry.
 
 **macOS (Keychain / `Keyring` backend).** OAuth can succeed while persistence fails with `Can't store password on keychain: (-25244, 'Unknown Error')`. That code is `errSecInvalidOwnerEdit` from Security.framework ("Invalid attempt to change the owner of this item") — not `errSecParam` (`-50`). The `keyring` macOS backend deletes any existing item and re-adds it on every write, so a stale entry created by another Python binary (for example a previous `uvx` cache path, or a login from Terminal.app followed by a write from an IDE/agent host) can surface this error. The root cause is not fully pinned; treat the steps below as remediation, not a proven mechanism.
 
-1. Clear the entry with `pipefy auth logout`. If it reports `Not signed in. Nothing to do.` (or fails), remove it directly with `security delete-generic-password -s pipefy` — today logout early-returns when `load_session` cannot read the item, so a stale/unreadable entry can look like "already clean" without deleting anything.
+1. Clear the entry with `pipefy auth logout`, which removes a stored entry even when that entry can no longer be parsed. If it fails, remove the entry directly with `security delete-generic-password -s pipefy`.
 2. Run `pipefy auth login` again.
 3. Prefer running that login from a regular **Terminal.app** session; if macOS prompts for keychain access, click **Always Allow**.
 4. If the OS keychain remains unusable, set `PIPEFY_KEYCHAIN_BACKEND=file` (plaintext under the Pipefy config directory) or use a static `PIPEFY_TOKEN`.

--- a/packages/auth/src/pipefy_auth/__init__.py
+++ b/packages/auth/src/pipefy_auth/__init__.py
@@ -47,12 +47,14 @@ from pipefy_auth.revoke import (
 from pipefy_auth.settings import AuthSettings, JwtValidationSettings
 from pipefy_auth.storage import (
     SessionDeleteError,
+    SessionEntryPresence,
     StoredSession,
     configure_keychain_backend,
     delete_session,
     keychain_backend_name,
     keychain_key,
     load_session,
+    session_entry_presence,
     store_session,
 )
 from pipefy_auth.verification import (
@@ -85,6 +87,7 @@ __all__ = [
     "ServiceAccount",
     "ServiceAccountAuth",
     "SessionDeleteError",
+    "SessionEntryPresence",
     "StaticBearerAuth",
     "StaticTokenAuth",
     "StoredSession",
@@ -106,5 +109,6 @@ __all__ = [
     "resolve_pipefy_auth",
     "revoke_session",
     "run_login",
+    "session_entry_presence",
     "store_session",
 ]

--- a/packages/auth/src/pipefy_auth/storage.py
+++ b/packages/auth/src/pipefy_auth/storage.py
@@ -158,8 +158,43 @@ def store_session(
     return session
 
 
+SessionEntryPresence = Literal["present", "absent", "unknown"]
+
+
+def session_entry_presence(*, issuer: str, client_id: str) -> SessionEntryPresence:
+    """Report whether a keychain entry exists, without parsing its contents.
+
+    An entry that exists but cannot be parsed is ``"present"``: a caller whose
+    job is to clear the credential needs presence, not readability, and
+    :func:`load_session` cannot supply it because it collapses "absent",
+    "unreadable" and "backend failed" into ``None``.
+
+    Returns:
+        ``"present"`` when the backend returns a blob of any content,
+        ``"absent"`` when it returns nothing, and ``"unknown"`` when the
+        backend itself fails. ``"unknown"`` means presence was not
+        established: no caller may then report the credential as removed, or
+        as never having been there.
+    """
+    import keyring
+    from keyring.errors import KeyringError
+
+    try:
+        blob = keyring.get_password(_SERVICE, keychain_key(issuer, client_id))
+    except KeyringError:
+        return "unknown"
+    return "absent" if blob is None else "present"
+
+
 def load_session(*, issuer: str, client_id: str) -> StoredSession | None:
-    """Return the stored session for this issuer + client, or ``None`` if absent."""
+    """Return the stored session for this issuer + client, or ``None``.
+
+    ``None`` means "no usable session", which covers three distinct states:
+    no entry, an entry that fails validation, and a backend that refused the
+    read. Callers that must distinguish them — anything that deletes, or that
+    reports the credential as gone — need
+    :func:`session_entry_presence` instead.
+    """
     import keyring
     from keyring.errors import KeyringError
 
@@ -210,11 +245,13 @@ def keychain_backend_name() -> str:
 
 __all__ = [
     "SessionDeleteError",
+    "SessionEntryPresence",
     "StoredSession",
     "configure_keychain_backend",
     "delete_session",
     "keychain_backend_name",
     "keychain_key",
     "load_session",
+    "session_entry_presence",
     "store_session",
 ]

--- a/packages/auth/tests/test_storage_backend.py
+++ b/packages/auth/tests/test_storage_backend.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import keyring
 import pytest
 from conftest import InMemoryKeyring
+from keyring.errors import KeyringError
 from keyrings.alt.file import PlaintextKeyring
 from pydantic import ValidationError
 
@@ -20,6 +21,7 @@ from pipefy_auth.storage import (
     configure_keychain_backend,
     keychain_key,
     load_session,
+    session_entry_presence,
     store_session,
 )
 
@@ -207,6 +209,61 @@ def test_load_session_returns_none_when_required_field_missing(
         json.dumps({"issuer": _ISSUER, "client_id": _CLIENT_ID, "obtained_at": 1}),
     )
     assert load_session(issuer=_ISSUER, client_id=_CLIENT_ID) is None
+
+
+# --------------------------------------------------------------------------- #
+# session_entry_presence                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_presence_is_absent_when_nothing_stored(
+    fake_keyring: InMemoryKeyring,
+) -> None:
+    assert session_entry_presence(issuer=_ISSUER, client_id=_CLIENT_ID) == "absent"
+
+
+@pytest.mark.unit
+def test_presence_is_present_for_a_readable_entry(
+    fake_keyring: InMemoryKeyring,
+) -> None:
+    store_session(issuer=_ISSUER, client_id=_CLIENT_ID, token=_token())
+    assert session_entry_presence(issuer=_ISSUER, client_id=_CLIENT_ID) == "present"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "blob",
+    [
+        pytest.param("{not json", id="corrupt-json"),
+        pytest.param(
+            json.dumps({"issuer": _ISSUER, "client_id": _CLIENT_ID, "obtained_at": 1}),
+            id="schema-drift",
+        ),
+        pytest.param("", id="empty-string"),
+    ],
+)
+@pytest.mark.usefixtures("fake_keyring")
+def test_presence_is_present_for_an_unparseable_entry(blob: str) -> None:
+    """The whole point: an entry ``load_session`` cannot parse still exists."""
+    keyring.set_password(_SERVICE, keychain_key(_ISSUER, _CLIENT_ID), blob)
+
+    assert load_session(issuer=_ISSUER, client_id=_CLIENT_ID) is None
+    assert session_entry_presence(issuer=_ISSUER, client_id=_CLIENT_ID) == "present"
+
+
+@pytest.mark.unit
+def test_presence_is_unknown_when_the_backend_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backend that refuses the read leaves presence unestablished."""
+
+    def _boom(service: str, username: str) -> str | None:
+        raise KeyringError("keychain is locked")
+
+    monkeypatch.setattr(keyring, "get_password", _boom)
+
+    assert session_entry_presence(issuer=_ISSUER, client_id=_CLIENT_ID) == "unknown"
 
 
 @pytest.mark.unit

--- a/packages/cli/src/pipefy_cli/commands/_auth_keychain_hints.py
+++ b/packages/cli/src/pipefy_cli/commands/_auth_keychain_hints.py
@@ -22,8 +22,7 @@ _LINUX_HINT = (
 _MACOS_HINT = (
     "macOS Keychain rejected the write (often errSecInvalidOwnerEdit, -25244: "
     "invalid attempt to change the owner of this item). Clear the entry with "
-    "`pipefy auth logout`; if it reports `Not signed in. Nothing to do.` "
-    "(or fails), remove it directly with "
+    "`pipefy auth logout`; if that fails, remove it directly with "
     "`security delete-generic-password -s pipefy`. Then run "
     "`pipefy auth login` again from Terminal.app and click Always Allow if "
     f"prompted. {_ESCAPE_HATCH}"

--- a/packages/cli/src/pipefy_cli/commands/auth.py
+++ b/packages/cli/src/pipefy_cli/commands/auth.py
@@ -29,6 +29,7 @@ from pipefy_auth import (
     load_session,
     revoke_session,
     run_login,
+    session_entry_presence,
     store_session,
 )
 from pipefy_auth.settings import _LEGACY_ENV_KEYS_TO_NEW
@@ -443,9 +444,46 @@ def auth_status(
     _render(report, json_out=json_out)
 
 
+_UNREADABLE_NOT_REVOKED = (
+    "The stored session entry could not be read, so its refresh token could "
+    "not be revoked at the IdP; that token remains valid at the server until "
+    "natural expiry."
+)
+
+
+def _revoke_or_warning(
+    *,
+    issuer: str,
+    client_id: str,
+    refresh_token: str,
+    policy: DiscoveryPolicy,
+) -> str | None:
+    """Revoke at the IdP; return a stderr warning when revocation did not happen."""
+    try:
+        revoke_session(
+            issuer=issuer,
+            client_id=client_id,
+            refresh_token=refresh_token,
+            policy=policy,
+        )
+    except RevocationUnsupportedError:
+        return (
+            "Pipefy auth server does not advertise a logout endpoint; the "
+            "refresh token could not be revoked server-side. Clearing local "
+            "session only."
+        )
+    except RevocationError as exc:
+        return (
+            f"Could not revoke refresh token at the IdP: {exc}. Clearing "
+            "local session anyway; the refresh token may remain valid at the "
+            "server until natural expiry."
+        )
+    return None
+
+
 @auth_app.command("logout")
 def auth_logout(ctx: typer.Context) -> None:
-    """Revoke the stored refresh token at the IdP and clear the local session."""
+    """Clear the local session, revoking the refresh token when it can be read."""
     settings, auth = settings_and_auth_from_ctx(ctx)
     if auth.oidc_client is None:
         typer.echo(
@@ -457,38 +495,28 @@ def auth_logout(ctx: typer.Context) -> None:
     issuer = auth.oidc_client.issuer_url
     client_id = auth.oidc_client.client_id
 
-    session = load_session(issuer=issuer, client_id=client_id)
-    if session is None:
+    # Presence, not readability, decides whether there is anything to clear: a
+    # corrupt or schema-drifted entry is still a credential on disk.
+    presence = session_entry_presence(issuer=issuer, client_id=client_id)
+    if presence == "absent":
         typer.echo("Not signed in. Nothing to do.")
         return
 
     # Revoke at the IdP first — once we delete the keychain entry we no longer
     # have the refresh_token to send. On any revoke failure still proceed to
-    # delete (warning makes the difference honest: server-side credential may
-    # remain valid until natural expiry).
+    # delete, and warn, because the server-side credential may remain valid.
+    session = load_session(issuer=issuer, client_id=client_id)
     revoke_warning: str | None = None
-    try:
-        revoke_session(
+    if session is not None:
+        revoke_warning = _revoke_or_warning(
             issuer=issuer,
             client_id=client_id,
             refresh_token=session.token.refresh_token,
             policy=DiscoveryPolicy(allow_insecure_urls=settings.allow_insecure_urls),
         )
-    except RevocationUnsupportedError:
-        revoke_warning = (
-            "Pipefy auth server does not advertise a logout endpoint; the "
-            "refresh token could not be revoked server-side. Clearing local "
-            "session only."
-        )
-    except RevocationError as exc:
-        revoke_warning = (
-            f"Could not revoke refresh token at the IdP: {exc}. Clearing "
-            "local session anyway; the refresh token may remain valid at the "
-            "server until natural expiry."
-        )
 
     try:
-        delete_session(issuer=issuer, client_id=client_id)
+        deleted = delete_session(issuer=issuer, client_id=client_id)
     except SessionDeleteError as exc:
         if revoke_warning:
             typer.echo(revoke_warning, err=True)
@@ -500,9 +528,26 @@ def auth_logout(ctx: typer.Context) -> None:
         )
         raise typer.Exit(1) from exc
 
-    if revoke_warning:
-        typer.echo(revoke_warning, err=True)
-    typer.echo(f"Signed out of Pipefy ({issuer}).")
+    if session is not None:
+        if revoke_warning:
+            typer.echo(revoke_warning, err=True)
+        typer.echo(f"Signed out of Pipefy ({issuer}).")
+        return
+    if deleted:
+        typer.echo(_UNREADABLE_NOT_REVOKED, err=True)
+        typer.echo(f"Removed an unreadable Pipefy session entry ({issuer}).")
+        return
+    if presence == "unknown":
+        typer.echo(
+            "Could not read the keychain to check for a stored session "
+            f"({issuer}), and no entry was removed. A credential may still be "
+            "present; check for it manually via your OS keychain (service: "
+            f"'pipefy'). See {DOCS_CLI_AUTH_REF}.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    # Probed as present, gone by the time we deleted: a concurrent logout won.
+    typer.echo("Not signed in. Nothing to do.")
 
 
 __all__ = ["auth_app"]

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -816,8 +816,8 @@ Usage: pipefy auth [OPTIONS] COMMAND [ARGS]...
 │          keychain.                                                           │
 │ status   Print which auth source is active, the authenticated identity, and  │
 │          session expiry.                                                     │
-│ logout   Revoke the stored refresh token at the IdP and clear the local      │
-│          session.                                                            │
+│ logout   Clear the local session, revoking the refresh token when it can be  │
+│          read.                                                               │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 
 ### HELP auth/login
@@ -839,7 +839,7 @@ Usage: pipefy auth login [OPTIONS]
 ### HELP auth/logout
 Usage: pipefy auth logout [OPTIONS]
 
- Revoke the stored refresh token at the IdP and clear the local session.
+ Clear the local session, revoking the refresh token when it can be read.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │

--- a/packages/cli/tests/test_auth_keychain_hints.py
+++ b/packages/cli/tests/test_auth_keychain_hints.py
@@ -15,7 +15,6 @@ from pipefy_cli.commands import _auth_keychain_hints as hints
             [
                 "errSecInvalidOwnerEdit",
                 "pipefy auth logout",
-                "Not signed in. Nothing to do.",
                 "security delete-generic-password -s pipefy",
                 "Terminal.app",
                 "Always Allow",

--- a/packages/cli/tests/test_auth_logout.py
+++ b/packages/cli/tests/test_auth_logout.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import httpx
+import keyring
 import pytest
 from conftest import InMemoryKeyring
+from keyring.errors import KeyringError
 from pipefy_auth import revoke, storage
 from pipefy_auth.responses import TokenResponse
 
@@ -17,6 +19,8 @@ from pipefy_cli.main import app as cli_app
 
 _ISSUER = "https://example.test/realms/foo"
 _LOGOUT_URL = f"{_ISSUER}/protocol/openid-connect/logout"
+_SERVICE = "pipefy"
+_CLIENT_ID = "pipefy-cli"
 
 
 def _discovery_payload(*, include_end_session: bool = True) -> dict:
@@ -299,3 +303,153 @@ class TestAuthLogoutCommand:
         assert f"Signed out of Pipefy ({_ISSUER})." in result.stdout
         assert "does not advertise a logout endpoint" in result.stderr
         assert storage.load_session(issuer=_ISSUER, client_id="pipefy-cli") is None
+
+
+# --------------------------------------------------------------------------- #
+# Command — an entry that exists but cannot be read                           #
+# --------------------------------------------------------------------------- #
+
+_KEY = storage.keychain_key(_ISSUER, _CLIENT_ID)
+
+
+def _store_unreadable_entry(blob: str = "{not json") -> None:
+    keyring.set_password(_SERVICE, _KEY, blob)
+
+
+def _forbid_revoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Revocation needs a readable refresh token; an unreadable entry must not try."""
+
+    def _never(**_kwargs: object) -> None:
+        raise AssertionError("revoke_session must not be called without a session")
+
+    monkeypatch.setattr(auth_module, "revoke_session", _never)
+
+
+def _break_keychain_reads(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(service: str, username: str) -> str | None:
+        raise KeyringError("keychain is locked")
+
+    monkeypatch.setattr(keyring, "get_password", _boom)
+
+
+class TestAuthLogoutUnreadableEntry:
+    def test_unreadable_entry_is_deleted_without_revocation(
+        self,
+        runner,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+        _store_unreadable_entry()
+        _forbid_revoke(monkeypatch)
+
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 0, result.stderr
+        assert f"Removed an unreadable Pipefy session entry ({_ISSUER})." in (
+            result.stdout
+        )
+        assert "could not be read" in result.stderr
+        assert "remains valid at the server until natural expiry" in result.stderr
+        assert fake_keyring.get_password(_SERVICE, _KEY) is None
+
+    def test_schema_drifted_entry_is_deleted(
+        self,
+        runner,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        """Valid JSON that no longer validates is still a credential to remove."""
+        monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+        _store_unreadable_entry('{"issuer": "x", "unexpected": 1}')
+        _forbid_revoke(monkeypatch)
+
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 0, result.stderr
+        assert "Removed an unreadable Pipefy session entry" in result.stdout
+        assert fake_keyring.get_password(_SERVICE, _KEY) is None
+
+    def test_unreadable_entry_delete_failure_exits_1(
+        self,
+        runner,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+        _store_unreadable_entry()
+        _forbid_revoke(monkeypatch)
+
+        def _delete_boom(*, issuer: str, client_id: str) -> bool:
+            raise storage.SessionDeleteError("Keychain is locked")
+
+        monkeypatch.setattr(auth_module, "delete_session", _delete_boom)
+
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 1
+        assert "Removed an unreadable" not in result.stdout
+        assert "Could not delete local session from the keychain" in result.stderr
+        assert "remove it manually" in result.stderr
+
+    def test_probe_failure_still_deletes_and_reports_removal(
+        self,
+        runner,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        """Presence unknown, delete succeeded: the entry existed and is gone."""
+        monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+        _store_unreadable_entry()
+        _forbid_revoke(monkeypatch)
+        _break_keychain_reads(monkeypatch)
+
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 0, result.stderr
+        assert "Removed an unreadable Pipefy session entry" in result.stdout
+        assert fake_keyring.get_password(_SERVICE, _KEY) is None
+
+    def test_probe_failure_with_no_delete_exits_1_without_claiming_clean(
+        self,
+        runner,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        """Presence unknown and nothing removed: never report a clean machine."""
+        monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+        _forbid_revoke(monkeypatch)
+        _break_keychain_reads(monkeypatch)
+
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 1
+        assert result.stdout == ""
+        assert "Could not read the keychain" in result.stderr
+        assert "A credential may still be present" in result.stderr
+
+    def test_entry_vanishing_between_probe_and_delete_is_nothing_to_do(
+        self,
+        runner,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_keyring: InMemoryKeyring,
+        clean_pipefy_env,
+        saved_cwd,
+    ) -> None:
+        monkeypatch.setenv("PIPEFY_AUTH_URL", _ISSUER)
+        _store_unreadable_entry()
+        _forbid_revoke(monkeypatch)
+
+        def _already_gone(*, issuer: str, client_id: str) -> bool:
+            return False
+
+        monkeypatch.setattr(auth_module, "delete_session", _already_gone)
+
+        result = runner.invoke(cli_app, ["auth", "logout"])
+        assert result.exit_code == 0, result.stderr
+        assert "Not signed in. Nothing to do." in result.stdout

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -32,7 +32,7 @@ Full reference (every `PIPEFY_*` variable, validation rules, TOML schema, preced
 
 ### macOS keychain `errSecInvalidOwnerEdit (-25244)`
 
-`pipefy auth login` may exit with `errSecInvalidOwnerEdit (-25244)` ("Invalid attempt to change the owner of this item") at the final keychain-write step even though OAuth itself succeeded. Clear the entry with `pipefy auth logout`; if it reports `Not signed in. Nothing to do.` (or fails), remove it with `security delete-generic-password -s pipefy`. Then run `pipefy auth login` again from Terminal.app and click **Always Allow** if prompted. If the OS keychain remains unusable, set `PIPEFY_KEYCHAIN_BACKEND=file` or use a static `PIPEFY_TOKEN`. See [`docs/cli/auth.md`](../../docs/cli/auth.md) for the full platform-specific troubleshooting.
+`pipefy auth login` may exit with `errSecInvalidOwnerEdit (-25244)` ("Invalid attempt to change the owner of this item") at the final keychain-write step even though OAuth itself succeeded. Clear the entry with `pipefy auth logout`, which removes a stored entry even when that entry can no longer be parsed; if it fails, remove the entry with `security delete-generic-password -s pipefy`. Then run `pipefy auth login` again from Terminal.app and click **Always Allow** if prompted. If the OS keychain remains unusable, set `PIPEFY_KEYCHAIN_BACKEND=file` or use a static `PIPEFY_TOKEN`. See [`docs/cli/auth.md`](../../docs/cli/auth.md) for the full platform-specific troubleshooting.
 
 ### Claude Code: `claude mcp add` (per-project terminal flow)
 


### PR DESCRIPTION
## Motivation

`pipefy auth logout` reported `Not signed in. Nothing to do.` while leaving the credential on disk. It branched on whether `load_session` returned a session, and `load_session` collapses three different states into one `None`: no entry, an entry that fails validation, and a keychain backend that refused the read. A stale, corrupt, or schema-drifted entry therefore looked like an already-clean machine.

Two things depended on that being wrong. The macOS `errSecInvalidOwnerEdit` remediation in `docs/cli/auth.md` told the user to fall back to `security delete-generic-password` precisely because logout could not be trusted, and the teardown work in #536 needs logout to actually delete.

## Outcome

Logout branches on entry presence. `session_entry_presence` in `pipefy_auth.storage` returns `present`, `absent`, or `unknown`, reading the entry without parsing it, so the decision rests on positive evidence gathered before anything is destroyed rather than on a delete failure after the fact.

Four outcomes are now distinguishable:

| State | stdout | Exit |
|---|---|---|
| Signed out and revoked | `Signed out of Pipefy (<issuer>).` | 0 |
| Entry present but unreadable | `Removed an unreadable Pipefy session entry (<issuer>).` plus a stderr line saying the refresh token was not revoked and stays valid at the IdP until natural expiry | 0 |
| No entry | `Not signed in. Nothing to do.` | 0 |
| Keychain read failed and nothing was deleted | stderr only: presence is unknown, so the command claims neither removal nor a clean machine | 1 |

Revocation needs a readable refresh token, so an unreadable entry is delete-only and says so instead of implying the credential is dead. The revoke-then-delete order, the revoke-failure warnings, and the exit-1 manual-removal hint on a rejected delete are unchanged — the revoke block moved into `_revoke_or_warning` verbatim so its existing tests cover it untouched.

An empty-string entry counts as present. `load_session` treats a falsy blob as `None`, so keying presence on readability would have let an empty entry survive a logout that reported success.

The stale caveat lived in three places, not the one the issue named: `docs/cli/auth.md`, `packages/mcp/README.md`, and the runtime macOS hint in `_auth_keychain_hints.py`. All three now describe presence-based deletion.

## Notes

Costs one extra `get_password` on the signed-in path, since presence is probed before the session is loaded. Inferring absence from `PasswordDeleteError` would avoid it, but that derives "there was nothing there" from a failure signal — the same class of bug this fixes.

Verified with the in-memory keyring in `packages/cli/tests/conftest.py`; no test touches a real keychain. Not verified against a real macOS keychain in the `errSecInvalidOwnerEdit` state, which is the condition the doc caveat described.

Closes #538
