### PR TITLE
feat(uninstall): teardown with tiered approval and client adapters

### DIFF
--- a/tests/test_uninstall_scan.py
+++ b/tests/test_uninstall_scan.py
@@ -1051,33 +1051,54 @@ def test_dry_run_is_accepted_and_changes_nothing(tmp_path):
     assert sorted(p.name for p in home.iterdir()) == before
 
 
-def test_script_contains_no_removal_verbs():
-    """Detection only: the phase guarantee is that a scan cannot damage anything."""
-    body = _SCRIPT.read_text(encoding="utf-8")
-    forbidden = (
-        "rm -",
-        "rmdir",
-        "mv ",
-        "uv tool uninstall",
-        "claude mcp remove",
-        "security delete",
-        "secret-tool clear",
-        "os.replace",
-        "os.remove",
-        "shutil.rmtree",
-        "truncate",
+def test_a_scan_reaches_no_removal_verb(tmp_path):
+    """A scan cannot damage anything, and the proof is behavioural.
+
+    The script does remove things in its other modes, so the guarantee is no
+    longer a grep for `rm`. It is that `--scan` leaves the tree byte-identical
+    and never calls a command that could change it.
+    """
+    home = _home(tmp_path)
+    _write_json(
+        home / ".claude.json",
+        {"mcpServers": {"pipefy": {"command": "pipefy-mcp-server"}}},
     )
-    for token in forbidden:
-        occurrences = [
-            line
-            for line in body.splitlines()
-            if token in line
-            and not line.lstrip().startswith(("#", "say "))
-            and "trap" not in line
-        ]
-        assert not occurrences, f"{token!r} appears in uninstall.sh: {occurrences}"
-    # The one exception is the tempfile the script owns.
-    assert "trap 'rm -f \"$RECORDS\"' EXIT INT TERM" in body
+    _write_json(
+        home / ".cursor" / "mcp.json",
+        {"mcpServers": {"pipefy": {"command": "pipefy-mcp-server"}}},
+    )
+    codex = home / ".codex" / "config.toml"
+    codex.parent.mkdir(parents=True)
+    codex.write_text(
+        '[mcp_servers.pipefy]\ncommand = "pipefy-mcp-server"\n', encoding="utf-8"
+    )
+    (home / ".zshrc").write_text('export PIPEFY_TOKEN="x"\n', encoding="utf-8")
+    config = home / ".config" / "pipefy"
+    config.mkdir(parents=True)
+    (config / "refresh.lock").write_text("", encoding="utf-8")
+    stub = _stub_path(tmp_path, uv_tools=("pipefy-cli",))
+    log = tmp_path / "verbs.log"
+    for name in ("claude", "security", "secret-tool", "pipefy"):
+        _write_exec(
+            stub / name,
+            f'#!/bin/sh\nprintf "{name} %s\\n" "$*" >> "{log}"\nexit 0\n',
+        )
+
+    before = {
+        str(p.relative_to(home)): p.read_bytes() for p in home.rglob("*") if p.is_file()
+    }
+    result = _run(home, stub)
+    after = {
+        str(p.relative_to(home)): p.read_bytes() for p in home.rglob("*") if p.is_file()
+    }
+
+    assert result.returncode == 1
+    assert after == before
+    # `run` echoes every command it executes; a scan executes none.
+    assert "\n+ " not in "\n" + result.stderr
+    # The keychain is read, never written, and no client CLI is called at all.
+    invocations = log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+    assert invocations == ["secret-tool search service pipefy"], invocations
 
 
 # ------------------------------------------------------------- name lists

--- a/tests/test_uninstall_teardown.py
+++ b/tests/test_uninstall_teardown.py
@@ -1,0 +1,922 @@
+"""``uninstall.sh``'s destructive path, against fixture homes and stub commands.
+
+Every run gets a synthetic ``HOME`` and a ``PATH`` built from scratch. ``uv``,
+``claude``, ``security``, ``secret-tool``, ``pipefy`` and ``ps`` are stubs that
+append their argv to a log, so no test touches a real keychain, a real client
+config, or a real tool environment.
+
+Two independent traces are asserted. The stub log records what external
+commands were called with; the ``+ `` lines the script writes to stderr record
+every command it ran, including its own ``rm`` and ``cp``. Ordering is the part
+that matters most and no filesystem check can see it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "uninstall.sh"
+# Prefer dash where present: /bin/sh is bash in POSIX mode on macOS, which
+# forgives constructs a Debian-family /bin/sh rejects.
+_SH = shutil.which("dash") or shutil.which("sh") or "/bin/sh"
+
+_BASE_TOOLS = (
+    "cat",
+    "cp",
+    "mv",
+    "rm",
+    "rmdir",
+    "mkdir",
+    "date",
+    "basename",
+    "id",
+    "mktemp",
+    "readlink",
+    "dirname",
+    "awk",
+    "grep",
+    "cut",
+    "tr",
+    "ls",
+    "env",
+    "find",
+    "python3",
+)
+
+
+def _write_exec(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _home(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+# Each stub logs "<name> <argv>" and exits 0. `claude` answers the capability
+# probes, `pipefy` reproduces the observed side effect of `auth logout`:
+# it recreates the config directory with a fresh lock file.
+_UV = """#!/bin/sh
+printf '%s\\n' "uv $*" >> "$STUBLOG"
+if [ "$1" = tool ] && [ "$2" = list ]; then
+    printf 'pipefy-cli v0.0.0\\npipefy-mcp-server v0.0.0\\n'
+fi
+exit 0
+"""
+
+_CLAUDE = """#!/bin/sh
+printf '%s\\n' "claude $*" >> "$STUBLOG"
+case "$*" in
+    "mcp --help") printf '  list\\n  add\\n  remove\\n  logout\\n' ;;
+    "plugin --help") printf '  install\\n  uninstall\\n  marketplace\\n' ;;
+    "plugin marketplace --help") printf '  add\\n  remove\\n  list\\n' ;;
+esac
+exit 0
+"""
+
+_PIPEFY = """#!/bin/sh
+printf '%s\\n' "pipefy $*" >> "$STUBLOG"
+mkdir -p "$HOME/.config/pipefy"
+: > "$HOME/.config/pipefy/refresh.lock"
+exit 0
+"""
+
+_SECRET_TOOL = """#!/bin/sh
+printf '%s\\n' "secret-tool $*" >> "$STUBLOG"
+if [ "$1" = search ] && [ -f "$STUBSTATE/keychain" ]; then
+    printf 'attribute.username = signin.pipefy.com|pipefy-cli\\n'
+fi
+if [ "$1" = clear ]; then
+    rm -f "$STUBSTATE/keychain"
+fi
+exit 0
+"""
+
+_SECURITY = """#!/bin/sh
+printf '%s\\n' "security $*" >> "$STUBLOG"
+case "$1" in
+    find-generic-password)
+        [ -f "$STUBSTATE/keychain" ] || exit 44 ;;
+    dump-keychain)
+        [ -f "$STUBSTATE/keychain" ] || exit 0
+        printf 'keychain: "login"\\n'
+        printf 'class: "genp"\\n'
+        printf 'attributes:\\n'
+        printf '    "acct"<blob>="signin.pipefy.com|pipefy-cli"\\n'
+        printf '    "svce"<blob>="pipefy"\\n' ;;
+    delete-generic-password)
+        rm -f "$STUBSTATE/keychain" ;;
+esac
+exit 0
+"""
+
+
+def _stub_path(
+    tmp_path: Path,
+    *,
+    os_name: str = "Linux",
+    git: bool = False,
+    claude: str | None = _CLAUDE,
+    pipefy: bool = True,
+    ps_output: str = "",
+) -> Path:
+    stub = tmp_path / "stubbin"
+    stub.mkdir(parents=True, exist_ok=True)
+    wanted = list(_BASE_TOOLS)
+    if git:
+        wanted.append("git")
+    for tool in wanted:
+        real = shutil.which(tool)
+        if real is None:  # pragma: no cover - depends on the host image
+            pytest.skip(f"{tool} not available to stub")
+        link = stub / tool
+        if not link.exists():
+            link.symlink_to(real)
+    _write_exec(stub / "uname", f'#!/bin/sh\nprintf "%s\\n" "{os_name}"\n')
+    _write_exec(stub / "uv", _UV)
+    _write_exec(stub / "secret-tool", _SECRET_TOOL)
+    _write_exec(stub / "security", _SECURITY)
+    # printf interprets escapes in its format string, so ps_output carries
+    # real newlines into the stub's output.
+    _write_exec(stub / "ps", f"#!/bin/sh\nprintf '{ps_output}'\nexit 0\n")
+    if claude is not None:
+        _write_exec(stub / "claude", claude)
+    if pipefy:
+        _write_exec(stub / "pipefy", _PIPEFY)
+    return stub
+
+
+class Run:
+    """A completed run plus the two traces it produced."""
+
+    def __init__(self, proc: subprocess.CompletedProcess[str], log: Path) -> None:
+        self.proc = proc
+        self.returncode = proc.returncode
+        self.stdout = proc.stdout
+        self.stderr = proc.stderr
+        self.stubs = (
+            log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+        )
+        self.trace = [
+            line[2:] for line in proc.stderr.splitlines() if line.startswith("+ ")
+        ]
+
+    def index(self, needle: str) -> int:
+        """Position of the first traced command containing ``needle``."""
+        for position, line in enumerate(self.trace):
+            if needle in line:
+                return position
+        raise AssertionError(f"{needle!r} not in trace:\n" + "\n".join(self.trace))
+
+    def missing(self, needle: str) -> bool:
+        return all(needle not in line for line in self.trace)
+
+
+def _run(
+    home: Path,
+    stub: Path,
+    *,
+    args: tuple[str, ...] = ("--yes",),
+    cwd: Path | None = None,
+    extra_path: tuple[Path, ...] = (),
+    env_extra: dict[str, str] | None = None,
+    script: Path | None = None,
+) -> Run:
+    log = stub.parent / "stub.log"
+    state = stub.parent / "stubstate"
+    state.mkdir(exist_ok=True)
+    env = {
+        "HOME": str(home),
+        "PATH": ":".join([str(p) for p in extra_path] + [str(stub)]),
+        "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
+        "UV_CACHE_DIR": str(home / "no-such-uv-cache"),
+        "STUBLOG": str(log),
+        "STUBSTATE": str(state),
+    }
+    if env_extra:
+        env.update(env_extra)
+    proc = subprocess.run(
+        [_SH, str(script or _SCRIPT), *args],
+        cwd=str(cwd or home),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    return Run(proc, log)
+
+
+def _keychain_entry(stub: Path) -> None:
+    state = stub.parent / "stubstate"
+    state.mkdir(exist_ok=True)
+    (state / "keychain").write_text("", encoding="utf-8")
+
+
+def _full_fixture(home: Path) -> None:
+    """One artifact of every kind, so a run exercises the whole sequence."""
+    _write_json(
+        home / ".claude.json",
+        {
+            "mcpServers": {
+                "pipefy-dev": {"command": "uvx", "args": ["pipefy-mcp-server"]},
+                "work": {"type": "http", "url": "https://mcp.pipefy.com/mcp"},
+            },
+            "pluginUsage": {"pipefy@pipefy": 3},
+        },
+    )
+    _write_json(
+        home / ".claude" / "settings.json",
+        {
+            "env": {"PIPEFY_TOKEN": "sentinel-token"},
+            "extraKnownMarketplaces": {"pipefy": {}},
+            "enabledPlugins": {"pipefy@pipefy": True},
+        },
+    )
+    clone = home / ".claude" / "plugins" / "marketplaces" / "pipefy"
+    clone.mkdir(parents=True)
+    _write_json(
+        home / ".claude" / "plugins" / "known_marketplaces.json",
+        {"pipefy": {"installLocation": str(clone)}},
+    )
+    _write_json(
+        home / ".claude" / "plugins" / "installed_plugins.json",
+        {
+            "version": 2,
+            "plugins": {
+                "pipefy@pipefy": [
+                    {"scope": "user", "installPath": str(clone), "version": "0.5.0"}
+                ]
+            },
+        },
+    )
+    _write_json(
+        home / ".cursor" / "mcp.json",
+        {"mcpServers": {"pipefy": {"command": "pipefy-mcp-server"}}},
+    )
+    codex = home / ".codex" / "config.toml"
+    codex.parent.mkdir(parents=True)
+    codex.write_text(
+        '[profiles.default]\nmodel = "x"\n\n'
+        '[mcp_servers.pipefy]\ncommand = "pipefy-mcp-server"\n',
+        encoding="utf-8",
+    )
+    skill = home / ".claude" / "skills" / "pipefy-tasks"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: x\n---\n", encoding="utf-8")
+
+
+# ------------------------------------------------------------ the sequence
+
+
+def test_the_command_sequence_is_credentials_configs_tools_skills_state(tmp_path):
+    """Ordering is load-bearing and only the trace can show it."""
+    home = _home(tmp_path)
+    _full_fixture(home)
+    stub = _stub_path(tmp_path)
+    _keychain_entry(stub)
+
+    run = _run(home, stub)
+
+    revoke = run.index("pipefy auth logout")
+    hosted = run.index("claude mcp logout work")
+    keychain = run.index("secret-tool clear")
+    registration = run.index("claude mcp remove pipefy-dev")
+    cursor = run.index("mcpServers pipefy from")
+    tool = run.index("uv tool uninstall pipefy-cli")
+    skill = run.index("skills/pipefy-tasks")
+    lock = run.index("refresh.lock")
+
+    # Only `pipefy auth logout` revokes server-side, and that ability goes away
+    # with the tool environment, so it leads.
+    assert revoke < keychain
+    assert revoke < hosted
+    # Credentials before client configs before tools: the reverse strands a
+    # registration pointing at a binary that no longer exists.
+    assert keychain < registration
+    assert registration < tool
+    assert cursor < tool
+    assert tool < skill
+    # Runtime state last, because logout recreates the config directory.
+    assert skill < lock
+
+
+def test_logout_recreates_the_config_directory_and_the_ordering_still_clears_it(
+    tmp_path,
+):
+    """`pipefy auth logout` recreates ~/.config/pipefy with a refresh.lock."""
+    home = _home(tmp_path)
+    stub = _stub_path(tmp_path)
+    _keychain_entry(stub)
+    config = home / ".config" / "pipefy"
+    assert not config.exists()
+
+    run = _run(home, stub)
+
+    assert "pipefy auth logout" in run.stubs
+    assert run.index("pipefy auth logout") < run.index("refresh.lock")
+    # The directory the logout brought back is gone again at the end.
+    assert not config.exists(), sorted(p.name for p in config.iterdir())
+
+
+def test_uv_cache_clean_is_never_invoked(tmp_path):
+    home = _home(tmp_path)
+    _full_fixture(home)
+    stub = _stub_path(tmp_path)
+    _keychain_entry(stub)
+
+    run = _run(home, stub)
+
+    assert any(line.startswith("uv tool uninstall") for line in run.stubs)
+    for line in run.stubs:
+        assert "cache clean" not in line
+        assert "cache prune" not in line
+    assert run.missing("cache clean")
+
+
+def test_registrations_are_removed_under_the_name_they_were_registered_with(tmp_path):
+    """A real environment had the server registered as `pipefy-dev`."""
+    home = _home(tmp_path)
+    _write_json(
+        home / ".claude.json",
+        {
+            "mcpServers": {
+                "pipefy-dev": {"command": "uvx", "args": ["pipefy-mcp-server"]}
+            }
+        },
+    )
+
+    run = _run(home, _stub_path(tmp_path))
+
+    assert "claude mcp remove pipefy-dev -s user" in run.stubs
+    assert not any(line == "claude mcp remove pipefy -s user" for line in run.stubs)
+
+
+def test_cli_delegation_is_gated_on_a_verb_probe_not_a_version(tmp_path):
+    """With no `logout` verb, the run falls back to the in-client instruction."""
+    home = _home(tmp_path)
+    _write_json(
+        home / ".claude.json",
+        {
+            "mcpServers": {
+                "pipefy": {"type": "http", "url": "https://mcp.pipefy.com/mcp"}
+            }
+        },
+    )
+    older = _CLAUDE.replace("\\n  logout", "")
+    assert "logout" not in older
+    stub = _stub_path(tmp_path, claude=older)
+
+    run = _run(home, stub)
+
+    assert "claude mcp --help" in run.stubs
+    assert not any(line.startswith("claude mcp logout") for line in run.stubs)
+    assert "Clear authentication" in run.stdout
+    # The registration itself still goes, through the verb that does exist.
+    assert "claude mcp remove pipefy -s user" in run.stubs
+
+
+def test_without_the_client_cli_the_config_is_edited_directly(tmp_path):
+    home = _home(tmp_path)
+    _write_json(
+        home / ".claude.json",
+        {"mcpServers": {"pipefy": {"command": "pipefy-mcp-server"}}},
+    )
+    stub = _stub_path(tmp_path, claude=None)
+
+    run = _run(home, stub)
+
+    payload = json.loads((home / ".claude.json").read_text(encoding="utf-8"))
+    assert payload["mcpServers"] == {}
+    assert any(p.name.startswith(".claude.json.bak.") for p in home.iterdir())
+    # There was no client CLI to delegate to, so none was probed or called.
+    assert not any(line.startswith("claude") for line in run.stubs)
+
+
+# ------------------------------------------------------------- codex adapter
+
+
+def _codex(home: Path, body: str) -> Path:
+    path = home / ".codex" / "config.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_an_installer_appended_codex_section_is_excised(tmp_path):
+    home = _home(tmp_path)
+    codex = _codex(
+        home,
+        '[profiles.default]\nmodel = "x"\n\n'
+        '[mcp_servers.pipefy]\ncommand = "pipefy-mcp-server"\n\n'
+        '[history]\npersistence = "none"\n',
+    )
+
+    run = _run(home, _stub_path(tmp_path))
+
+    body = codex.read_text(encoding="utf-8")
+    assert "[mcp_servers.pipefy]" not in body
+    # Everything either side survives, separator and all.
+    assert body == (
+        '[profiles.default]\nmodel = "x"\n\n[history]\npersistence = "none"\n'
+    )
+    assert (codex.parent / f"{codex.name}.bak.{_stamp(run)}").exists()
+
+
+def test_a_hand_edited_codex_section_degrades_to_report_only(tmp_path):
+    home = _home(tmp_path)
+    codex = _codex(
+        home,
+        '[mcp_servers.pipefy]\ncommand = "pipefy-mcp-server"\n'
+        'args = ["--profile", "mine"]\n\n'
+        '[mcp_servers.pipefy.env]\nPIPEFY_MCP_PROFILE = "admin"\n',
+    )
+    before = codex.read_text(encoding="utf-8")
+
+    run = _run(home, _stub_path(tmp_path))
+
+    assert codex.read_text(encoding="utf-8") == before
+    assert "holds more than the single line the installer appends" in run.stdout
+    assert "excise the section yourself" in run.stdout
+
+
+def test_a_codex_section_that_ends_the_file_takes_its_blank_line_with_it(tmp_path):
+    home = _home(tmp_path)
+    codex = _codex(
+        home,
+        '[profiles.default]\nmodel = "x"\n\n'
+        '[mcp_servers.pipefy]\ncommand = "pipefy-mcp-server"\n',
+    )
+
+    _run(home, _stub_path(tmp_path))
+
+    assert codex.read_text(encoding="utf-8") == '[profiles.default]\nmodel = "x"\n'
+
+
+# --------------------------------------------------------- the delete guard
+
+
+def _guard_run(tmp_path, snippet: str, home: Path) -> subprocess.CompletedProcess[str]:
+    """Source the script with its entry point removed, then call into it.
+
+    DRY_RUN is forced on so that a guard which failed to refuse would print the
+    command rather than run it. The assertions then distinguish the two.
+    """
+    body = _SCRIPT.read_text(encoding="utf-8")
+    assert body.endswith('main "$@"\n')
+    lib = tmp_path / "lib.sh"
+    lib.write_text(body[: -len('main "$@"\n')] + "DRY_RUN=1\n" + snippet, "utf-8")
+    return subprocess.run(
+        [_SH, str(lib)],
+        env={"HOME": str(home), "PATH": os.environ["PATH"]},
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("snippet", "message"),
+    [
+        ('remove_path ""', "refusing to remove an empty path"),
+        ("remove_path", "refusing to remove an empty path"),
+        ('remove_path "/"', "refusing to remove /"),
+        ('remove_path "//"', "refusing to remove /"),
+        ('remove_path "$HOME"', "refusing to remove $HOME"),
+        ('remove_path "$HOME/"', "refusing to remove $HOME"),
+        ('remove_path "relative/path"', "refusing to remove a relative path"),
+        ('remove_path "$HOME" empty-dir', "refusing to remove $HOME"),
+    ],
+)
+def test_the_deletion_guard_refuses(tmp_path, snippet, message):
+    home = _home(tmp_path)
+    result = _guard_run(tmp_path, snippet + "\n", home)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert message in result.stderr
+    # Not even the dry-run echo: the guard refuses before anything is traced.
+    assert "+ rm" not in result.stderr
+    assert "+ rmdir" not in result.stderr
+
+
+def test_the_deletion_guard_allows_a_path_below_home(tmp_path):
+    home = _home(tmp_path)
+    result = _guard_run(tmp_path, 'touch "$HOME/x"\nremove_path "$HOME/x"\n', home)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"+ rm -rf -- {home}/x" in result.stderr
+
+
+# ----------------------------------------------------------------- approval
+
+
+def _stamp(run: Run) -> str:
+    match = re.search(r"\.bak\.(\d{14})", run.stdout + run.stderr)
+    assert match, "no timestamped backup in the report"
+    return match.group(1)
+
+
+def test_yes_approves_every_tier(tmp_path):
+    home = _home(tmp_path)
+    _full_fixture(home)
+    stub = _stub_path(tmp_path)
+    _keychain_entry(stub)
+    (home / ".zshrc").write_text(
+        'export PIPEFY_TOKEN="x"\nexport PIPEFY_ORG_ID=1\n', encoding="utf-8"
+    )
+
+    run = _run(home, stub)
+
+    assert "[1] Ours, reversible" in run.stdout
+    assert "[2] Credentials" in run.stdout and "cannot be undone" in run.stdout
+    assert "[3] Your files" in run.stdout and "backed up first" in run.stdout
+    assert "declined" not in run.stdout
+    # One action from each tier actually happened.
+    assert "uv tool uninstall pipefy-cli" in run.stubs
+    assert "secret-tool clear service pipefy username signin.pipefy.com|pipefy-cli" in (
+        run.stubs
+    )
+    assert (home / ".zshrc").read_text(encoding="utf-8") == ""
+
+
+def test_no_tty_without_yes_refuses_to_guess(tmp_path):
+    home = _home(tmp_path)
+    _write_json(
+        home / ".cursor" / "mcp.json",
+        {"mcpServers": {"pipefy": {"command": "pipefy-mcp-server"}}},
+    )
+
+    run = _run(home, _stub_path(tmp_path), args=())
+
+    # No TTY at all errors out; a TTY that answers nothing declines every tier.
+    # Either way the plan is printed first and nothing is removed.
+    assert run.returncode in (1, 2)
+    assert "PLAN — " in run.stdout
+    assert (
+        "No TTY available for prompt" in run.stderr
+        or "Nothing was removed." in run.stdout
+    )
+    assert json.loads((home / ".cursor" / "mcp.json").read_text())["mcpServers"]
+    assert run.trace == []
+
+
+def test_keep_credentials_skips_tier_two_only(tmp_path):
+    home = _home(tmp_path)
+    _full_fixture(home)
+    stub = _stub_path(tmp_path)
+    _keychain_entry(stub)
+
+    run = _run(home, stub, args=("--yes", "--keep-credentials"))
+
+    assert "[2] Credentials" not in run.stdout
+    assert "kept by --keep-credentials" in run.stdout
+    assert not any(line.startswith("pipefy auth logout") for line in run.stubs)
+    assert not any(line.startswith("secret-tool clear") for line in run.stubs)
+    # Tier 1 still ran.
+    assert "uv tool uninstall pipefy-cli" in run.stubs
+
+
+def test_keep_config_keeps_user_authored_configuration(tmp_path):
+    home = _home(tmp_path)
+    _full_fixture(home)
+    config = home / ".config" / "pipefy"
+    config.mkdir(parents=True)
+    (config / "config.toml").write_text("org_id = 1\n", encoding="utf-8")
+    (config / ".env").write_text("PIPEFY_ORG_ID=1\n", encoding="utf-8")
+    (config / "refresh.lock").write_text("", encoding="utf-8")
+    (home / ".zshrc").write_text("export PIPEFY_ORG_ID=1\n", encoding="utf-8")
+
+    run = _run(home, _stub_path(tmp_path), args=("--yes", "--keep-config"))
+
+    assert "kept by --keep-config" in run.stdout
+    assert (config / "config.toml").exists()
+    assert (config / ".env").exists()
+    assert (home / ".zshrc").read_text(encoding="utf-8") == "export PIPEFY_ORG_ID=1\n"
+    # Ours in the same directory still goes.
+    assert not (config / "refresh.lock").exists()
+
+
+def test_config_toml_and_env_need_consent_and_are_backed_up(tmp_path):
+    home = _home(tmp_path)
+    config = home / ".config" / "pipefy"
+    config.mkdir(parents=True)
+    (config / "config.toml").write_text("org_id = 1\n", encoding="utf-8")
+    (config / ".env").write_text("PIPEFY_ORG_ID=1\n", encoding="utf-8")
+
+    run = _run(home, _stub_path(tmp_path))
+
+    assert "[3] Your files" in run.stdout
+    assert "delete your" in run.stdout
+    stamp = _stamp(run)
+    assert (config / f"config.toml.bak.{stamp}").exists()
+    assert (config / f".env.bak.{stamp}").exists()
+    assert not (config / "config.toml").exists()
+    # A backup of the user's own file keeps the directory alive, and the report
+    # says which file did it.
+    assert "was kept: it still holds" in run.stdout
+
+
+def test_backups_carry_a_timestamped_suffix_and_the_original_bytes(tmp_path):
+    home = _home(tmp_path)
+    before = {"mcpServers": {"pipefy": {"command": "pipefy-mcp-server"}}}
+    _write_json(home / ".cursor" / "mcp.json", before)
+
+    run = _run(home, _stub_path(tmp_path))
+
+    stamp = _stamp(run)
+    backup = home / ".cursor" / f"mcp.json.bak.{stamp}"
+    assert re.fullmatch(r"\d{14}", stamp)
+    assert json.loads(backup.read_text(encoding="utf-8")) == before
+    assert json.loads((home / ".cursor" / "mcp.json").read_text())["mcpServers"] == {}
+
+
+# ------------------------------------------------------- guards and refusals
+
+
+def test_the_live_server_guard_names_the_running_client(tmp_path):
+    home = _home(tmp_path)
+    _write_json(
+        home / ".cursor" / "mcp.json",
+        {"mcpServers": {"pipefy": {"command": "pipefy-mcp-server"}}},
+    )
+    stub = _stub_path(tmp_path, ps_output="/usr/bin/login\\n/Applications/Cursor\\n")
+
+    run = _run(home, stub)
+
+    assert "Running client detected: Cursor" in run.stdout
+    assert "can put back an entry this" in run.stdout
+    # --yes proceeds, but the report says the run happened under a live client.
+    assert "may have rewritten their config" in run.stdout
+
+
+def test_an_unrelated_process_does_not_trip_the_live_server_guard(tmp_path):
+    home = _home(tmp_path)
+    _write_json(
+        home / ".cursor" / "mcp.json",
+        {"mcpServers": {"pipefy": {"command": "pipefy-mcp-server"}}},
+    )
+    stub = _stub_path(tmp_path, ps_output="/usr/bin/claudette\\n/bin/cursorish\\n")
+
+    run = _run(home, stub)
+
+    assert "Running client detected" not in run.stdout
+
+
+def test_a_git_tracked_project_file_is_disabled_rather_than_edited(tmp_path):
+    home = _home(tmp_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    tracked = {
+        "mcpServers": {"pipefy": {"command": "uvx", "args": ["pipefy-mcp-server"]}}
+    }
+    _write_json(repo / ".mcp.json", tracked)
+    stub = _stub_path(tmp_path, git=True)
+    git = str(stub / "git")
+    subprocess.run([git, "init", "-q", str(repo)], check=True)
+    subprocess.run([git, "-C", str(repo), "add", ".mcp.json"], check=True)
+
+    run = _run(home, stub, cwd=repo)
+
+    assert json.loads((repo / ".mcp.json").read_text(encoding="utf-8")) == tracked
+    assert "through disabledMcpjsonServers" in run.stdout
+    payload = json.loads((home / ".claude.json").read_text(encoding="utf-8"))
+    assert payload["projects"][str(repo)]["disabledMcpjsonServers"] == ["pipefy"]
+
+
+def test_dry_run_prints_the_plan_and_changes_nothing(tmp_path):
+    home = _home(tmp_path)
+    _full_fixture(home)
+    stub = _stub_path(tmp_path)
+    _keychain_entry(stub)
+    before = {
+        str(path.relative_to(home)): path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    }
+
+    run = _run(home, stub, args=("--dry-run",))
+
+    assert run.returncode == 0
+    assert "PLAN — " in run.stdout
+    assert "--dry-run: nothing was changed." in run.stdout
+    after = {
+        str(path.relative_to(home)): path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+    # Only the read-only probes the scan itself makes.
+    for line in run.stubs:
+        assert line in ("uv tool list", "secret-tool search service pipefy"), line
+
+
+def test_scan_writes_nothing_even_with_state_everywhere(tmp_path):
+    home = _home(tmp_path)
+    _full_fixture(home)
+    stub = _stub_path(tmp_path)
+    _keychain_entry(stub)
+    before = {
+        str(path.relative_to(home)): path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    }
+
+    run = _run(home, stub, args=("--scan",))
+
+    assert run.returncode == 1
+    after = {
+        str(path.relative_to(home)): path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+    assert run.trace == []
+    assert "--scan removes nothing" in run.stdout
+
+
+def test_a_deleted_credential_that_could_not_be_revoked_says_so(tmp_path):
+    home = _home(tmp_path)
+    stub = _stub_path(tmp_path, pipefy=False)
+    _keychain_entry(stub)
+
+    run = _run(home, stub)
+
+    assert "could not be revoked at the identity provider" in run.stdout
+    assert "stays valid" in run.stdout
+    assert "secret-tool clear service pipefy username signin.pipefy.com|pipefy-cli" in (
+        run.stubs
+    )
+
+
+def test_secrets_never_reach_the_output_of_a_teardown(tmp_path):
+    sentinel = "s3cr3t-value-do-not-print"
+    home = _home(tmp_path)
+    _write_json(home / ".claude" / "settings.json", {"env": {"PIPEFY_TOKEN": sentinel}})
+    _write_json(
+        home / ".claude.json",
+        {
+            "mcpServers": {
+                "pipefy": {
+                    "command": "pipefy-mcp-server",
+                    "env": {"PIPEFY_SERVICE_ACCOUNT_CLIENT_SECRET": sentinel},
+                }
+            }
+        },
+    )
+    (home / ".zshrc").write_text(
+        f'export PIPEFY_TOKEN="{sentinel}"\n', encoding="utf-8"
+    )
+    config = home / ".config" / "pipefy"
+    config.mkdir(parents=True)
+    (config / "keyring.cfg").write_text(
+        f"[pipefy]\nsignin_2epipefy_2ecom_7cpipefy_2dcli = \n\t{sentinel}\n",
+        encoding="utf-8",
+    )
+
+    run = _run(
+        home,
+        _stub_path(tmp_path),
+        env_extra={"PIPEFY_TOKEN": sentinel, "PIPEFY_ORG_ID": "9876543210987"},
+    )
+
+    assert sentinel not in run.stdout
+    assert sentinel not in run.stderr
+    assert "9876543210987" not in run.stdout
+    assert "unset PIPEFY_TOKEN" in run.stdout
+    # The backup holds the secret, as a backup must; only the report is clean.
+    backup = next(p for p in (home / ".claude").iterdir() if ".bak." in p.name)
+    assert sentinel in backup.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------- the client table
+
+
+def _table_rows() -> list[list[str]]:
+    body = _SCRIPT.read_text(encoding="utf-8")
+    match = re.search(r'^CLIENT_TABLE="(.*?)"$', body, re.S | re.M)
+    assert match, "CLIENT_TABLE not found"
+    return [line.split("|") for line in match.group(1).splitlines() if line.strip()]
+
+
+def _script_with_extra_client(tmp_path: Path, row: str) -> Path:
+    """The shipped script plus one row, and nothing else changed."""
+    body = _SCRIPT.read_text(encoding="utf-8")
+    match = re.search(r'^CLIENT_TABLE="(.*?)"$', body, re.S | re.M)
+    assert match
+    patched = f'CLIENT_TABLE="{match.group(1)}\n{row}"'
+    path = tmp_path / "uninstall-with-extra-client.sh"
+    path.write_text(body[: match.start()] + patched + body[match.end() :], "utf-8")
+    return path
+
+
+def test_every_row_has_the_same_shape():
+    rows = _table_rows()
+    assert rows
+    for row in rows:
+        assert len(row) == 9, row
+        assert row[2] in {"json", "toml"}, row
+        assert row[1] == "*" or row[1] in {"Darwin", "Linux"}, row
+        for capability in row[7].split(","):
+            assert capability in {"-", "scopes", "plugin-system", "removal-cli"}, row
+
+
+def test_the_client_allowlist_in_help_comes_from_the_table(tmp_path):
+    run = _run(_home(tmp_path), _stub_path(tmp_path), args=("--help",))
+    assert run.returncode == 0
+    listed = re.search(r"One of: (\S+)\.", run.stdout)
+    assert listed
+    assert listed.group(1).split("|") == [row[0] for row in _table_rows()] + ["none"]
+
+
+def test_an_unknown_client_is_rejected_against_the_table(tmp_path):
+    run = _run(_home(tmp_path), _stub_path(tmp_path), args=("--client", "windsurf"))
+    assert run.returncode == 2
+    assert "Invalid --client: windsurf" in run.stderr
+
+
+def test_a_new_client_costs_one_row_and_no_new_logic(tmp_path):
+    """Detection and removal both pick up a client added as a table row."""
+    home = _home(tmp_path)
+    config = home / ".demo" / "mcp.json"
+    _write_json(config, {"mcpServers": {"anything": {"command": "pipefy-mcp-server"}}})
+    script = _script_with_extra_client(
+        tmp_path, "demo|*|json|~/.demo/mcp.json|mcpServers|client:demo|-|-|-"
+    )
+    stub = _stub_path(tmp_path)
+
+    scan = _run(home, stub, args=("--scan",), script=script)
+    assert "client:demo scope, named 'anything': stdio" in scan.stdout
+
+    teardown = _run(home, stub, script=script)
+    assert f"remove the 'anything' registration from {config}" in teardown.stdout
+    assert json.loads(config.read_text(encoding="utf-8"))["mcpServers"] == {}
+    assert any(p.name.startswith("mcp.json.bak.") for p in config.parent.iterdir())
+
+    fresh = tmp_path / "second"
+    fresh.mkdir()
+    _write_json(
+        fresh / ".demo" / "mcp.json",
+        {"mcpServers": {"anything": {"command": "pipefy-mcp-server"}}},
+    )
+    narrowed = _run(fresh, stub, args=("--yes", "--client", "cursor"), script=script)
+    assert "--client cursor excludes demo" in narrowed.stdout
+    assert json.loads((fresh / ".demo" / "mcp.json").read_text())["mcpServers"]
+
+
+# ------------------------------------------------------------ source guards
+
+
+def test_removal_verbs_live_only_in_the_one_guarded_primitive():
+    """`--scan` safety is behavioural now, but the guard is still structural."""
+    body = _SCRIPT.read_text(encoding="utf-8")
+    lines = body.splitlines()
+    deleting = [
+        line
+        for line in lines
+        if re.search(r"(^|[;&|(']\s*|\brun\s+)(rm|rmdir)\s", line)
+        and not line.lstrip().startswith(("#", "say ", "detail "))
+    ]
+    assert deleting == [
+        '        run rmdir "$_rp"',
+        '        run rm -rf -- "$_rp"',
+        """    trap 'rm -f "$RECORDS" "$PLAN" "$NOTES"' EXIT INT TERM""",
+    ], deleting
+
+
+def test_uv_cache_clean_appears_only_as_advice_never_as_a_command():
+    body = _SCRIPT.read_text(encoding="utf-8")
+    for line in body.splitlines():
+        if "cache clean" not in line:
+            continue
+        assert line.lstrip().startswith(("#", "say ", "detail ")), line
+
+
+def test_every_planned_action_carries_a_full_row():
+    """A short plan_add loses its description to `set -u` at runtime."""
+    body = _SCRIPT.read_text(encoding="utf-8").replace("\\\n", " ")
+    calls = [m.group(0).strip() for m in re.finditer(r"^\s*plan_add .*$", body, re.M)]
+    assert calls
+    for call in calls:
+        flat = call.rstrip(" ;")
+        # Collapse command substitutions so their inner quoting does not look
+        # like another argument.
+        while "$(" in flat:
+            flat, changed = re.subn(r"\$\([^()]*\)", "X", flat)
+            if not changed:
+                break
+        fields = re.findall(r"'[^']*'|\"[^\"]*\"|\S+", flat)
+        assert len(fields) - 1 == 11, call

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,12 +1,15 @@
 #!/bin/sh
-# uninstall.sh — report Pipefy toolkit state across every install channel and MCP client.
+# uninstall.sh — report and remove Pipefy toolkit state across every install
+# channel and MCP client.
 #
-# This version scans only. It reads; it never removes, moves, or edits anything,
-# and the single path it writes is a tempfile holding its own record stream.
+# `--scan` reads and reports; it never removes, moves, or edits anything, and
+# the only paths it writes are tempfiles holding its own record streams. Any
+# other invocation scans, prints the plan it derived from that scan, asks for
+# approval in tiers, removes what was approved, and scans again.
 #
 # Channels: the Claude Code plugin, a local install (install.sh / uv tool /
-# uvx), and the hosted HTTP server. Clients: Claude Code, Cursor, Claude
-# Desktop, Codex.
+# uvx), and the hosted HTTP server. Clients come from CLIENT_TABLE below;
+# adding one is a row there and no new code.
 #
 # A registration is matched on what it *runs*, not on what it is called. The
 # registration key is free text — a real environment had the server registered
@@ -18,7 +21,11 @@
 # and directory names, and `env | grep -i pipefy` matches PWD for anyone
 # working inside a directory named after it.
 #
-# Exit codes: 0 nothing found, 1 findings present, 2 the scan itself failed.
+# Removal uses what the scan found, including the name a registration was
+# actually registered under, and every deletion goes through remove_path().
+#
+# Exit codes: 0 nothing found / nothing left, 1 findings remain, 2 the run
+# itself failed.
 
 set -eu
 
@@ -30,17 +37,65 @@ HOSTED_HOST="mcp.pipefy.com"   # the documented hosted endpoint, and the only on
 RUNNERS="uvx uv npx python python3 pipx"
 PLUGIN_ID="pipefy@pipefy"
 MARKETPLACE_ID="pipefy"
+UV_TOOLS="pipefy-cli $SERVER_BINARY"
 
+# The client table. One row per MCP client, pipe-separated because a config
+# path can contain spaces:
+#
+#   id|platform|format|config|servers|scope|statedir|capabilities|cli
+#
+#   id            the --client value; the allowlist is derived from this column
+#   platform      `uname -s` this row applies to, or * for every platform
+#   format        json or toml — the only thing that selects a reader or an editor
+#   config        the file holding server registrations; ~/ is expanded
+#   servers       the key path registrations live under
+#   scope         how a registration from this file is labelled in reports
+#   statedir      client state directory (settings, plugin registry), or -
+#   capabilities  comma-separated, see below
+#   cli           the client's own command-line tool, or -
+#
+# Capabilities gate the client-specific work, so nothing branches on an id:
+#
+#   scopes         resolves one registration name across local/project/user/
+#                  plugin sources, with the whole entry taken from the winner
+#   plugin-system  ships a plugin and marketplace registry under statedir
+#   removal-cli    ships a CLI that can remove registrations, tokens and
+#                  plugins; each verb is still probed for before it is used
+#
+# Direct file editing is the baseline for every row. Delegation is the
+# exception one row happens to enable.
+CLIENT_TABLE="claude-code|*|json|~/.claude.json|mcpServers|user|~/.claude|scopes,plugin-system,removal-cli|claude
+claude-desktop|Darwin|json|~/Library/Application Support/Claude/claude_desktop_config.json|mcpServers|client:claude-desktop|-|-|-
+codex|*|toml|~/.codex/config.toml|mcp_servers|client:codex|-|-|-
+cursor|*|json|~/.cursor/mcp.json|mcpServers|client:cursor|-|-|-"
+
+MODE=teardown
 CLIENT=""
 ALLOW_ROOT=0
 DRY_RUN=0
+YES=0
+KEEP_CREDENTIALS=0
+KEEP_CONFIG=0
 
 OS=""
 CONFIG_DIR=""
 PYTHON3=""
 RECORDS=""
+PLAN=""
+NOTES=""
+COLLECTING=0
 FINDINGS=0
 SCAN_ERRORS=0
+BACKUP_STAMP=""
+BACKUPS=0
+DONE_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+REVOKED=0
+CRED_DELETED=0
+TIER1_OK=0
+TIER2_OK=0
+TIER3_OK=0
 TAB=$(printf '\t')
 
 # Secrets. `_session_masking_env_vars()` (packages/cli/.../commands/auth.py)
@@ -103,57 +158,186 @@ detail() { printf '      %s\n' "$*"; }
 # A source this run could not inspect, so a partial scan never reads as clean.
 uninspected() { printf '  ! %s\n' "$*"; SCAN_ERRORS=$((SCAN_ERRORS + 1)); }
 
+trace() { printf '+ %s\n' "$*" >&2; }
+
+run() {
+    trace "$*"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        return 0
+    fi
+    "$@"
+}
+
+confirm() {
+    _cf_msg="$1"
+    if [ "$YES" -eq 1 ]; then
+        return 0
+    fi
+    if [ -t 0 ]; then
+        printf '%s [y/N] ' "$_cf_msg"
+        read -r _cf_reply || _cf_reply=""
+    elif [ -r /dev/tty ]; then
+        printf '%s [y/N] ' "$_cf_msg" >&2
+        read -r _cf_reply < /dev/tty || _cf_reply=""
+    else
+        err "No TTY available for prompt: \"$_cf_msg\". Re-run with --yes to proceed non-interactively."
+    fi
+    case "$_cf_reply" in
+        [yY]|[yY][eE][sS]) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ------------------------------------------------------------- client table
+
+# The table writes paths with a literal ~/ prefix; this is where one becomes a
+# real path.
+# shellcheck disable=SC2088
+expand_home() {
+    case "$1" in
+        '~/'*) printf '%s\n' "$HOME/${1#\~/}" ;;
+        *) printf '%s\n' "$1" ;;
+    esac
+}
+
+# Every row, paths expanded, platform ignored. The allowlist and the help text
+# both come from here, so they cannot drift apart.
+all_client_rows() {
+    printf '%s\n' "$CLIENT_TABLE" \
+        | while IFS='|' read -r _id _plat _fmt _cfg _srv _sc _st _caps _cli; do
+        [ -n "$_id" ] || continue
+        printf '%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
+            "$_id" "$_plat" "$_fmt" "$(expand_home "$_cfg")" "$_srv" "$_sc" \
+            "$(expand_home "$_st")" "$_caps" "$_cli"
+    done
+}
+
+# The rows that apply to this machine.
+client_rows() {
+    all_client_rows | while IFS='|' read -r _id _plat _fmt _cfg _srv _sc _st _caps _cli; do
+        case "$_plat" in
+            '*'|"$OS") ;;
+            *) continue ;;
+        esac
+        printf '%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
+            "$_id" "$_plat" "$_fmt" "$_cfg" "$_srv" "$_sc" "$_st" "$_caps" "$_cli"
+    done
+}
+
+client_ids() {
+    all_client_rows | cut -d'|' -f1
+}
+
+client_row() {
+    all_client_rows | awk -F'|' -v id="$1" '$1 == id { print; exit }'
+}
+
+# Field n of a row: 1 id, 3 format, 4 config, 5 servers, 6 scope, 7 statedir,
+# 8 capabilities, 9 cli.
+client_field() {
+    printf '%s\n' "$1" | cut -d'|' -f"$2"
+}
+
+client_has_cap() {
+    printf '%s\n' "$1" | cut -d'|' -f8 | tr ',' '\n' \
+        | awk -v c="$2" '$0 == c { f = 1 } END { exit !f }'
+}
+
+# The first row claiming a capability. The plugin registry, the marketplace,
+# the skills directory and CLI delegation all hang off this rather than off a
+# client id.
+client_row_with_cap() {
+    client_rows | while IFS= read -r _cr; do
+        if client_has_cap "$_cr" "$1"; then
+            printf '%s\n' "$_cr"
+            break
+        fi
+    done
+}
+
+# Which client owns a config path, for --client narrowing and for reports.
+client_id_for_file() {
+    client_rows | awk -F'|' -v f="$1" '$4 == f { print $1; exit }'
+}
+
+# --client narrows *registration edits* only; detection always sweeps every
+# client, and tools, credentials, skills and the plugin are unaffected.
+client_selected() {
+    [ -z "$CLIENT" ] && return 0
+    [ "$1" = "$CLIENT" ]
+}
+
+client_choice_list() {
+    _ccl=$(client_ids | tr '\n' '|')
+    printf '%s\n' "${_ccl%|}"
+}
+
 print_help() {
+    _choices="$(client_choice_list)|none"
     cat <<EOF
 Usage: uninstall.sh [OPTIONS]
 
-Report Pipefy toolkit state across every install channel and MCP client.
-This version detects only; it removes nothing.
+Report Pipefy toolkit state across every install channel and MCP client, then
+remove what you approve. A bare invocation scans, shows the plan, and asks.
 
 MCP registrations are matched on what they run — the $SERVER_BINARY
 command, a known runner invoking it, or the hosted endpoint's host — so an
-entry registered under any name is found.
+entry registered under any name is found, and removed under that name.
 
 Options:
-  --scan              Report state and exit. The only mode this version has,
-                      and what a bare invocation does.
-  --client <id>       Accepted and validated for symmetry with install.sh.
-                      One of: claude-code, claude-desktop, cursor, codex, none.
+  --scan              Report state and exit. Changes nothing.
+  --client <id>       Limit MCP registration edits to this client's config.
+                      One of: $_choices.
                       Detection always sweeps every client regardless, since
-                      the point is finding state you forgot about.
-  --dry-run           Accepted for symmetry with install.sh. A scan has no
-                      side effects, so this changes nothing.
+                      the point is finding state you forgot about, and tools,
+                      credentials, skills and the plugin are not narrowed.
+  --dry-run           Print the plan and exit without removing anything.
+  --yes, -y           Approve every tier. Required with no TTY.
+  --keep-credentials  Leave stored credentials alone (skips tier 2).
+  --keep-config       Leave user configuration alone: config.toml, .env, and
+                      non-credential PIPEFY_* settings in your own files.
   --allow-root        Allow running as root (refuses by default).
   -h, --help          Show this help.
 
+Approval is tiered, not per action:
+  [1] ours and reversible   one confirmation for the whole group
+  [2] credentials           its own confirmation; cannot be undone
+  [3] your own files        its own confirmation; backed up first
+
 Exit codes:
-  0  nothing found
-  1  findings present
-  2  the scan itself failed (a source could not be inspected)
+  0  nothing found, or nothing left after removal
+  1  findings remain
+  2  the run itself failed (a source could not be inspected)
 
 Examples:
   curl -LsSf https://raw.githubusercontent.com/$REPO/main/uninstall.sh \\
     | sh -s -- --scan
 
-  ./uninstall.sh --scan
+  ./uninstall.sh --dry-run
+  ./uninstall.sh --yes --keep-config
 EOF
 }
 
 parse_args() {
     while [ $# -gt 0 ]; do
         case "$1" in
-            --scan) shift ;;
+            --scan) MODE=scan; shift ;;
             --client) [ $# -ge 2 ] || err "--client requires a value"; CLIENT="$2"; shift 2 ;;
             --client=*) CLIENT="${1#--client=}"; shift ;;
             --dry-run) DRY_RUN=1; shift ;;
+            --yes|-y) YES=1; shift ;;
+            --keep-credentials) KEEP_CREDENTIALS=1; shift ;;
+            --keep-config) KEEP_CONFIG=1; shift ;;
             --allow-root) ALLOW_ROOT=1; shift ;;
             -h|--help) print_help; exit 0 ;;
             *) err "Unknown flag: $1 (try --help)" ;;
         esac
     done
     case "$CLIENT" in
-        ""|claude-code|claude-desktop|cursor|codex|none) ;;
-        *) err "Invalid --client: $CLIENT (use claude-code|claude-desktop|cursor|codex|none)" ;;
+        ""|none) ;;
+        *)
+            [ -n "$(client_row "$CLIENT")" ] \
+                || err "Invalid --client: $CLIENT (use $(client_choice_list)|none)" ;;
     esac
 }
 
@@ -289,13 +473,13 @@ run_json_probe() {
     SCAN_RUNNERS="$RUNNERS" \
     SCAN_PLUGIN_ID="$PLUGIN_ID" \
     SCAN_MARKETPLACE_ID="$MARKETPLACE_ID" \
+    SCAN_CLIENTS="$(client_rows)" \
     "$PYTHON3" - "$@" <<'PY' >>"$RECORDS"
 import json
 import os
 import posixpath
 import sys
 
-HOME = os.path.expanduser("~")
 CANON = os.environ["SCAN_CANONICAL_NAME"]
 BINARY = os.environ["SCAN_SERVER_BINARY"]
 HOSTED_HOST = os.environ["SCAN_HOSTED_HOST"]
@@ -305,6 +489,24 @@ MARKET = os.environ["SCAN_MARKETPLACE_ID"]
 CRED = set(os.environ["SCAN_ENV_CRED"].split())
 CONFIG = set(os.environ["SCAN_ENV_CONFIG"].split())
 PIPEFY_ENV = CRED | CONFIG
+
+# The client table, already filtered to this platform and with ~ expanded.
+CLIENTS = []
+for _raw in os.environ["SCAN_CLIENTS"].splitlines():
+    if not _raw.strip():
+        continue
+    _f = _raw.split("|")
+    CLIENTS.append(
+        {
+            "id": _f[0],
+            "format": _f[2],
+            "config": _f[3],
+            "servers": _f[4],
+            "scope": _f[5],
+            "statedir": _f[6],
+            "caps": set(c for c in _f[7].split(",") if c and c != "-"),
+        }
+    )
 
 
 def emit(*fields):
@@ -394,20 +596,29 @@ def classify(name, entry):
     return kind, endpoint, command, "no"
 
 
-def scan_env_block(path, keypath, block):
+def scan_env_block(path, keypath, segs, block):
+    """Report PIPEFY_* keys in an env block, with the JSON path a remover needs.
+
+    The dotted keypath is for humans; the padded segment list is machine-read,
+    because a project directory used as a key contains dots and slashes.
+    """
     if not isinstance(block, dict):
         return
     for key in block:
         if key in CRED:
-            emit("envkey", path, "%s.%s" % (keypath, key), key, "credential")
+            tier = "credential"
         elif key in CONFIG:
-            emit("envkey", path, "%s.%s" % (keypath, key), key, "config")
+            tier = "config"
+        else:
+            continue
+        padded = (list(segs) + [key] + ["-"] * 6)[:6]
+        emit("envkey", path, "%s.%s" % (keypath, key), key, tier, *padded)
 
 
 MCP_ROWS = []
 
 
-def walk_servers(path, keypath, servers, scope, projdir):
+def walk_servers(path, keypath, segs, servers, scope, projdir):
     if not isinstance(servers, dict):
         return
     for name, entry in servers.items():
@@ -418,7 +629,12 @@ def walk_servers(path, keypath, servers, scope, projdir):
                 (match, name, scope, projdir, path, kind, endpoint, command)
             )
         if isinstance(entry, dict):
-            scan_env_block(path, "%s.%s.env" % (keypath, name), entry.get("env"))
+            scan_env_block(
+                path,
+                "%s.%s.env" % (keypath, name),
+                list(segs) + [name, "env"],
+                entry.get("env"),
+            )
 
 
 def listed(value, name):
@@ -429,7 +645,7 @@ def scan_settings(path, projdir):
     data = load(path)
     if data is None:
         return
-    scan_env_block(path, "env", data.get("env"))
+    scan_env_block(path, "env", ["env"], data.get("env"))
     markets = data.get("extraKnownMarketplaces")
     if isinstance(markets, dict) and MARKET in markets:
         emit("marketplace", path, "extraKnownMarketplaces.%s" % MARKET, "")
@@ -450,94 +666,109 @@ for raw in sys.argv[1:]:
     if raw and raw not in project_dirs:
         project_dirs.append(raw)
 
-# --- ~/.claude.json: user scope, local scope, per-project toggles, residue
-claude_json = os.path.join(HOME, ".claude.json")
-data = load(claude_json)
-if data is not None:
-    walk_servers(claude_json, "mcpServers", data.get("mcpServers"), "user", "-")
-    usage = data.get("pluginUsage")
-    if isinstance(usage, dict) and PLUGIN in usage:
-        emit("pluginusage", claude_json, "pluginUsage[%s]" % PLUGIN)
-    projects = data.get("projects")
-    if isinstance(projects, dict):
-        for pdir, pdata in projects.items():
-            if pdir not in project_dirs:
-                project_dirs.append(pdir)
-            if not isinstance(pdata, dict):
-                continue
-            where = "%s projects.%s" % (claude_json, pdir)
-            walk_servers(
-                claude_json,
-                "projects.%s.mcpServers" % pdir,
-                pdata.get("mcpServers"),
-                "local",
-                pdir,
-            )
-            if listed(pdata.get("disabledMcpjsonServers"), CANON):
-                emit("disabledjson", pdir, where)
-            if listed(pdata.get("enabledMcpjsonServers"), CANON):
-                emit("enabledjson", pdir, where)
-            if listed(pdata.get("disabledMcpServers"), CANON):
-                emit("disabledsrv", pdir, where)
-
-# --- user settings files
-for name in ("settings.json", "settings.local.json"):
-    scan_settings(os.path.join(HOME, ".claude", name), "-")
-
-# --- marketplace registry and installed plugins
-known = os.path.join(HOME, ".claude", "plugins", "known_marketplaces.json")
-data = load(known)
-if isinstance(data, dict) and MARKET in data:
-    entry = data[MARKET] if isinstance(data.get(MARKET), dict) else {}
-    emit("marketplace", known, MARKET, str(entry.get("installLocation") or ""))
-
-installed = os.path.join(HOME, ".claude", "plugins", "installed_plugins.json")
-data = load(installed)
-if data is not None:
-    plugins = data.get("plugins")
-    if isinstance(plugins, dict) and PLUGIN in plugins:
-        entries = plugins[PLUGIN]
-        if not isinstance(entries, list):
-            entries = [entries]
-        for entry in entries:
-            if not isinstance(entry, dict):
-                continue
-            install_path = str(entry.get("installPath") or "")
-            emit("plugin", installed, PLUGIN, str(entry.get("scope") or "?"),
-                 str(entry.get("version") or "?"), install_path)
-            if install_path:
-                # A plugin ships its own MCP config, which ranks below user scope.
-                plugin_mcp = os.path.join(install_path, ".mcp.json")
-                pdata = load(plugin_mcp)
-                if pdata is not None:
-                    walk_servers(plugin_mcp, "mcpServers",
-                                 pdata.get("mcpServers"), "plugin", "-")
-
-# --- other clients
-cursor = os.path.join(HOME, ".cursor", "mcp.json")
-data = load(cursor)
-if data is not None:
-    walk_servers(cursor, "mcpServers", data.get("mcpServers"), "client:cursor", "-")
-
-if sys.platform == "darwin":
-    desktop = os.path.join(
-        HOME, "Library", "Application Support", "Claude",
-        "claude_desktop_config.json",
+# --- every JSON client, from the table. A row is all it takes to add one.
+scoped = None
+for row in CLIENTS:
+    if row["format"] != "json":
+        continue
+    # A missing or unreadable config only costs this file: the state directory
+    # below is registered independently of it.
+    data = load(row["config"]) or {}
+    walk_servers(
+        row["config"],
+        row["servers"],
+        [row["servers"]],
+        data.get(row["servers"]),
+        row["scope"],
+        "-",
     )
-    data = load(desktop)
-    if data is not None:
-        walk_servers(desktop, "mcpServers", data.get("mcpServers"),
-                     "client:claude-desktop", "-")
+    if "scopes" in row["caps"]:
+        # Per-project registrations and toggles live in the same file, under
+        # the project's own path. Scope resolution is this client's concept,
+        # which is why it hangs off the capability and not off an id.
+        scoped = row
+        projects = data.get("projects")
+        if isinstance(projects, dict):
+            for pdir, pdata in projects.items():
+                if pdir not in project_dirs:
+                    project_dirs.append(pdir)
+                if not isinstance(pdata, dict):
+                    continue
+                where = "%s projects.%s" % (row["config"], pdir)
+                walk_servers(
+                    row["config"],
+                    "projects.%s.%s" % (pdir, row["servers"]),
+                    ["projects", pdir, row["servers"]],
+                    pdata.get(row["servers"]),
+                    "local",
+                    pdir,
+                )
+                if listed(pdata.get("disabledMcpjsonServers"), CANON):
+                    emit("disabledjson", pdir, where)
+                if listed(pdata.get("enabledMcpjsonServers"), CANON):
+                    emit("enabledjson", pdir, where)
+                if listed(pdata.get("disabledMcpServers"), CANON):
+                    emit("disabledsrv", pdir, where)
+    if "plugin-system" in row["caps"]:
+        usage = data.get("pluginUsage")
+        if isinstance(usage, dict) and PLUGIN in usage:
+            emit("pluginusage", row["config"], "pluginUsage[%s]" % PLUGIN)
 
-# --- project scope: .mcp.json plus project-local settings
+    statedir = row["statedir"]
+    if statedir == "-":
+        continue
+
+    for name in ("settings.json", "settings.local.json"):
+        scan_settings(os.path.join(statedir, name), "-")
+
+    if "plugin-system" not in row["caps"]:
+        continue
+
+    known = os.path.join(statedir, "plugins", "known_marketplaces.json")
+    data = load(known)
+    if isinstance(data, dict) and MARKET in data:
+        entry = data[MARKET] if isinstance(data.get(MARKET), dict) else {}
+        emit("marketplace", known, MARKET, str(entry.get("installLocation") or ""))
+
+    installed = os.path.join(statedir, "plugins", "installed_plugins.json")
+    data = load(installed)
+    if data is None:
+        continue
+    plugins = data.get("plugins")
+    if not isinstance(plugins, dict) or PLUGIN not in plugins:
+        continue
+    entries = plugins[PLUGIN]
+    if not isinstance(entries, list):
+        entries = [entries]
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        install_path = str(entry.get("installPath") or "")
+        emit("plugin", installed, PLUGIN, str(entry.get("scope") or "?"),
+             str(entry.get("version") or "?"), install_path)
+        if install_path:
+            # A plugin ships its own MCP config, which ranks below user scope.
+            plugin_mcp = os.path.join(install_path, ".mcp.json")
+            pdata = load(plugin_mcp)
+            if pdata is not None:
+                walk_servers(plugin_mcp, "mcpServers", ["mcpServers"],
+                             pdata.get("mcpServers"), "plugin", "-")
+
+# --- project scope: .mcp.json is the cross-client project file; the settings
+# beside it belong to the client that resolves scopes.
 for pdir in project_dirs:
     mcp_json = os.path.join(pdir, ".mcp.json")
     data = load(mcp_json)
     if data is not None:
         emit("projectfile", pdir, mcp_json)
-        walk_servers(mcp_json, "mcpServers", data.get("mcpServers"), "project", pdir)
+        walk_servers(mcp_json, "mcpServers", ["mcpServers"],
+                     data.get("mcpServers"), "project", pdir)
+    if scoped is None:
+        continue
     for name in ("settings.json", "settings.local.json"):
-        scan_settings(os.path.join(pdir, ".claude", name), pdir)
+        scan_settings(
+            os.path.join(pdir, os.path.basename(scoped["statedir"]), name), pdir
+        )
 
 # --- one group per distinct registration, so a repo with many worktrees does
 # not print the same stdio entry dozens of times
@@ -693,12 +924,14 @@ scan_uv_tools() {
         detail "UV_TOOL_DIR=$UV_TOOL_DIR"
     fi
     _listing=$(uv tool list 2>/dev/null) || _listing=""
-    for _tool in pipefy-cli "$SERVER_BINARY"; do
+    for _tool in $UV_TOOLS; do
         # `uv tool list` prints "<name> v<version>" per tool with its
         # executables indented under it. Match the first field exactly.
         if printf '%s\n' "$_listing" \
             | awk -v t="$_tool" '$1 == t { f = 1 } END { exit !f }'; then
             finding "uv tool installed: $_tool"
+            plan_add 4 ours uvtool "$_tool" - - - - - - \
+                "uv tool uninstall $_tool"
         else
             note "uv tool not installed: $_tool"
         fi
@@ -745,7 +978,7 @@ scan_registrations() {
         uninspected "JSON client configs not inspected — python3 unavailable"
         detail "affects the Claude Code, Cursor and Claude Desktop configs, the plugin"
         detail "registry, and every project .mcp.json"
-        scan_codex
+        scan_toml_clients
         return 0
     fi
     _any=0
@@ -789,7 +1022,7 @@ EOF
 $(records disabledjson)
 EOF
     scan_project_files
-    scan_codex
+    scan_toml_clients
 }
 
 # Entries carrying a weak signal — a name in this toolkit's namespace, or one
@@ -840,13 +1073,24 @@ EOF
     fi
 }
 
-# Codex config is TOML and install.sh appends its section blind, so detection
-# keys on the section header. Every section is then matched on what it runs, so
-# a server registered under another name is found too.
-scan_codex() {
-    _codex="$HOME/.codex/config.toml"
-    if [ ! -f "$_codex" ]; then
-        note "codex: no $_codex"
+scan_toml_clients() {
+    while IFS='|' read -r _tc_id _tc_plat _tc_fmt _tc_cfg _tc_srv _tc_scope _tc_st _tc_caps _tc_cli; do
+        [ "${_tc_fmt:-}" = "toml" ] || continue
+        scan_toml_client "$_tc_id" "$_tc_cfg" "$_tc_srv"
+    done <<EOF
+$(client_rows)
+EOF
+}
+
+# A TOML client's config is text install.sh appends to blind, so detection keys
+# on the section header. Every section is then matched on what it runs, so a
+# server registered under another name is found too.
+scan_toml_client() {
+    _tcl_id="$1"
+    _tcl_file="$2"
+    _tcl_key="$3"
+    if [ ! -f "$_tcl_file" ]; then
+        note "$_tcl_id: no $_tcl_file"
         return 0
     fi
     _hit=0
@@ -855,7 +1099,7 @@ scan_codex() {
         if is_set "$_url"; then
             [ "$(url_host "$_url")" = "$HOSTED_HOST" ] || continue
             _hit=$((_hit + 1))
-            finding "codex, section [mcp_servers.$_name]: $_url"
+            finding "$_tcl_id, section [$_tcl_key.$_name]: $_url"
         else
             is_set "$_command" || continue
             # Word splitting is how the flattened argument list is re-read.
@@ -863,27 +1107,28 @@ scan_codex() {
             stdio_matches "$_command" $_args || continue
             _hit=$((_hit + 1))
             if is_set "$_args"; then
-                finding "codex, section [mcp_servers.$_name]: $_command $_args"
+                finding "$_tcl_id, section [$_tcl_key.$_name]: $_command $_args"
             else
-                finding "codex, section [mcp_servers.$_name]: $_command"
+                finding "$_tcl_id, section [$_tcl_key.$_name]: $_command"
             fi
             if ! command -v "$_command" >/dev/null 2>&1; then
                 detail "broken: command '$_command' does not resolve on PATH"
             fi
         fi
-        detail "in $_codex"
+        detail "in $_tcl_file"
+        plan_toml_section "$_tcl_id" "$_tcl_file" "$_tcl_key" "$_name"
     done <<EOF
-$(codex_sections "$_codex")
+$(toml_sections "$_tcl_file" "$_tcl_key")
 EOF
     if [ "$_hit" -eq 0 ]; then
-        note "codex: no section in $_codex runs this toolkit"
+        note "$_tcl_id: no section in $_tcl_file runs this toolkit"
     fi
 }
 
-# One tab-separated line per [mcp_servers.<name>] section: name, command, url,
-# and args flattened to a space-separated list.
-codex_sections() {
-    awk '
+# One tab-separated line per [<key>.<name>] section: name, command, url, and
+# args flattened to a space-separated list.
+toml_sections() {
+    AW_KEY="$2" awk '
         # "-" for an empty field: tab is IFS whitespace, so the consuming shell
         # would collapse a run of tabs and shift columns.
         function dash(v) { return v == "" ? "-" : v }
@@ -892,10 +1137,11 @@ codex_sections() {
                 printf "%s\t%s\t%s\t%s\n", sec, dash(cmd), dash(url), dash(args)
             sec = ""; cmd = ""; url = ""; args = ""
         }
+        BEGIN { key = ENVIRON["AW_KEY"]; head = "^\\[" key "\\.[^.]+\\]$" }
         /^[ \t]*\[/ {
             flush()
-            if ($0 ~ /^\[mcp_servers\.[^.]+\]$/) {
-                sec = substr($0, 14, length($0) - 14)
+            if ($0 ~ head) {
+                sec = substr($0, length(key) + 3, length($0) - length(key) - 3)
             }
             next
         }
@@ -910,6 +1156,30 @@ codex_sections() {
             gsub(/\[|\]|"/, "", v); gsub(/,/, " ", v); args = v; next
         }
         END { flush() }
+    ' "$1"
+}
+
+# install.sh appends exactly a header and one `command = "<binary>"` line. A
+# section holding anything else — extra keys, a sub-table, a comment — was
+# written or edited by hand, and is reported rather than excised.
+toml_section_is_pristine() {
+    AW_KEY="$2" AW_NAME="$3" AW_BIN="$SERVER_BINARY" awk '
+        function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+        BEGIN {
+            sec = "[" ENVIRON["AW_KEY"] "." ENVIRON["AW_NAME"] "]"
+            want = "command = \"" ENVIRON["AW_BIN"] "\""
+        }
+        {
+            t = trim($0)
+            if (inside) {
+                if (substr(t, 1, 1) == "[") { inside = 0 }
+                else if (t == "") { next }
+                else if (t == want) { seen++; next }
+                else { other++; next }
+            }
+            if (t == sec) inside = 1
+        }
+        END { exit !(seen == 1 && other == 0) }
     ' "$1"
 }
 
@@ -962,8 +1232,12 @@ EOF
 }
 
 scan_plugin() {
-    section "Claude Code plugin and marketplace"
-    _clone="$HOME/.claude/plugins/marketplaces/$MARKETPLACE_ID"
+    _prow=$(client_row_with_cap plugin-system)
+    [ -n "$_prow" ] || return 0
+    _pclient=$(client_field "$_prow" 1)
+    _pstate=$(client_field "$_prow" 7)
+    section "$_pclient plugin and marketplace"
+    _clone="$_pstate/plugins/marketplaces/$MARKETPLACE_ID"
     if [ -z "$PYTHON3" ]; then
         uninspected "plugin registry not inspected — python3 unavailable"
         if [ -d "$_clone" ]; then
@@ -979,6 +1253,15 @@ scan_plugin() {
         if is_set "$_location"; then
             detail "clone at $_location"
         fi
+        case "$_key" in
+            extraKnownMarketplaces.*)
+                plan_add 3 ours jsonkey "$_file" extraKnownMarketplaces \
+                    "$MARKETPLACE_ID" - - - - \
+                    "drop extraKnownMarketplaces.$MARKETPLACE_ID from $_file" ;;
+            *)
+                plan_add 3 ours market "$MARKETPLACE_ID" "$_file" "$_location" \
+                    - - - - "unregister the '$MARKETPLACE_ID' marketplace" ;;
+        esac
     done <<EOF
 $(records marketplace)
 EOF
@@ -991,24 +1274,32 @@ EOF
         if is_set "$_path"; then
             detail "files at $_path"
         fi
+        plan_add 3 ours plugin "$_id" "$_file" "$_scope" - - - - \
+            "uninstall the $_id plugin ($_scope scope)"
     done <<EOF
 $(records plugin)
 EOF
     while IFS="$TAB" read -r _ _file _key _state; do
         [ -n "${_file:-}" ] || continue
         finding "plugin flag: $_key = $_state in $_file"
+        plan_add 3 ours jsonkey "$_file" enabledPlugins "$PLUGIN_ID" - - - - \
+            "drop enabledPlugins[$PLUGIN_ID] from $_file"
     done <<EOF
 $(records pluginflag)
 EOF
     while IFS="$TAB" read -r _ _file _key; do
         [ -n "${_file:-}" ] || continue
         finding "plugin usage record: $_key in $_file"
+        plan_add 3 ours jsonkey "$_file" pluginUsage "$PLUGIN_ID" - - - - \
+            "drop pluginUsage[$PLUGIN_ID] from $_file"
     done <<EOF
 $(records pluginusage)
 EOF
     if [ -d "$_clone" ]; then
         if [ "$_registered" -eq 0 ]; then
             finding "orphan clone: $_clone exists with no marketplace registration"
+            plan_add 3 ours rmpath "$_clone" - - - - - - \
+                "delete the orphan marketplace clone $_clone"
         fi
     else
         note "no marketplace clone at $_clone"
@@ -1069,19 +1360,42 @@ scan_keychain_backend() {
     detail "both stores are checked below, whichever one is effective"
 }
 
+keychain_has_entry() {
+    case "$OS" in
+        Darwin)
+            command -v security >/dev/null 2>&1 || return 1
+            security find-generic-password -s "$KEYCHAIN_SERVICE" >/dev/null 2>&1 ;;
+        Linux)
+            command -v secret-tool >/dev/null 2>&1 || return 1
+            [ -n "$(secret-tool search service "$KEYCHAIN_SERVICE" 2>/dev/null)" ] ;;
+        *) return 1 ;;
+    esac
+}
+
 scan_credentials() {
     section "Stored credentials"
     scan_keychain_backend
+    _cfg="$CONFIG_DIR/keyring.cfg"
+    # `pipefy auth logout` is the only step that can revoke server-side, so it
+    # is planned ahead of every local delete and only when there is a session
+    # to revoke.
+    if [ "$COLLECTING" -eq 1 ]; then
+        if [ -f "$_cfg" ] || keychain_has_entry; then
+            plan_add 1 credential logout - - - - - - - \
+                "revoke and delete the stored session (pipefy auth logout)"
+        fi
+    fi
     case "$OS" in
         Darwin) scan_keychain_macos ;;
         Linux) scan_keychain_linux ;;
     esac
-    _cfg="$CONFIG_DIR/keyring.cfg"
     if [ ! -f "$_cfg" ]; then
         note "no file-backend store at $_cfg"
         return 0
     fi
     finding "file keyring backend: $_cfg stores refresh tokens in plaintext"
+    plan_add 2 credential rmpath "$_cfg" - - - - - - \
+        "delete the plaintext file keyring $_cfg"
     # An INI whose section is the keyring service and whose keys are escaped
     # account names. Values sit on indented continuation lines and are not read.
     while IFS= read -r _acct; do
@@ -1133,6 +1447,8 @@ scan_keychain_macos() {
         [ -n "$_acct" ] || continue
         _found=1
         finding "keychain: service $KEYCHAIN_SERVICE, account $_acct"
+        plan_add 2 credential keychain "$_acct" - - - - - - \
+            "delete the keychain item $KEYCHAIN_SERVICE / $_acct"
     done <<EOF
 $(security dump-keychain 2>/dev/null | keychain_accounts)
 EOF
@@ -1169,6 +1485,8 @@ scan_keychain_linux() {
         [ -n "$_acct" ] || continue
         _found=1
         finding "keychain: service $KEYCHAIN_SERVICE, account $_acct"
+        plan_add 2 credential keychain "$_acct" - - - - - - \
+            "delete the keychain item $KEYCHAIN_SERVICE / $_acct"
     done <<EOF
 $(secret-tool search service "$KEYCHAIN_SERVICE" 2>/dev/null \
     | awk -F' = ' '$1 == "attribute.username" { print $2 }')
@@ -1187,6 +1505,14 @@ scan_config_dir() {
     fi
     if [ ! -d "$CONFIG_DIR" ]; then
         note "does not exist"
+        # `pipefy auth logout` recreates it with a refresh.lock, so the cleanup
+        # is planned now even though there is nothing here yet.
+        if plan_has_kind logout; then
+            plan_add 6 ours rmpath "$CONFIG_DIR/refresh.lock" - - - - - - \
+                "delete $CONFIG_DIR/refresh.lock, which the logout above recreates"
+            plan_add 6 ours rmdir "$CONFIG_DIR" - - - - - - \
+                "remove $CONFIG_DIR if it ends up empty"
+        fi
         return 0
     fi
     _empty=1
@@ -1194,12 +1520,21 @@ scan_config_dir() {
         [ -n "$_name" ] || continue
         _empty=0
         case "$_name" in
-            config.toml)
-                finding "$CONFIG_DIR/$_name (user-authored; never remove without consent)" ;;
+            config.toml|.env|.env.*)
+                finding "$CONFIG_DIR/$_name (user-authored; never remove without consent)"
+                plan_add 6 userconfig rmpath "$CONFIG_DIR/$_name" - - - - - - \
+                    "delete your $CONFIG_DIR/$_name" ;;
             keyring.cfg)
                 note "$CONFIG_DIR/$_name (reported under stored credentials)" ;;
+            *.bak.*)
+                note "$CONFIG_DIR/$_name (a backup; kept on purpose)" ;;
+            refresh.lock)
+                finding "$CONFIG_DIR/$_name"
+                plan_add 6 ours rmpath "$CONFIG_DIR/$_name" - - - - - - \
+                    "delete $CONFIG_DIR/$_name" ;;
             *)
-                finding "$CONFIG_DIR/$_name" ;;
+                finding "$CONFIG_DIR/$_name"
+                note "$CONFIG_DIR/$_name is not a file this toolkit writes; left in place" ;;
         esac
     done <<EOF
 $(ls -A "$CONFIG_DIR" 2>/dev/null)
@@ -1207,6 +1542,9 @@ EOF
     if [ "$_empty" -eq 1 ]; then
         note "exists but is empty"
     fi
+    # Last action of the run, and only if nothing of the user's is left in it.
+    plan_add 6 ours rmdir "$CONFIG_DIR" - - - - - - \
+        "remove $CONFIG_DIR if it ends up empty"
     detail "the next CLI invocation recreates this directory, so removing it is not idempotent"
 }
 
@@ -1241,33 +1579,59 @@ env_is_set() {
     env | awk -v n="$1" 'index($0, n "=") == 1 { f = 1 } END { exit !f }'
 }
 
+is_credential_name() {
+    printf '%s\n' "$CRED_ENV_NAMES" | awk -v n="$1" '$0 == n { f = 1 } END { exit !f }'
+}
+
+# An assignment to the exact name, optionally exported. The remover deletes
+# the lines this expression matches, so detection and removal cannot disagree
+# about what counts as an assignment.
+rc_assignment_ere() {
+    printf '%s\n' "^[[:space:]]*(export[[:space:]]+)?$1="
+}
+
+fish_assignment_ere() {
+    printf '%s\n' "^[[:space:]]*set([[:space:]]+-[A-Za-z]+)*[[:space:]]+$1[[:space:]]"
+}
+
+# Line numbers only, so no value ever reaches the report.
+matching_lines() {
+    grep -nE "$2" "$1" | cut -d: -f1 | tr '\n' ' '
+}
+
 scan_shell_rc() {
     _hit=0
     for _rc in \
         "$HOME/.profile" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.bash_login" \
-        "$HOME/.zshenv" "$HOME/.zprofile" "$HOME/.zshrc" "$HOME/.kshrc"
+        "$HOME/.zshenv" "$HOME/.zprofile" "$HOME/.zshrc" "$HOME/.kshrc" \
+        "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"
     do
         [ -f "$_rc" ] || continue
+        case "$_rc" in
+            */config.fish) _fish=1 ;;
+            *) _fish=0 ;;
+        esac
         for _name in $CRED_ENV_NAMES $CONFIG_ENV_NAMES; do
-            # An assignment to the exact name, optionally exported. Line numbers
-            # only, so no value ever reaches the report.
-            _lines=$(grep -nE "^[[:space:]]*(export[[:space:]]+)?$_name=" "$_rc" \
-                | cut -d: -f1 | tr '\n' ' ') || _lines=""
+            if is_credential_name "$_name"; then
+                _class=credential
+                _phase=2
+            else
+                _class=userconfig
+                _phase=6
+            fi
+            if [ "$_fish" -eq 1 ]; then
+                _ere=$(fish_assignment_ere "$_name")
+            else
+                _ere=$(rc_assignment_ere "$_name")
+            fi
+            _lines=$(matching_lines "$_rc" "$_ere") || _lines=""
             [ -n "$_lines" ] || continue
             _hit=1
             finding "$_name assigned in $_rc (line ${_lines% })"
+            plan_add "$_phase" "$_class" rcline "$_rc" "$_ere" - - - - - \
+                "delete the $_name assignment from $_rc"
         done
     done
-    _fish="${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"
-    if [ -f "$_fish" ]; then
-        for _name in $CRED_ENV_NAMES $CONFIG_ENV_NAMES; do
-            _lines=$(grep -nE "^[[:space:]]*set([[:space:]]+-[A-Za-z]+)*[[:space:]]+${_name}[[:space:]]" "$_fish" \
-                | cut -d: -f1 | tr '\n' ' ') || _lines=""
-            [ -n "$_lines" ] || continue
-            _hit=1
-            finding "$_name assigned in $_fish (line ${_lines% })"
-        done
-    fi
     if [ "$_hit" -eq 0 ]; then
         note "none assigned in a shell rc file"
     fi
@@ -1279,10 +1643,19 @@ scan_env_blocks() {
         return 0
     fi
     _hit=0
-    while IFS="$TAB" read -r _ _file _keypath _name _tier; do
+    while IFS="$TAB" read -r _ _file _keypath _name _tier _s1 _s2 _s3 _s4 _s5 _s6; do
         [ -n "${_file:-}" ] || continue
         _hit=1
         finding "$_name ($_tier) in $_file at $_keypath"
+        if [ "$_tier" = "credential" ]; then
+            plan_add 2 credential jsonkey "$_file" \
+                "$_s1" "$_s2" "$_s3" "$_s4" "$_s5" "$_s6" \
+                "delete $_keypath from $_file"
+        else
+            plan_add 6 userconfig jsonkey "$_file" \
+                "$_s1" "$_s2" "$_s3" "$_s4" "$_s5" "$_s6" \
+                "delete $_keypath from $_file"
+        fi
     done <<EOF
 $(records envkey)
 EOF
@@ -1302,6 +1675,7 @@ scan_completions() {
         [ -f "$_f" ] || continue
         _hit=1
         finding "$_f"
+        plan_add 6 ours rmpath "$_f" - - - - - - "delete $_f"
     done
     if [ -f "$HOME/.bashrc" ]; then
         # A source directive naming our exact script, not a line mentioning it.
@@ -1310,6 +1684,9 @@ scan_completions() {
         if [ -n "$_lines" ]; then
             _hit=1
             finding "$HOME/.bashrc sources the completion script (line ${_lines% })"
+            plan_add 6 userfile rcline "$HOME/.bashrc" \
+                '^[[:space:]]*(source|\.)[[:space:]]+.*/\.bash_completions/pipefy\.sh' \
+                - - - - - "delete the completion source line from $HOME/.bashrc"
         fi
     fi
     if [ -f "$HOME/.zfunc/_pipefy" ] && [ -f "$HOME/.zshrc" ]; then
@@ -1328,7 +1705,11 @@ scan_completions() {
 
 scan_skills() {
     section "Skills"
-    _dir="$HOME/.claude/skills"
+    # `npx skills add` writes into the state directory of the client that owns
+    # the plugin system, which is also where install.sh's skills step lands.
+    _srow=$(client_row_with_cap plugin-system)
+    [ -n "$_srow" ] || return 0
+    _dir="$(client_field "$_srow" 7)/skills"
     if [ ! -d "$_dir" ]; then
         note "no $_dir"
         return 0
@@ -1339,7 +1720,10 @@ scan_skills() {
         # gives this catalog's skills.
         [ -f "$_skill/SKILL.md" ] || continue
         _hit=$((_hit + 1))
-        detail "$(basename "$_skill")"
+        _sname=$(basename "$_skill")
+        detail "$_sname"
+        plan_add 5 ours rmpath "$_skill" - - - - - - \
+            "delete the $_sname skill"
     done
     if [ "$_hit" -eq 0 ]; then
         note "no pipefy-* skills in $_dir"
@@ -1358,12 +1742,731 @@ $(records err)
 EOF
 }
 
-print_next_steps() {
+
+# ------------------------------------------------------------ plan records
+#
+# One tab-separated row per action, eleven fields:
+#
+#   phase class kind a1 a2 a3 a4 a5 a6 a7 description
+#
+# phase fixes execution order and is load-bearing:
+#
+#   1 revoke     only `pipefy auth logout` reaches the identity provider, and
+#                that ability goes away with the tool environment
+#   2 credentials  local credential stores, once revocation has had its chance
+#   3 client configs  before the tools, so no registration is left pointing at
+#                a binary that no longer exists
+#   4 tools
+#   5 skills
+#   6 runtime state  last, because `pipefy auth logout` and `auth status`
+#                recreate the config directory
+#
+# class picks the approval tier and the --keep-* filters:
+#
+#   ours        tier 1, reversible by re-installing
+#   credential  tier 2, cannot be undone; skipped by --keep-credentials
+#   userfile    tier 3, the user's file, backed up first
+#   userconfig  tier 3, and skipped by --keep-config
+#
+# kinds and their slots:
+#
+#   mcpreg      a1 name  a2 scope  a3 project dir  a4 config file
+#   mcpdisable  a1 name  a2 project dir
+#   jsonkey     a1 file  a2..a7 key path, "-" terminated
+#   toml        a1 file  a2 table key  a3 section name
+#   plugin      a1 plugin id  a2 registry file  a3 scope
+#   market      a1 marketplace id  a2 registry file  a3 clone location
+#   uvtool      a1 tool name
+#   logout      -
+#   mcplogout   a1 registration name
+#   keychain    a1 account
+#   rmpath      a1 path
+#   rmdir       a1 path, removed only when empty
+#   rcline      a1 file  a2 extended regular expression matching the lines
+
+plan_add() {
+    [ "$COLLECTING" -eq 1 ] || return 0
+    case "$2" in
+        credential) [ "$KEEP_CREDENTIALS" -eq 0 ] || {
+            note_left "${11} — kept by --keep-credentials"
+            return 0
+        } ;;
+        userconfig) [ "$KEEP_CONFIG" -eq 0 ] || {
+            note_left "${11} — kept by --keep-config"
+            return 0
+        } ;;
+    esac
+    _pa_row=$(printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s' \
+        "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "${11}")
+    # The same artifact can be reached from more than one source — a settings
+    # file that is also the working directory's project settings, say. One row
+    # per action keeps the count honest and the execution idempotent.
+    if grep -Fqx -- "$_pa_row" "$PLAN" 2>/dev/null; then
+        return 0
+    fi
+    printf '%s\n' "$_pa_row" >>"$PLAN"
+}
+
+# One line per distinct note: the same artifact can be reached from more than
+# one source, and saying it twice reads as two problems.
+record_note() {
+    _nt_row=$(printf '%s\t%s' "$1" "$2")
+    if grep -Fqx -- "$_nt_row" "$NOTES" 2>/dev/null; then
+        return 0
+    fi
+    printf '%s\n' "$_nt_row" >>"$NOTES"
+}
+
+note_done() { record_note 'done' "$*"; }
+note_fail() { record_note fail "$*"; }
+note_left() { record_note left "$*"; }
+note_manual() { record_note manual "$*"; }
+note_backup() { record_note backup "$*"; }
+notes_of() { awk -F"$TAB" -v k="$1" '$1 == k { print $2 }' "$NOTES"; }
+
+tier_rows() {
+    awk -F"$TAB" -v want="$1" '
+        { tier = ($2 == "ours") ? 1 : (($2 == "credential") ? 2 : 3) }
+        tier == want
+    ' "$PLAN"
+}
+
+count_lines() { awk 'END { print NR + 0 }' "$1"; }
+
+tier_count() { tier_rows "$1" | awk 'END { print NR + 0 }'; }
+
+phase_rows() { awk -F"$TAB" -v want="$1" '$1 == want' "$PLAN"; }
+
+plan_has_kind() {
+    awk -F"$TAB" -v k="$1" '$3 == k { f = 1 } END { exit !f }' "$PLAN"
+}
+
+tier_approved() {
+    case "$1" in
+        ours) [ "$TIER1_OK" -eq 1 ] ;;
+        credential) [ "$TIER2_OK" -eq 1 ] ;;
+        *) [ "$TIER3_OK" -eq 1 ] ;;
+    esac
+}
+
+# ---------------------------------------------------------- planning passes
+
+# Registrations are planned from the scan's own records, so removal always uses
+# the name an entry was really registered under.
+plan_registrations() {
+    [ "$COLLECTING" -eq 1 ] || return 0
+    [ -n "$PYTHON3" ] || return 0
+    _scoped_id=$(client_field "$(client_row_with_cap scopes)" 1)
+    _hosted_seen=""
+    while IFS="$TAB" read -r _ _match _name _scope _pdir _file _kind _endpoint _command; do
+        [ "${_match:-}" = "definite" ] || continue
+        _cid=$(client_id_for_file "$_file")
+        [ -n "$_cid" ] || _cid="$_scoped_id"
+        _crow=$(client_row "$_cid")
+        case "$_kind" in
+            http|streamable-http|sse|ws)
+                if [ "$(url_host "$_endpoint")" = "$HOSTED_HOST" ]; then
+                    plan_hosted_token "$_cid" "$_crow" "$_name"
+                fi ;;
+        esac
+        # A plugin's own MCP config goes with the plugin, never on its own.
+        [ "$_scope" != "plugin" ] || continue
+        if ! client_selected "$_cid"; then
+            note_left "'$_name' in $_file — --client $CLIENT excludes $_cid"
+            continue
+        fi
+        case "$_scope" in
+            user|local)
+                plan_add 3 ours mcpreg "$_name" "$_scope" "$_pdir" "$_file" - - - \
+                    "remove the '$_name' registration ($_scope scope) from $_file" ;;
+            project)
+                plan_project_registration "$_name" "$_pdir" "$_file" ;;
+            *)
+                plan_add 3 ours jsonkey "$_file" "$(client_field "$_crow" 5)" \
+                    "$_name" - - - - \
+                    "remove the '$_name' registration from $_file" ;;
+        esac
+    done <<EOF
+$(records mcp)
+EOF
+}
+
+# The hosted server's OAuth token lives in the client's own credential store,
+# so only a client that ships a removal CLI can clear it from here.
+plan_hosted_token() {
+    case " $_hosted_seen " in
+        *" $3 "*) return 0 ;;
+    esac
+    _hosted_seen="$_hosted_seen $3"
+    if client_has_cap "$2" removal-cli; then
+        plan_add 1 credential mcplogout "$3" - - - - - - \
+            "clear the stored OAuth token for '$3'"
+    else
+        note_manual "clear the OAuth token for '$3' in $1 yourself; it has no CLI for it"
+    fi
+}
+
+# A .mcp.json under version control is the repository's own source. Editing it
+# is not durable, so the git-clean remediation is offered instead.
+plan_project_registration() {
+    if ! command -v git >/dev/null 2>&1; then
+        note_left "'$1' in $3 — git is not on PATH, so this run cannot tell whether the file is tracked"
+        return 0
+    fi
+    if git -C "$2" ls-files --error-unmatch .mcp.json >/dev/null 2>&1; then
+        plan_add 3 userfile mcpdisable "$1" "$2" - - - - - \
+            "disable '$1' for $2 through disabledMcpjsonServers ($3 is git-tracked)"
+        return 0
+    fi
+    plan_add 3 ours jsonkey "$3" mcpServers "$1" - - - - \
+        "remove the '$1' registration from $3"
+}
+
+plan_toml_section() {
+    [ "$COLLECTING" -eq 1 ] || return 0
+    if ! client_selected "$1"; then
+        note_left "[$3.$4] in $2 — --client $CLIENT excludes $1"
+        return 0
+    fi
+    if toml_section_is_pristine "$2" "$3" "$4"; then
+        plan_add 3 ours toml "$2" "$3" "$4" - - - - \
+            "remove the [$3.$4] section from $2"
+        return 0
+    fi
+    note_left "[$3.$4] in $2 holds more than the single line the installer appends, so it was edited by hand; excise the section yourself"
+}
+
+# ------------------------------------------------------------- presentation
+
+present_plan() {
+    _total=$(count_lines "$PLAN")
     say ""
-    say "Removal is not available in this version — this run only reported state."
+    say "PLAN — $_total actions"
+    if [ "$_total" -eq 0 ]; then
+        say "  nothing to remove"
+        return 0
+    fi
+    for _t in 1 2 3; do
+        _n=$(tier_count "$_t")
+        [ "$_n" -gt 0 ] || continue
+        say ""
+        case "$_t" in
+            1) say "[1] Ours, reversible — $_n actions" ;;
+            2) say "[2] Credentials — $_n actions (cannot be undone)" ;;
+            3) say "[3] Your files — $_n actions (backed up first)" ;;
+        esac
+        while IFS="$TAB" read -r _ _ _ _ _ _ _ _ _ _ _pd; do
+            [ -n "${_pd:-}" ] || continue
+            say "    $_pd"
+        done <<EOF
+$(tier_rows "$_t")
+EOF
+    done
+}
+
+# Tiered, not per action: around twenty individual prompts pushes everyone to
+# --yes and loses the safety entirely.
+approve_tiers() {
+    _n=$(tier_count 1)
+    if [ "$_n" -gt 0 ]; then
+        if confirm "[1] Remove $_n items this toolkit installed? Reinstalling restores them."; then
+            TIER1_OK=1
+        else
+            say "  tier 1 declined; nothing in it is touched"
+        fi
+    fi
+    _n=$(tier_count 2)
+    if [ "$_n" -gt 0 ]; then
+        if confirm "[2] Delete $_n stored credentials? This cannot be undone."; then
+            TIER2_OK=1
+        else
+            say "  tier 2 declined; credentials stay where they are"
+        fi
+    fi
+    _n=$(tier_count 3)
+    if [ "$_n" -gt 0 ]; then
+        if confirm "[3] Edit $_n of your own files? Each is backed up to <file>.bak.$BACKUP_STAMP first."; then
+            TIER3_OK=1
+        else
+            say "  tier 3 declined; your files stay as they are"
+        fi
+    fi
+}
+
+# Exact process names, compared after stripping any directory: a substring
+# match on "claude" or "cursor" hits unrelated processes.
+LIVE_PROCESS_NAMES="claude Claude Cursor cursor-agent codex Code Codex"
+
+live_server_guard() {
+    if ! command -v ps >/dev/null 2>&1; then
+        note_left "no 'ps' on PATH, so this run could not check for a running client"
+        return 0
+    fi
+    _live=""
+    while IFS= read -r _proc; do
+        _proc="${_proc##*/}"
+        [ -n "$_proc" ] || continue
+        for _want in $LIVE_PROCESS_NAMES "$SERVER_BINARY"; do
+            [ "$_proc" = "$_want" ] || continue
+            case " $_live " in
+                *" $_proc "*) ;;
+                *) _live="$_live $_proc" ;;
+            esac
+        done
+    done <<EOF
+$(ps -A -o comm= 2>/dev/null || true)
+EOF
+    [ -n "$_live" ] || return 0
+    say ""
+    say "Running client detected:${_live}"
+    say "  A running client rewrites its own config and can put back an entry this"
+    say "  run removes. Quit it first, then continue."
+    if [ "$YES" -eq 1 ]; then
+        warn "--yes given; continuing with${_live} still running"
+        note_left "these were running during the run and may have rewritten their config:${_live}"
+        return 0
+    fi
+    confirm "Quit those, then continue?" || abort "Nothing was removed."
+}
+
+abort() {
+    say ""
+    say "$*"
+    exit 1
+}
+
+# ------------------------------------------------------- removal primitives
+
+# The one path this script deletes through. Everything routes here so the
+# refusals cannot be skipped by a caller that forgot them. Tempfiles this
+# script creates come back through here too.
+remove_path() {
+    _rp="${1:-}"
+    _rp_mode="${2:-tree}"
+    [ -n "$_rp" ] || err "refusing to remove an empty path"
+    case "$_rp" in
+        /*) ;;
+        *) err "refusing to remove a relative path: $_rp" ;;
+    esac
+    while [ "$_rp" != "/" ] && [ "${_rp%/}" != "$_rp" ]; do
+        _rp="${_rp%/}"
+    done
+    [ "$_rp" != "/" ] || err "refusing to remove /"
+    [ "$_rp" != "$HOME" ] || err "refusing to remove \$HOME ($HOME)"
+    if [ "$_rp_mode" = "empty-dir" ]; then
+        run rmdir "$_rp"
+    elif [ -e "$_rp" ] || [ -L "$_rp" ]; then
+        run rm -rf -- "$_rp"
+    fi
+}
+
+# Nothing this script did not write is edited before a copy exists beside it.
+backup_file() {
+    _bk="$1"
+    [ -f "$_bk" ] || return 0
+    _bk_dest="$_bk.bak.$BACKUP_STAMP"
+    if [ -e "$_bk_dest" ]; then
+        return 0
+    fi
+    if run cp -p "$_bk" "$_bk_dest"; then
+        BACKUPS=$((BACKUPS + 1))
+        note_backup "$_bk_dest"
+        return 0
+    fi
+    warn "could not back up $_bk; leaving it untouched"
+    return 1
+}
+
+# Rewrite a file through an awk program without ever leaving it half-written:
+# the temp file inherits the original's mode from cp -p, and the rename is
+# within the same directory, so a reader sees the old file or the new one.
+atomic_awk_rewrite() {
+    _aw_file="$1"
+    _aw_prog="$2"
+    _aw_arg="$3"
+    _aw_arg2="${4:-}"
+    trace "rewrite $_aw_file"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        return 0
+    fi
+    _aw_tmp=$(mktemp "$(dirname "$_aw_file")/.pipefy-uninstall.XXXXXX") || return 1
+    if cp -p "$_aw_file" "$_aw_tmp" \
+        && AW_ARG="$_aw_arg" AW_ARG2="$_aw_arg2" awk "$_aw_prog" "$_aw_file" >"$_aw_tmp" \
+        && mv -f "$_aw_tmp" "$_aw_file"
+    then
+        return 0
+    fi
+    remove_path "$_aw_tmp"
+    return 1
+}
+
+# Exit 3 from the program below means the key was already gone, which reaches
+# the same end state as removing it.
+json_remove_key() {
+    _jr_file="$1"
+    shift
+    [ -n "$PYTHON3" ] || return 1
+    trace "remove $* from $_jr_file"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        return 0
+    fi
+    _jr_rc=0
+    "$PYTHON3" - "$_jr_file" "$@" <<'PY' || _jr_rc=$?
+import json
+import os
+import sys
+import tempfile
+
+path = sys.argv[1]
+keys = sys.argv[2:]
+try:
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+except (OSError, ValueError) as exc:
+    sys.stderr.write("error: %s: %s\n" % (path, exc))
+    sys.exit(1)
+node = data
+for key in keys[:-1]:
+    if not isinstance(node, dict) or key not in node:
+        sys.exit(3)
+    node = node[key]
+if not isinstance(node, dict) or keys[-1] not in node:
+    sys.exit(3)
+del node[keys[-1]]
+fd, tmp = tempfile.mkstemp(
+    prefix=os.path.basename(path) + ".", dir=os.path.dirname(path) or "."
+)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+        fh.write("\n")
+    os.replace(tmp, path)
+except BaseException:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PY
+    [ "$_jr_rc" -ne 3 ] || return 0
+    return "$_jr_rc"
+}
+
+json_add_disabled() {
+    [ -n "$PYTHON3" ] || return 1
+    trace "add $3 to projects.$2.disabledMcpjsonServers in $1"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        return 0
+    fi
+    _ja_rc=0
+    "$PYTHON3" - "$1" "$2" "$3" <<'PY' || _ja_rc=$?
+import json
+import os
+import sys
+import tempfile
+
+path, projdir, name = sys.argv[1], sys.argv[2], sys.argv[3]
+data = {}
+if os.path.exists(path):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as exc:
+        sys.stderr.write("error: %s: %s\n" % (path, exc))
+        sys.exit(1)
+if not isinstance(data, dict):
+    sys.exit(1)
+projects = data.setdefault("projects", {})
+if not isinstance(projects, dict):
+    sys.exit(1)
+entry = projects.setdefault(projdir, {})
+if not isinstance(entry, dict):
+    sys.exit(1)
+disabled = entry.setdefault("disabledMcpjsonServers", [])
+if not isinstance(disabled, list):
+    sys.exit(1)
+if name in disabled:
+    sys.exit(3)
+disabled.append(name)
+fd, tmp = tempfile.mkstemp(
+    prefix=os.path.basename(path) + ".", dir=os.path.dirname(path) or "."
+)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+        fh.write("\n")
+    os.replace(tmp, path)
+except BaseException:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+PY
+    [ "$_ja_rc" -ne 3 ] || return 0
+    return "$_ja_rc"
+}
+
+# A verb is probed for, never inferred from a client version.
+cli_verb_exists() {
+    _cv_cli="$1"
+    _cv_verb="$2"
+    shift 2
+    [ "$_cv_cli" != "-" ] || return 1
+    command -v "$_cv_cli" >/dev/null 2>&1 || return 1
+    "$_cv_cli" "$@" --help 2>/dev/null \
+        | awk -v v="$_cv_verb" '$1 == v { f = 1 } END { exit !f }'
+}
+
+client_row_for_config() {
+    client_rows | awk -F'|' -v f="$1" '$4 == f { print; exit }'
+}
+
+removal_cli() {
+    _rc_row=$(client_row_with_cap removal-cli)
+    [ -n "$_rc_row" ] || return 1
+    _rc_cli=$(client_field "$_rc_row" 9)
+    [ "$_rc_cli" != "-" ] || return 1
+    printf '%s\n' "$_rc_cli"
+}
+
+# ----------------------------------------------------------------- actions
+
+act_mcpreg() {
+    _mr_row=$(client_row_for_config "$4")
+    _mr_cli=$(client_field "$_mr_row" 9)
+    if client_has_cap "$_mr_row" removal-cli && cli_verb_exists "$_mr_cli" remove mcp; then
+        if [ "$2" = "local" ]; then
+            # Local scope is resolved against the working directory.
+            ( cd "$3" && run "$_mr_cli" mcp remove "$1" -s local )
+            return $?
+        fi
+        run "$_mr_cli" mcp remove "$1" -s "$2"
+        return $?
+    fi
+    backup_file "$4" || return 1
+    _mr_key=$(client_field "$_mr_row" 5)
+    if [ "$2" = "local" ]; then
+        json_remove_key "$4" projects "$3" "$_mr_key" "$1"
+    else
+        json_remove_key "$4" "$_mr_key" "$1"
+    fi
+}
+
+act_mcpdisable() {
+    _md_row=$(client_row_with_cap scopes)
+    _md_file=$(client_field "$_md_row" 4)
+    backup_file "$_md_file" || return 1
+    json_add_disabled "$_md_file" "$2" "$1"
+}
+
+act_jsonkey() {
+    _jk_file="$1"
+    shift
+    backup_file "$_jk_file" || return 1
+    _jk_n=0
+    for _jk_seg in "$@"; do
+        [ "$_jk_seg" != "-" ] || break
+        _jk_n=$((_jk_n + 1))
+    done
+    case "$_jk_n" in
+        0) return 1 ;;
+        1) json_remove_key "$_jk_file" "$1" ;;
+        2) json_remove_key "$_jk_file" "$1" "$2" ;;
+        3) json_remove_key "$_jk_file" "$1" "$2" "$3" ;;
+        4) json_remove_key "$_jk_file" "$1" "$2" "$3" "$4" ;;
+        5) json_remove_key "$_jk_file" "$1" "$2" "$3" "$4" "$5" ;;
+        *) json_remove_key "$_jk_file" "$1" "$2" "$3" "$4" "$5" "$6" ;;
+    esac
+}
+
+# Section-aware, because install.sh appends the block as raw text: the excision
+# runs from the header to the next table header or end of file. Blank lines are
+# held back and printed before the next real line, so the blank the installer
+# put in front of its block disappears with it when the block ended the file,
+# and a separator between two sections that stay survives.
+act_toml() {
+    backup_file "$1" || return 1
+    # shellcheck disable=SC2016  # an awk program, not a shell expansion
+    atomic_awk_rewrite "$1" '
+        function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+        BEGIN { sec = "[" ENVIRON["AW_ARG2"] "." ENVIRON["AW_ARG"] "]" }
+        {
+            t = trim($0)
+            if (skip) {
+                if (substr(t, 1, 1) == "[") { skip = 0 }
+                else { next }
+            }
+            if (t == sec) { skip = 1; next }
+            if (t == "") { pending++; next }
+            while (pending > 0) { print ""; pending-- }
+            print
+        }
+    ' "$3" "$2"
+}
+
+act_rcline() {
+    backup_file "$1" || return 1
+    # shellcheck disable=SC2016  # an awk program, not a shell expansion
+    atomic_awk_rewrite "$1" '
+        BEGIN { re = ENVIRON["AW_ARG"] }
+        $0 ~ re { next }
+        { print }
+    ' "$2"
+}
+
+act_rmpath() {
+    if [ ! -e "$1" ] && [ ! -L "$1" ]; then
+        return 3
+    fi
+    case "$2" in
+        userfile|userconfig) backup_file "$1" || return 1 ;;
+    esac
+    remove_path "$1"
+}
+
+act_rmdir() {
+    if [ ! -d "$1" ]; then
+        return 0
+    fi
+    # shellcheck disable=SC2012  # names only, for a message
+    _rd_rest=$(ls -A "$1" 2>/dev/null | tr '\n' ' ')
+    if [ -n "$_rd_rest" ]; then
+        note_left "$1 was kept: it still holds ${_rd_rest% }"
+        return 3
+    fi
+    remove_path "$1" empty-dir
+}
+
+act_uvtool() {
+    if ! command -v uv >/dev/null 2>&1; then
+        note_left "uv is not on PATH, so '$1' could not be uninstalled"
+        return 1
+    fi
+    run uv tool uninstall "$1"
+}
+
+act_logout() {
+    if ! command -v pipefy >/dev/null 2>&1; then
+        note_left "'pipefy' is not on PATH, so the refresh token could not be revoked at the identity provider; whatever is deleted locally stays valid there until it expires"
+        return 3
+    fi
+    if run pipefy auth logout; then
+        REVOKED=1
+        return 0
+    fi
+    note_left "'pipefy auth logout' failed, so the refresh token was not revoked at the identity provider; anything deleted locally stays valid until it expires"
+    return 1
+}
+
+act_keychain() {
+    case "$OS" in
+        Darwin)
+            command -v security >/dev/null 2>&1 || return 1
+            run security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$1" ;;
+        Linux)
+            command -v secret-tool >/dev/null 2>&1 || return 1
+            run secret-tool clear service "$KEYCHAIN_SERVICE" username "$1" ;;
+        *) return 1 ;;
+    esac
+}
+
+act_mcplogout() {
+    _ml_cli=$(removal_cli) || _ml_cli="-"
+    if cli_verb_exists "$_ml_cli" logout mcp; then
+        run "$_ml_cli" mcp logout "$1"
+        return $?
+    fi
+    note_manual "clear the hosted token by hand: run /mcp, pick '$1', then Clear authentication"
+    return 3
+}
+
+act_plugin() {
+    _pl_cli=$(removal_cli) || _pl_cli="-"
+    if cli_verb_exists "$_pl_cli" uninstall plugin; then
+        case "$3" in
+            user|project|local) run "$_pl_cli" plugin uninstall "$1" -y -s "$3" ;;
+            *) run "$_pl_cli" plugin uninstall "$1" -y ;;
+        esac
+        return $?
+    fi
+    backup_file "$2" || return 1
+    json_remove_key "$2" plugins "$1"
+}
+
+act_market() {
+    _mk_cli=$(removal_cli) || _mk_cli="-"
+    note_left "the '$1' marketplace can come back: a later session re-adds it from a settings file that still lists it or from a plugin that still needs it, so confirm with a fresh session"
+    if cli_verb_exists "$_mk_cli" remove "plugin marketplace"; then
+        run "$_mk_cli" plugin marketplace remove "$1"
+        return $?
+    fi
+    backup_file "$2" || return 1
+    json_remove_key "$2" "$1" || return 1
+    if [ "$3" != "-" ] && [ -d "$3" ]; then
+        remove_path "$3"
+    fi
+}
+
+do_action() {
+    _ac_class="$1"
+    _ac_kind="$2"
+    shift 2
+    case "$_ac_kind" in
+        mcpreg) act_mcpreg "$1" "$2" "$3" "$4" ;;
+        mcpdisable) act_mcpdisable "$1" "$2" ;;
+        jsonkey) act_jsonkey "$1" "$2" "$3" "$4" "$5" "$6" "$7" ;;
+        toml) act_toml "$1" "$2" "$3" ;;
+        plugin) act_plugin "$1" "$2" "$3" ;;
+        market) act_market "$1" "$2" "$3" ;;
+        uvtool) act_uvtool "$1" ;;
+        logout) act_logout ;;
+        mcplogout) act_mcplogout "$1" ;;
+        keychain) act_keychain "$1" ;;
+        rmpath) act_rmpath "$1" "$_ac_class" ;;
+        rmdir) act_rmdir "$1" ;;
+        rcline) act_rcline "$1" "$2" ;;
+        *) return 1 ;;
+    esac
+}
+
+execute_plan() {
+    for _ph in 1 2 3 4 5 6; do
+        while IFS="$TAB" read -r _ _cls _knd _p1 _p2 _p3 _p4 _p5 _p6 _p7 _dsc; do
+            [ -n "${_knd:-}" ] || continue
+            tier_approved "$_cls" || continue
+            _rc=0
+            do_action "$_cls" "$_knd" \
+                "$_p1" "$_p2" "$_p3" "$_p4" "$_p5" "$_p6" "$_p7" || _rc=$?
+            # 3 means the action decided there was nothing to do and said why
+            # in a note of its own; anything else non-zero is a failure.
+            if [ "$_rc" -eq 0 ]; then
+                DONE_COUNT=$((DONE_COUNT + 1))
+                note_done "$_dsc"
+                if [ "$_cls" = credential ] && [ "$_knd" != logout ]; then
+                    CRED_DELETED=1
+                fi
+            elif [ "$_rc" -eq 3 ]; then
+                SKIP_COUNT=$((SKIP_COUNT + 1))
+            else
+                FAIL_COUNT=$((FAIL_COUNT + 1))
+                note_fail "$_dsc"
+            fi
+        done <<EOF
+$(phase_rows "$_ph")
+EOF
+    done
+}
+
+# ------------------------------------------------------------------ reports
+
+print_scan_next_steps() {
+    say ""
+    say "This run only reported state — --scan removes nothing."
     say "Nothing on this machine was changed."
     say ""
-    say "To reverse the pieces by hand until it is:"
+    say "Run uninstall.sh with no flags to remove what this found, or reverse the"
+    say "pieces by hand:"
     say "  local install       uv tool uninstall pipefy-cli $SERVER_BINARY"
     say "  Claude Code MCP     claude mcp remove <name> -s user   (also -s local)"
     say "  Claude Code plugin  /plugin uninstall $PLUGIN_ID, then"
@@ -1383,32 +2486,90 @@ print_next_steps() {
     say "disable it through disabledMcpjsonServers instead of editing the file."
 }
 
-main() {
-    parse_args "$@"
-    refuse_root
-    detect_platform
-    resolve_config_dir
-    PYTHON3=$(command -v python3 2>/dev/null) || PYTHON3=""
+print_note_group() {
+    _ng_any=0
+    while IFS= read -r _ng_line; do
+        [ -n "$_ng_line" ] || continue
+        if [ "$_ng_any" -eq 0 ]; then
+            say ""
+            say "$2"
+            _ng_any=1
+        fi
+        say "  * $_ng_line"
+    done <<EOF
+$(notes_of "$1")
+EOF
+}
 
-    RECORDS=$(mktemp "${TMPDIR:-/tmp}/pipefy-scan.XXXXXX") \
-        || err "mktemp failed (TMPDIR=${TMPDIR:-/tmp})"
-    trap 'rm -f "$RECORDS"' EXIT INT TERM
+print_teardown_report() {
+    section "What happened"
+    say "  $DONE_COUNT completed, $SKIP_COUNT skipped, $FAIL_COUNT failed, $BACKUPS backed up"
+    print_note_group 'done' "Removed:"
+    print_note_group 'fail' "Failed — these are still here:"
+    print_note_group 'backup' "Backed up before editing:"
+    print_note_group 'left' "Left alone:"
+    print_note_group 'manual' "Do this yourself:"
 
-    say "Pipefy toolkit scan"
-    say "  home:      $HOME"
-    say "  platform:  $OS"
-    say "  config:    $CONFIG_DIR"
-    if [ -n "$PYTHON3" ]; then
-        say "  python3:   $PYTHON3"
-    else
-        say "  python3:   not found — JSON sources will not be inspected"
+    if [ "$CRED_DELETED" -eq 1 ] && [ "$REVOKED" -eq 0 ]; then
+        say ""
+        say "A credential was deleted from this machine but not revoked at the identity"
+        say "provider, so it stays valid there until it expires. Only 'pipefy auth logout'"
+        say "revokes, and it could not run here."
     fi
-    if [ -n "$CLIENT" ]; then
-        say "  client:    $CLIENT (detection sweeps every client regardless)"
+
+    _live=0
+    for _name in $CRED_ENV_NAMES $CONFIG_ENV_NAMES; do
+        env_is_set "$_name" || continue
+        if [ "$_live" -eq 0 ]; then
+            say ""
+            say "Set in the shell that started this run:"
+            _live=1
+        fi
+        say "  * unset $_name"
+    done
+    if [ "$_live" -eq 1 ]; then
+        say "  A child process cannot unset a variable in its parent shell. Run the"
+        say "  commands above, or start a new shell."
     fi
-    if [ "$DRY_RUN" -eq 1 ]; then
-        say "  --dry-run has no effect: this version only scans."
+
+    say ""
+    say "Never touched, by design:"
+    say "  * uv itself, and the PATH lines its installer added to your shell rc."
+    say "    By now other tools depend on it. Edit those lines yourself if you want"
+    say "    them gone: uv tool dir is separate from uv."
+    say "  * The uv cache. Never run a bare 'uv cache clean': with no package"
+    say "    argument it clears the cache for every package, and uv hardlinks tool"
+    say "    environments into it, so a running MCP server breaks until its client"
+    say "    restarts. 'uv cache prune' is the safe form, and only while nothing is"
+    say "    running."
+    say "  * Editable-install entries in the uv cache. They belong to other"
+    say "    repositories' virtualenvs and removing one breaks that checkout."
+    say "  * Any git-tracked .mcp.json. git restores it on the next checkout, so"
+    say "    disabledMcpjsonServers is the durable answer."
+    say "  * Your git checkouts. Uninstalling is about tooling, not source."
+
+    say ""
+    say "Switching to another channel:"
+    say "  hosted        claude mcp add --transport http --scope user \\"
+    say "                  --client-id pipefy-mcp $CANONICAL_NAME https://$HOSTED_HOST/mcp"
+    say "  plugin        /plugin marketplace add $REPO"
+    say "                /plugin install $CANONICAL_NAME"
+    say "  local install curl -fsSL https://raw.githubusercontent.com/$REPO/main/install.sh \\"
+    say "                  | sh -s -- --client <claude-code|claude-desktop|cursor|codex>"
+    if [ -d "$CONFIG_DIR" ]; then
+        say ""
+        say "$CONFIG_DIR is still here. Any later 'pipefy' invocation recreates it —"
+        say "'auth logout' and 'auth status' both do — so its presence is not a failed"
+        say "removal."
     fi
+}
+
+# ------------------------------------------------------------------ driving
+
+run_scan() {
+    FINDINGS=0
+    SCAN_ERRORS=0
+    : >"$RECORDS"
 
     set --
     while IFS= read -r _pdir; do
@@ -1450,10 +2611,98 @@ EOF
     if [ "$SCAN_ERRORS" -gt 0 ]; then
         say "  $SCAN_ERRORS sources could not be inspected"
     fi
+}
 
-    print_next_steps
+main() {
+    parse_args "$@"
+    refuse_root
+    detect_platform
+    resolve_config_dir
+    PYTHON3=$(command -v python3 2>/dev/null) || PYTHON3=""
+    BACKUP_STAMP=$(date +%Y%m%d%H%M%S 2>/dev/null) || BACKUP_STAMP=""
+    [ -n "$BACKUP_STAMP" ] || BACKUP_STAMP="backup"
 
+    RECORDS=$(mktemp "${TMPDIR:-/tmp}/pipefy-scan.XXXXXX") \
+        || err "mktemp failed (TMPDIR=${TMPDIR:-/tmp})"
+    PLAN=$(mktemp "${TMPDIR:-/tmp}/pipefy-plan.XXXXXX") \
+        || err "mktemp failed (TMPDIR=${TMPDIR:-/tmp})"
+    NOTES=$(mktemp "${TMPDIR:-/tmp}/pipefy-notes.XXXXXX") \
+        || err "mktemp failed (TMPDIR=${TMPDIR:-/tmp})"
+    trap 'rm -f "$RECORDS" "$PLAN" "$NOTES"' EXIT INT TERM
+
+    if [ "$MODE" = scan ]; then
+        say "Pipefy toolkit scan"
+    else
+        say "Pipefy toolkit uninstall"
+    fi
+    say "  home:      $HOME"
+    say "  platform:  $OS"
+    say "  config:    $CONFIG_DIR"
+    if [ -n "$PYTHON3" ]; then
+        say "  python3:   $PYTHON3"
+    else
+        say "  python3:   not found — JSON sources will not be inspected"
+    fi
+    if [ -n "$CLIENT" ]; then
+        say "  client:    $CLIENT (detection sweeps every client regardless)"
+    fi
+    if [ "$DRY_RUN" -eq 1 ] && [ "$MODE" = scan ]; then
+        say "  --dry-run has no effect in --scan mode: a scan changes nothing."
+    fi
+
+    [ "$MODE" = scan ] || COLLECTING=1
+    run_scan
+
+    if [ "$MODE" = scan ]; then
+        print_scan_next_steps
+        if [ "$SCAN_ERRORS" -gt 0 ]; then
+            exit 2
+        fi
+        if [ "$FINDINGS" -gt 0 ]; then
+            exit 1
+        fi
+        exit 0
+    fi
+
+    plan_registrations
+    COLLECTING=0
+
+    if [ -z "$PYTHON3" ]; then
+        err "removal needs python3: without it the JSON sources above were never read, and a teardown planned from a partial scan would leave exactly the state that causes conflicts. Install python3, or use --scan."
+    fi
+
+    present_plan
+    if [ "$(count_lines "$PLAN")" -eq 0 ]; then
+        say ""
+        say "Nothing to remove."
+        exit 0
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        say ""
+        say "--dry-run: nothing was changed."
+        exit 0
+    fi
     if [ "$SCAN_ERRORS" -gt 0 ]; then
+        say ""
+        say "$SCAN_ERRORS sources could not be inspected, so this plan may be incomplete."
+        confirm "Continue anyway?" || abort "Nothing was removed."
+    fi
+
+    approve_tiers
+    if [ "$TIER1_OK" -eq 0 ] && [ "$TIER2_OK" -eq 0 ] && [ "$TIER3_OK" -eq 0 ]; then
+        abort "Every tier was declined. Nothing was removed."
+    fi
+
+    live_server_guard
+    execute_plan
+
+    section "Re-scan"
+    say "  'uninstalled' has to be an observed fact: a uv tool uninstall can succeed"
+    say "  while a binary of the same name is still earlier on PATH."
+    run_scan
+    print_teardown_report
+
+    if [ "$FAIL_COUNT" -gt 0 ] || [ "$SCAN_ERRORS" -gt 0 ]; then
         exit 2
     fi
     if [ "$FINDINGS" -gt 0 ]; then


### PR DESCRIPTION
## Motivation

The scan reports; nothing removes. Teardown is the point of the milestone, and the ordering it needs is not obvious enough to leave to whoever writes it next.

## Outcome

The destructive path, on the client table the scan already uses.

**Clients are data.** One row carries id, platform, format, config path, servers key, scope label, state directory, capabilities and cli. Adding a client is a row and no new code — `test_a_new_client_costs_one_row_and_no_new_logic` appends a synthetic row to a copy of the shipped script and asserts detection, planned removal, the file edit, the backup and `--client` narrowing all work with nothing else changed. `--help` and the accepted values are both derived from the table so they cannot drift.

**Capabilities gate the client-specific work, not the client id.** `scopes` drives the project walk and precedence, `plugin-system` the marketplace and skills directory, `removal-cli` the delegation. This change also retrofits the scan, whose Cursor and Claude Desktop handling was inline: both surfaces now enumerate clients exactly once.

**Ordering is load-bearing.** Revoke first, because only `pipefy auth logout` reaches the identity provider and that ability leaves with the tool environment. Then credentials, then client configs — before tools, or a registration is left pointing at a binary that no longer exists. Runtime state last, because `pipefy auth logout` and `auth status` both recreate `~/.config/pipefy`, so clearing it earlier clears nothing. A re-scan closes the run: `uv tool uninstall` can succeed while a binary of the same name is still earlier on `PATH`. The stub log asserts the sequence, which no filesystem check can see.

**Approval is tiered.** What the toolkit installed, bulk; credentials, separately and worded as permanent; your own files, separately and copied to `<file>.bak.<timestamp>` first. Around twenty individual prompts pushes everyone to `--yes` and loses the safety entirely. `--yes`, `--dry-run`, `--keep-credentials`, `--keep-config` and `--client` are all covered.

**One deletion primitive.** Every `rm` and `rmdir` routes through `remove_path`, which refuses an empty argument, a relative path, `/` and `$HOME`. The script's own tempfiles go through it too. Eight refusals are tested under `--dry-run`, so a broken guard echoes rather than deletes.

Registrations are removed under the name they were found with. The hosted OAuth token goes through `claude mcp logout`, gated on a probe for the verb rather than a client version — a stub whose help omits the verb falls back to the `/mcp` instruction while other delegation still works.

Never done, and reported instead: `uv cache clean` in any form, removing uv, editing the shell rc lines uv added, machine-editing a git-tracked `.mcp.json`, and chasing the editable-install entries in the uv cache, which belong to other repositories' virtualenvs. Where a marketplace or a tracked file is reported, the report says removal is not durable and what brings it back.

## Notes

Exercised end to end against a fixture: a registration named `pipefy-dev` removed while an unrelated server in the same file survived, the Codex section excised, timestamped backups beside both files, and the config directory cleared. A Codex section edited by hand degrades to report-only, since `install.sh` appends exactly a header and one command line.

The hosted-token behavior corrects #536, which claimed the token was not separately removable. `claude mcp logout <name>` clears one server and leaves the rest, verified against Claude Code 2.1.221; the issue has been updated.

Based on #581. Part of #536. Closes #539.
