### PR TITLE
fix(mcp): write failure without blank message or blind retry (#522)

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/graphql_error_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/graphql_error_helpers.py
@@ -40,6 +40,16 @@ from pipefy_mcp.core.tool_error_envelope import tool_error
 _DICT_REPR_PREFIX_RE = re.compile(r"^\s*\{\s*['\"]message['\"]\s*:")
 
 
+def ensure_non_empty_error_message(text: str, fallback: str) -> str:
+    """Return ``text`` when non-blank after strip; otherwise ``fallback``.
+
+    Args:
+        text: Candidate error message (may be empty or whitespace-only).
+        fallback: Stable non-empty message used when ``text`` is blank.
+    """
+    return text if text.strip() else fallback
+
+
 def _try_extract_message_from_dict_repr(raw: str) -> str | None:
     """Return inner ``message`` when ``str(exc)`` is a single-error dict repr.
 
@@ -541,6 +551,7 @@ __all__ = [
     "enrich_invalid_arguments_error",
     "enrich_not_found_error",
     "enrich_permission_denied_error",
+    "ensure_non_empty_error_message",
     "extract_error_strings",
     "extract_graphql_correlation_id",
     "extract_graphql_error_codes",

--- a/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
@@ -16,6 +16,21 @@ from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
 
 _GRAPHQL_TOOL_REQUEST_FAILED = "GraphQL request failed."
+_EXECUTE_GRAPHQL_FAILED = (
+    "GraphQL request failed. If this was a write, re-read counts/ids "
+    "before retrying; do not blind-retry."
+)
+_GRAPHQL_RETURNED_ERRORS = "GraphQL returned errors."
+
+
+def _exception_error_payload(exc: BaseException, fallback: str) -> dict:
+    return build_error_payload(ensure_non_empty_error_message(str(exc), fallback))
+
+
+def _soft_result_error_payload(err: str) -> dict:
+    return build_error_payload(
+        ensure_non_empty_error_message(err, _GRAPHQL_RETURNED_ERRORS)
+    )
 
 
 class IntrospectionTools:
@@ -50,14 +65,10 @@ class IntrospectionTools:
             try:
                 result = await client.introspect_type(type_name, max_depth=max_depth)
             except Exception as exc:  # noqa: BLE001
-                return build_error_payload(
-                    ensure_non_empty_error_message(
-                        str(exc), _GRAPHQL_TOOL_REQUEST_FAILED
-                    )
-                )
+                return _exception_error_payload(exc, _GRAPHQL_TOOL_REQUEST_FAILED)
             err = result.get("error")
-            if isinstance(err, str) and err:
-                return build_error_payload(err)
+            if isinstance(err, str):
+                return _soft_result_error_payload(err)
             return build_success_payload(result, include_parsed=include_parsed)
 
         @mcp.tool(
@@ -87,14 +98,10 @@ class IntrospectionTools:
                     mutation_name, max_depth=max_depth
                 )
             except Exception as exc:  # noqa: BLE001
-                return build_error_payload(
-                    ensure_non_empty_error_message(
-                        str(exc), _GRAPHQL_TOOL_REQUEST_FAILED
-                    )
-                )
+                return _exception_error_payload(exc, _GRAPHQL_TOOL_REQUEST_FAILED)
             err = result.get("error")
-            if isinstance(err, str) and err:
-                return build_error_payload(err)
+            if isinstance(err, str):
+                return _soft_result_error_payload(err)
             return build_success_payload(result, include_parsed=include_parsed)
 
         @mcp.tool(
@@ -122,14 +129,10 @@ class IntrospectionTools:
             try:
                 result = await client.introspect_query(query_name, max_depth=max_depth)
             except Exception as exc:  # noqa: BLE001
-                return build_error_payload(
-                    ensure_non_empty_error_message(
-                        str(exc), _GRAPHQL_TOOL_REQUEST_FAILED
-                    )
-                )
+                return _exception_error_payload(exc, _GRAPHQL_TOOL_REQUEST_FAILED)
             err = result.get("error")
-            if isinstance(err, str) and err:
-                return build_error_payload(err)
+            if isinstance(err, str):
+                return _soft_result_error_payload(err)
             return build_success_payload(result, include_parsed=include_parsed)
 
         @mcp.tool(
@@ -157,14 +160,10 @@ class IntrospectionTools:
             try:
                 result = await client.search_schema(keyword, kind=kind)
             except Exception as exc:  # noqa: BLE001
-                return build_error_payload(
-                    ensure_non_empty_error_message(
-                        str(exc), _GRAPHQL_TOOL_REQUEST_FAILED
-                    )
-                )
+                return _exception_error_payload(exc, _GRAPHQL_TOOL_REQUEST_FAILED)
             err = result.get("error")
-            if isinstance(err, str) and err:
-                return build_error_payload(err)
+            if isinstance(err, str):
+                return _soft_result_error_payload(err)
             return build_success_payload(result, include_parsed=include_parsed)
 
         @mcp.tool(
@@ -181,6 +180,8 @@ class IntrospectionTools:
 
             Prefer dedicated tools when available. Use this as a fallback when no specific
             tool exists. Always introspect the mutation's input shape before executing.
+            On ambiguous write failure (``success: false`` with empty or unclear message),
+            re-read counts/ids before retrying; do not blind-retry creates.
             Returns ``result`` (pretty-printed JSON string).  Set ``include_parsed=True``
             to also get a ``data`` dict for programmatic access.
 
@@ -193,22 +194,20 @@ class IntrospectionTools:
             try:
                 result = await client.execute_graphql(query, variables)
             except Exception as exc:  # noqa: BLE001
-                return build_error_payload(
-                    ensure_non_empty_error_message(
-                        str(exc), _GRAPHQL_TOOL_REQUEST_FAILED
-                    )
-                )
+                return _exception_error_payload(exc, _EXECUTE_GRAPHQL_FAILED)
             gql_errors = result.get("errors")
             if isinstance(gql_errors, list) and gql_errors:
                 messages: list[str] = []
                 for item in gql_errors:
                     if isinstance(item, dict):
                         msg = item.get("message")
-                        if isinstance(msg, str) and msg:
-                            messages.append(msg)
-                text = "; ".join(messages) if messages else "GraphQL returned errors."
+                        if isinstance(msg, str):
+                            stripped = msg.strip()
+                            if stripped:
+                                messages.append(stripped)
+                text = "; ".join(messages) if messages else _GRAPHQL_RETURNED_ERRORS
                 return build_error_payload(text)
             err = result.get("error")
-            if isinstance(err, str) and err:
-                return build_error_payload(err)
+            if isinstance(err, str):
+                return _soft_result_error_payload(err)
             return build_success_payload(result, include_parsed=include_parsed)

--- a/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
@@ -7,12 +7,15 @@ from typing import Any
 from mcp.server.mcpserver import Context, MCPServer
 from mcp.types import ToolAnnotations
 
+from pipefy_mcp.tools.graphql_error_helpers import ensure_non_empty_error_message
 from pipefy_mcp.tools.introspection_tool_helpers import (
     build_error_payload,
     build_success_payload,
 )
 from pipefy_mcp.tools.remote_profile import REMOTE
 from pipefy_mcp.tools.tool_context import get_pipefy_client
+
+_GRAPHQL_TOOL_REQUEST_FAILED = "GraphQL request failed."
 
 
 class IntrospectionTools:
@@ -47,7 +50,11 @@ class IntrospectionTools:
             try:
                 result = await client.introspect_type(type_name, max_depth=max_depth)
             except Exception as exc:  # noqa: BLE001
-                return build_error_payload(str(exc))
+                return build_error_payload(
+                    ensure_non_empty_error_message(
+                        str(exc), _GRAPHQL_TOOL_REQUEST_FAILED
+                    )
+                )
             err = result.get("error")
             if isinstance(err, str) and err:
                 return build_error_payload(err)
@@ -80,7 +87,11 @@ class IntrospectionTools:
                     mutation_name, max_depth=max_depth
                 )
             except Exception as exc:  # noqa: BLE001
-                return build_error_payload(str(exc))
+                return build_error_payload(
+                    ensure_non_empty_error_message(
+                        str(exc), _GRAPHQL_TOOL_REQUEST_FAILED
+                    )
+                )
             err = result.get("error")
             if isinstance(err, str) and err:
                 return build_error_payload(err)
@@ -111,7 +122,11 @@ class IntrospectionTools:
             try:
                 result = await client.introspect_query(query_name, max_depth=max_depth)
             except Exception as exc:  # noqa: BLE001
-                return build_error_payload(str(exc))
+                return build_error_payload(
+                    ensure_non_empty_error_message(
+                        str(exc), _GRAPHQL_TOOL_REQUEST_FAILED
+                    )
+                )
             err = result.get("error")
             if isinstance(err, str) and err:
                 return build_error_payload(err)
@@ -142,7 +157,11 @@ class IntrospectionTools:
             try:
                 result = await client.search_schema(keyword, kind=kind)
             except Exception as exc:  # noqa: BLE001
-                return build_error_payload(str(exc))
+                return build_error_payload(
+                    ensure_non_empty_error_message(
+                        str(exc), _GRAPHQL_TOOL_REQUEST_FAILED
+                    )
+                )
             err = result.get("error")
             if isinstance(err, str) and err:
                 return build_error_payload(err)
@@ -174,7 +193,11 @@ class IntrospectionTools:
             try:
                 result = await client.execute_graphql(query, variables)
             except Exception as exc:  # noqa: BLE001
-                return build_error_payload(str(exc))
+                return build_error_payload(
+                    ensure_non_empty_error_message(
+                        str(exc), _GRAPHQL_TOOL_REQUEST_FAILED
+                    )
+                )
             gql_errors = result.get("errors")
             if isinstance(gql_errors, list) and gql_errors:
                 messages: list[str] = []

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -34,6 +34,7 @@ from pipefy_mcp.core.tool_error_envelope import (
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import (
     enrich_permission_denied_error,
+    ensure_non_empty_error_message,
     extract_graphql_correlation_id,
     extract_graphql_error_codes,
     handle_tool_graphql_error,
@@ -288,7 +289,9 @@ class PipeTools:
                 error_text = str(exc)
                 if perm_msg:
                     error_text = f"{perm_msg}\n{error_text}"
-                return tool_error(error_text)
+                return tool_error(
+                    ensure_non_empty_error_message(error_text, "Failed to create card.")
+                )
             card_data_node = (result.get("createCard") or {}).get("card")
             card_id = (
                 card_data_node.get("id") if isinstance(card_data_node, dict) else None

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -115,6 +115,10 @@ class PipeTools:
             elicitation, an interactive form is presented even if ``fields``
             carries pre-filled values — the human can review and adjust them.
 
+            On ambiguous failure (empty or unclear ``error.message``), re-read
+            ``get_cards`` / ``get_phase_cards_count`` before retrying; do not
+            blind-retry creates (``CreateCardInput`` has no ``idempotency_key``).
+
             A form is only possible when the connection can carry a
             server-to-client request. It cannot on protocol revision 2026-07-28,
             on a stateless HTTP transport, or on a deployment serving
@@ -290,7 +294,11 @@ class PipeTools:
                 if perm_msg:
                     error_text = f"{perm_msg}\n{error_text}"
                 return tool_error(
-                    ensure_non_empty_error_message(error_text, "Failed to create card.")
+                    ensure_non_empty_error_message(
+                        error_text,
+                        "Failed to create card. Re-read get_cards or "
+                        "get_phase_cards_count before retrying; do not blind-retry.",
+                    )
                 )
             card_data_node = (result.get("createCard") or {}).get("card")
             card_id = (

--- a/packages/mcp/src/pipefy_mcp/tools/portal_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/portal_tool_helpers.py
@@ -46,7 +46,7 @@ def map_portal_error_to_message(exc: BaseException) -> str:
     """
     if isinstance(exc, PortalPermissionError):
         return ensure_non_empty_error_message(
-            str(exc).strip(), _PORTAL_OPERATION_FAILED
+            str(exc).strip(), _PORTAL_PERMISSION_GUIDANCE
         )
 
     text = str(exc).strip()
@@ -71,7 +71,7 @@ def map_portal_error_to_message(exc: BaseException) -> str:
         if messages:
             return "; ".join(messages)
 
-    return text or _PORTAL_OPERATION_FAILED
+    return ensure_non_empty_error_message(text, _PORTAL_OPERATION_FAILED)
 
 
 def validate_tool_ids(

--- a/packages/mcp/src/pipefy_mcp/tools/portal_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/portal_tool_helpers.py
@@ -17,6 +17,7 @@ from pydantic import ValidationError
 
 from pipefy_mcp.core.tool_error_envelope import tool_error
 from pipefy_mcp.tools.graphql_error_helpers import (
+    ensure_non_empty_error_message,
     extract_error_strings,
     extract_graphql_error_codes,
 )
@@ -30,6 +31,7 @@ _PORTAL_PERMISSION_GUIDANCE = (
     "Permission denied. Request organization permissions such as "
     "`create_portal` or `manage_portals` from your admin."
 )
+_PORTAL_OPERATION_FAILED = "Portal operation failed. Try again or contact support."
 
 
 def map_portal_error_to_message(exc: BaseException) -> str:
@@ -43,7 +45,9 @@ def map_portal_error_to_message(exc: BaseException) -> str:
         and ``manage_portals``.
     """
     if isinstance(exc, PortalPermissionError):
-        return str(exc).strip()
+        return ensure_non_empty_error_message(
+            str(exc).strip(), _PORTAL_OPERATION_FAILED
+        )
 
     text = str(exc).strip()
     lowered = text.lower()
@@ -67,7 +71,7 @@ def map_portal_error_to_message(exc: BaseException) -> str:
         if messages:
             return "; ".join(messages)
 
-    return text or "Portal operation failed. Try again or contact support."
+    return text or _PORTAL_OPERATION_FAILED
 
 
 def validate_tool_ids(

--- a/packages/mcp/tests/tools/test_graphql_error_helpers.py
+++ b/packages/mcp/tests/tools/test_graphql_error_helpers.py
@@ -6,7 +6,10 @@ import pytest
 from pipefy_sdk import PipefyClient, PipefyGraphQLError
 
 import pipefy_mcp.settings as settings_mod
-from pipefy_mcp.tools.graphql_error_helpers import enrich_permission_denied_error
+from pipefy_mcp.tools.graphql_error_helpers import (
+    enrich_permission_denied_error,
+    ensure_non_empty_error_message,
+)
 
 
 def _make_permission_denied_exc(message="forbidden"):
@@ -44,6 +47,21 @@ def _mock_settings(monkeypatch):
     mock_settings = MagicMock()
     mock_settings.pipefy.permission_denied_enrichment_timeout_seconds = 5.0
     monkeypatch.setattr(settings_mod, "settings", mock_settings)
+
+
+@pytest.mark.unit
+def test_ensure_non_empty_error_message_empty_uses_fallback():
+    assert ensure_non_empty_error_message("", "fallback") == "fallback"
+
+
+@pytest.mark.unit
+def test_ensure_non_empty_error_message_whitespace_uses_fallback():
+    assert ensure_non_empty_error_message("   ", "fallback") == "fallback"
+
+
+@pytest.mark.unit
+def test_ensure_non_empty_error_message_preserves_non_blank():
+    assert ensure_non_empty_error_message("boom", "fallback") == "boom"
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_introspection_tools.py
+++ b/packages/mcp/tests/tools/test_introspection_tools.py
@@ -404,3 +404,75 @@ async def test_execute_graphql_transport_error_returns_error_payload(
     payload = extract_payload(result)
     assert payload["success"] is False
     assert "Connection refused" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("introspection_session", [None], indirect=True)
+async def test_execute_graphql_empty_exception_message_uses_fallback(
+    introspection_session, mock_introspection_client, extract_payload
+):
+    mock_introspection_client.execute_graphql = AsyncMock(side_effect=RuntimeError(""))
+    async with introspection_session as session:
+        result = await session.call_tool(
+            "execute_graphql",
+            {"query": "query Q { __typename }"},
+        )
+    assert result.is_error is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    message = tool_error_message(payload)
+    assert message.strip()
+    assert "GraphQL request failed." in message
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("introspection_session", [None], indirect=True)
+async def test_execute_graphql_preserves_non_empty_exception_message(
+    introspection_session, mock_introspection_client, extract_payload
+):
+    mock_introspection_client.execute_graphql = AsyncMock(
+        side_effect=RuntimeError("boom")
+    )
+    async with introspection_session as session:
+        result = await session.call_tool(
+            "execute_graphql",
+            {"query": "query Q { __typename }"},
+        )
+    assert result.is_error is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert "boom" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("introspection_session", [None], indirect=True)
+@pytest.mark.parametrize(
+    ("tool_name", "client_attr", "arguments"),
+    [
+        ("introspect_type", "introspect_type", {"type_name": "Card"}),
+        ("introspect_mutation", "introspect_mutation", {"mutation_name": "createCard"}),
+        ("introspect_query", "introspect_query", {"query_name": "card"}),
+        ("search_schema", "search_schema", {"keyword": "card"}),
+    ],
+)
+async def test_introspection_tools_empty_exception_message_uses_fallback(
+    introspection_session,
+    mock_introspection_client,
+    extract_payload,
+    tool_name,
+    client_attr,
+    arguments,
+):
+    setattr(
+        mock_introspection_client,
+        client_attr,
+        AsyncMock(side_effect=RuntimeError("")),
+    )
+    async with introspection_session as session:
+        result = await session.call_tool(tool_name, arguments)
+    assert result.is_error is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    message = tool_error_message(payload)
+    assert message.strip()
+    assert "GraphQL request failed." in message

--- a/packages/mcp/tests/tools/test_introspection_tools.py
+++ b/packages/mcp/tests/tools/test_introspection_tools.py
@@ -408,10 +408,13 @@ async def test_execute_graphql_transport_error_returns_error_payload(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("introspection_session", [None], indirect=True)
+@pytest.mark.parametrize("exc_message", ["", "   "])
 async def test_execute_graphql_empty_exception_message_uses_fallback(
-    introspection_session, mock_introspection_client, extract_payload
+    introspection_session, mock_introspection_client, extract_payload, exc_message
 ):
-    mock_introspection_client.execute_graphql = AsyncMock(side_effect=RuntimeError(""))
+    mock_introspection_client.execute_graphql = AsyncMock(
+        side_effect=RuntimeError(exc_message)
+    )
     async with introspection_session as session:
         result = await session.call_tool(
             "execute_graphql",
@@ -423,6 +426,8 @@ async def test_execute_graphql_empty_exception_message_uses_fallback(
     message = tool_error_message(payload)
     assert message.strip()
     assert "GraphQL request failed." in message
+    assert "re-read counts/ids" in message
+    assert "do not blind-retry" in message
 
 
 @pytest.mark.anyio
@@ -455,7 +460,43 @@ async def test_execute_graphql_preserves_non_empty_exception_message(
         ("search_schema", "search_schema", {"keyword": "card"}),
     ],
 )
+@pytest.mark.parametrize("exc_message", ["", "   "])
 async def test_introspection_tools_empty_exception_message_uses_fallback(
+    introspection_session,
+    mock_introspection_client,
+    extract_payload,
+    tool_name,
+    client_attr,
+    arguments,
+    exc_message,
+):
+    setattr(
+        mock_introspection_client,
+        client_attr,
+        AsyncMock(side_effect=RuntimeError(exc_message)),
+    )
+    async with introspection_session as session:
+        result = await session.call_tool(tool_name, arguments)
+    assert result.is_error is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    message = tool_error_message(payload)
+    assert message.strip()
+    assert "GraphQL request failed." in message
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("introspection_session", [None], indirect=True)
+@pytest.mark.parametrize(
+    ("tool_name", "client_attr", "arguments"),
+    [
+        ("introspect_type", "introspect_type", {"type_name": "Card"}),
+        ("introspect_mutation", "introspect_mutation", {"mutation_name": "createCard"}),
+        ("introspect_query", "introspect_query", {"query_name": "card"}),
+        ("search_schema", "search_schema", {"keyword": "card"}),
+    ],
+)
+async def test_introspection_tools_preserves_non_empty_exception_message(
     introspection_session,
     mock_introspection_client,
     extract_payload,
@@ -466,13 +507,52 @@ async def test_introspection_tools_empty_exception_message_uses_fallback(
     setattr(
         mock_introspection_client,
         client_attr,
-        AsyncMock(side_effect=RuntimeError("")),
+        AsyncMock(side_effect=RuntimeError("boom")),
     )
     async with introspection_session as session:
         result = await session.call_tool(tool_name, arguments)
     assert result.is_error is False
     payload = extract_payload(result)
     assert payload["success"] is False
+    assert "boom" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("introspection_session", [None], indirect=True)
+@pytest.mark.parametrize("soft_error", ["", "   "])
+async def test_execute_graphql_soft_error_field_empty_or_whitespace_uses_fallback(
+    introspection_session, mock_introspection_client, extract_payload, soft_error
+):
+    mock_introspection_client.execute_graphql = AsyncMock(
+        return_value={"error": soft_error}
+    )
+    async with introspection_session as session:
+        result = await session.call_tool(
+            "execute_graphql",
+            {"query": "query Q { __typename }"},
+        )
+    assert result.is_error is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
     message = tool_error_message(payload)
     assert message.strip()
-    assert "GraphQL request failed." in message
+    assert "GraphQL returned errors." in message
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("introspection_session", [None], indirect=True)
+async def test_execute_graphql_soft_errors_whitespace_messages_use_fallback(
+    introspection_session, mock_introspection_client, extract_payload
+):
+    mock_introspection_client.execute_graphql = AsyncMock(
+        return_value={"errors": [{"message": "   "}]}
+    )
+    async with introspection_session as session:
+        result = await session.call_tool(
+            "execute_graphql",
+            {"query": "query Q { __typename }"},
+        )
+    assert result.is_error is False
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert tool_error_message(payload) == "GraphQL returned errors."

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -492,17 +492,19 @@ class TestCreateCardTool:
         assert "invite_members" in tool_error_message(payload)
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
+    @pytest.mark.parametrize("exc_message", ["", "   "])
     async def test_create_card_empty_exception_message_uses_fallback(
         self,
         client_session,
         mock_pipefy_client,
         pipe_id,
         extract_payload,
+        exc_message,
     ):
         mock_pipefy_client.get_start_form_fields.return_value = {
             "start_form_fields": []
         }
-        mock_pipefy_client.create_card.side_effect = RuntimeError("")
+        mock_pipefy_client.create_card.side_effect = RuntimeError(exc_message)
 
         async with client_session as session:
             result = await session.call_tool(
@@ -513,7 +515,9 @@ class TestCreateCardTool:
         assert payload["success"] is False
         message = tool_error_message(payload)
         assert message.strip()
-        assert message == "Failed to create card."
+        assert message.startswith("Failed to create card.")
+        assert "get_cards" in message or "get_phase_cards_count" in message
+        assert "do not blind-retry" in message
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
     async def test_create_card_preserves_non_empty_exception_message(

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -492,6 +492,52 @@ class TestCreateCardTool:
         assert "invite_members" in tool_error_message(payload)
 
     @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_create_card_empty_exception_message_uses_fallback(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": []
+        }
+        mock_pipefy_client.create_card.side_effect = RuntimeError("")
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {"pipe_id": pipe_id, "skip_elicitation": True},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        message = tool_error_message(payload)
+        assert message.strip()
+        assert message == "Failed to create card."
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
+    async def test_create_card_preserves_non_empty_exception_message(
+        self,
+        client_session,
+        mock_pipefy_client,
+        pipe_id,
+        extract_payload,
+    ):
+        mock_pipefy_client.get_start_form_fields.return_value = {
+            "start_form_fields": []
+        }
+        mock_pipefy_client.create_card.side_effect = RuntimeError("boom")
+
+        async with client_session as session:
+            result = await session.call_tool(
+                "create_card",
+                {"pipe_id": pipe_id, "skip_elicitation": True},
+            )
+        payload = extract_payload(result)
+        assert payload["success"] is False
+        assert "boom" in tool_error_message(payload)
+
+    @pytest.mark.parametrize("client_session", [None], indirect=True)
     @pytest.mark.parametrize("invalid_phase_id", [0, -1])
     async def test_create_card_rejects_invalid_phase_id(
         self,

--- a/packages/mcp/tests/tools/test_portal_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_portal_tool_helpers.py
@@ -27,6 +27,22 @@ def test_map_portal_error_returns_portal_permission_message() -> None:
 
 
 @pytest.mark.unit
+def test_map_portal_error_blank_permission_message_uses_fallback():
+    assert (
+        map_portal_error_to_message(PortalPermissionError("  "))
+        == "Portal operation failed. Try again or contact support."
+    )
+
+
+@pytest.mark.unit
+def test_map_portal_error_preserves_non_blank_permission_message():
+    assert (
+        map_portal_error_to_message(PortalPermissionError("real permission text"))
+        == "real permission text"
+    )
+
+
+@pytest.mark.unit
 def test_map_portal_error_permission_denied_transport_query_error() -> None:
     """GraphQL PERMISSION_DENIED codes map to portal permission guidance."""
     exc = PipefyGraphQLError([{"message": "forbidden"}])

--- a/packages/mcp/tests/tools/test_portal_tool_helpers.py
+++ b/packages/mcp/tests/tools/test_portal_tool_helpers.py
@@ -28,10 +28,10 @@ def test_map_portal_error_returns_portal_permission_message() -> None:
 
 @pytest.mark.unit
 def test_map_portal_error_blank_permission_message_uses_fallback():
-    assert (
-        map_portal_error_to_message(PortalPermissionError("  "))
-        == "Portal operation failed. Try again or contact support."
-    )
+    message = map_portal_error_to_message(PortalPermissionError("  "))
+    assert "create_portal" in message
+    assert "manage_portals" in message
+    assert "Try again" not in message
 
 
 @pytest.mark.unit

--- a/skills/api-troubleshoot/pipefy-api-fallback/SKILL.md
+++ b/skills/api-troubleshoot/pipefy-api-fallback/SKILL.md
@@ -140,6 +140,19 @@ GraphQL always returns HTTP 200, even on errors. Check the `errors` array, not t
 | invalid_input | Wrong argument name or type | Run `introspect_type` (Tier 2) to recheck the input shape. |
 | INTERNAL_SERVER_ERROR | API bug or unsupported payload | **Do NOT retry the same payload.** Try an alternative mutation or workaround. |
 | missingRequiredInputObjectAttribute | A required field is missing from the input | Compare the payload against `__type(name: …InputType)`. |
+| Ambiguous write failure (`success: false`, empty or unclear message) | Mutation may already have applied (side effects on the server) | **Re-read before any retry** — see [Ambiguous write failure](#ambiguous-write-failure-re-read-before-retry). |
+
+---
+
+## Ambiguous write failure (re-read before retry)
+
+Write tools and `execute_graphql` can report failure even when the mutation already applied. Blind retry duplicates customer data (e.g. many cards created despite `success: false`).
+
+1. **Do not** immediately re-run the same create/mutation.
+2. **Re-read** first: `get_cards` / `get_phase_cards_count` / returned ids / `cards_count` on the pipe or phase you targeted. Prefer comparing to a count or id set you recorded **before** the write when available.
+3. Retry **only** if the re-read clearly shows the write did not land.
+4. If the re-read is **inconclusive** (no pre-write baseline, pagination truncates results, or counts cannot prove absence), **stop** — report the ambiguous failure and the re-read evidence to the user. Do not guess-retry.
+5. **Hard stop — no client-side idempotency:** `CreateCardInput` has no `idempotency_key` (only `clientMutationId`, which is not create-idempotency). Do not invent client-side keys or assume retries are safe. Re-read is the only safe path until the API adds real idempotency.
 
 ---
 
@@ -201,6 +214,7 @@ Only after all 3 tiers and external resources have failed:
 - **400 Bad Request** — GraphQL syntax error. Validate the query string and escape quotes properly when embedding via shell.
 - **500 / service unavailable** — Pipefy API outage. Check [status.pipefy.com](https://status.pipefy.com) and retry later. Do not loop.
 - **`INTERNAL_SERVER_ERROR` in `errors` array** — do NOT retry the same payload; pick a different mutation path.
+- **Ambiguous write failure** — reported error with empty/unclear message after a create or other write: re-read counts/ids before retrying; never blind-retry creates ([Ambiguous write failure](#ambiguous-write-failure-re-read-before-retry)).
 
 ## Security notes
 

--- a/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
+++ b/skills/pipes-and-cards/pipefy-pipes-and-cards/SKILL.md
@@ -232,6 +232,7 @@ Do not hide a required field — MCP rejects `hide`/`hidden` on `required=true` 
 
 - **`create_field_condition` fails with missing/wrong phase:** use `error.details.condition_id` (or the id in the message) with `delete_field_condition` and `confirm=true` before recreating; do not blind-retry create on the same requested phase.
 - **`create_card` fails with missing required fields:** call `get_start_form_fields` first to discover required `field_id` values.
+- **`create_card` / write reports failure (empty or unclear message):** do not blind-retry. Re-read `get_cards` / `get_phase_cards_count` (or pipe `cards_count`) before any retry — see [Ambiguous write failure](../../api-troubleshoot/pipefy-api-fallback/SKILL.md#ambiguous-write-failure-re-read-before-retry).
 - **`create_phase_field` rejects type:** call `introspect_type type_name="CreatePhaseFieldInput"` to get valid values.
 - **Delete fails with preview error:** expected — call without `confirm=true` first, show user the preview, then call with `confirm=true`.
 


### PR DESCRIPTION
## Summary

- Shared `ensure_non_empty_error_message` so wired evidence-path write/error shells never return a blank failure to agents (remaining raw `str(exc)` shells → #587).
- Wired on #522 evidence paths: `execute_graphql` / introspection excepts, portal `PortalPermissionError`, `create_card` mutation except.
- Skills: re-read counts/ids before retrying ambiguous writes; hard stop when re-read is inconclusive; no fake client-side idempotency (`CreateCardInput` has no `idempotency_key`).

Closes #522

**Deferred** remaining raw `str(exc)` shells → **#587** (same milestone; intentional split for reviewability).

## Audit (write-error paths)

| Path | Verdict |
|------|---------|
| `execute_graphql` except | **fixed** |
| introspect_* / `search_schema` except | **fixed** |
| portal `PortalPermissionError` | **fixed** |
| portal generic fallback | **already OK** |
| `create_card` mutation except | **fixed** (does not use `handle_tool_graphql_error`) |
| `handle_tool_graphql_error` + most card writes | **already OK** |
| automation empty-message (#288) | **already OK** — untouched |
| Blind retry after ambiguous write | **skill-only** (+ envelope re-read steer on write fallbacks) |
| Other raw `str(exc)` (iPaaS, KB/LLM, …) | **deferred → #587** |

Grep used: `rg -n 'str\(exc\)' packages/mcp/src/pipefy_mcp/tools/` and `rg -n 'build_error_payload\(|tool_error\(' packages/mcp/src/pipefy_mcp/tools/`.

## Review follow-ups (post-#588 review)

Addressed on tip after PR-driven review (merge-with-notes), before merge:

| Item | Change |
|------|--------|
| Blank `PortalPermissionError` fallback | Uses `_PORTAL_PERMISSION_GUIDANCE` (`create_portal` / `manage_portals`), not “Try again” |
| Envelope re-read steer | `create_card` / `execute_graphql` empty fallbacks + tool docstrings point at re-read / no blind-retry |
| Soft GraphQL blank/whitespace | Empty/`"   "` `result.error` and whitespace-only `errors[].message` → `success: false` with stable fallback |
| DRY introspection excepts | Shared `_exception_error_payload` / `_soft_result_error_payload` |
| Session tests | Whitespace `str(exc)` + preserve-non-blank matrix for introspect tools / `create_card` / `execute_graphql` |

Commits: `cbc56484` (follow-ups) + `754c26ca` (CI re-trigger only).

## Idempotency

`introspect_mutation(createCard)`: `CreateCardInput` has `clientMutationId` only — **no** `idempotency_key`. Documented hard stop in `pipefy-api-fallback`; do not invent client-side idempotency.

## Test plan

- [x] Focused empty-message / preserve / soft-error tests (25 passed after follow-ups)
- [x] `uv run pytest -m "not integration"` (**4299** passed locally on tip)
- [x] `uv run ruff check` + `ruff format --check` + `bump_version.py verify` + `packages/mcp` `lint-imports` + `lint_skill_refs.py`
- [x] Cursor MCP smoke (server restarted on tip `754c26ca`, PipeClaw org `302398434` / Analytics pipe `306996636`):
  - `execute_graphql` invalid query → `success: false` + non-empty API message
  - `execute_graphql` bare `createCard` → `success: false` + required-field messages
  - `create_card` missing required fields → `success: false` + non-empty required-field messages (no card created)
- [x] Disclosure sweep on diff: clean
- [x] No diff in `automation_tool_helpers.py` / `test_automation_tools.py`

**CI note:** GitHub Actions for this PR previously cancelled (hosted runners never acquired). Local CI-equivalent gates are green on tip; re-queue Actions when runners are available.

Local review (T2): Approved with caveats; C.7 applied. PR-driven review: merge with notes; follow-ups above landed on tip.
