### PR TITLE
docs: require commit sign-off (DCO) in commit guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ Skills (`skills/`) and tools (`packages/mcp/`, `packages/cli/`) live in the same
 ## Commit & PR guidelines
 - Conventional Commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:` with optional scopes.
 - One functional change per commit (atomic). PRs touching more than 10 files or 300 changed lines should be split.
+- Sign off every commit (`git commit -s`). CI enforces the Developer Certificate of Origin (DCO), so an unsigned commit fails the check.
 - PRs must include: summary, testing performed (commands + results), docs updates if tool behavior or config changed.
 
 ## Security


### PR DESCRIPTION
Adds a bullet to the AGENTS.md commit guidelines: sign off every commit with `git commit -s`, because CI enforces the Developer Certificate of Origin (DCO) and an unsigned commit fails the check.