### PR TITLE
ci: put the back-merge workflow on main so its triggers can fire

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,82 @@
+name: Back-merge
+
+# Anything merged straight into `main` leaves `dev` behind until a human
+# remembers to reconcile it. `release.py release-pr` refuses to cut while that
+# is true, so forgotten drift does not corrupt a release -- it blocks one, at
+# the least convenient moment, for whoever happens to be cutting. This opens the
+# back-merge pull request itself so the fix is waiting for review instead of
+# waiting to be remembered.
+#
+# All the logic is in `scripts/backmerge.py` rather than inline shell: the
+# idempotency rules (an existing branch, an existing pull request, an unchanged
+# tracking issue) are decisions worth unit-testing, and `tests/test_backmerge.py`
+# does exactly that. This file only supplies credentials and a checkout.
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Daily, off the hour -- GitHub drops scheduled runs queued at popular
+    # times. This is the backstop for drift the push event missed (a failed
+    # run, a merge during an Actions outage) and for re-checking a divergence
+    # that is still unresolved.
+    - cron: "37 6 * * *"
+  workflow_dispatch:
+  # This workflow's own changes are exercised by the pull request that makes
+  # them. `schedule` and `workflow_dispatch` stay dormant until the file
+  # reaches `main`, since GitHub reads both from the default branch alone.
+  pull_request:
+    paths:
+      - .github/workflows/backmerge.yml
+      - .github/workflows/scripts/backmerge.py
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  # Every real trigger shares one group: two at once would race each other
+  # between "does the branch exist" and "push the branch". Pull request dry
+  # runs write nothing, so they get their own per-ref group rather than queuing
+  # behind a real run.
+  group: backmerge-${{ github.event_name == 'pull_request' && github.ref || 'default' }}
+  cancel-in-progress: false
+
+jobs:
+  backmerge:
+    name: Open the main to dev back-merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The merge needs real history, not the default depth-1 cone.
+          fetch-depth: 0
+          # A pull request opened with GITHUB_TOKEN does not trigger
+          # `on: pull_request` workflows, so the back-merge pull request shows
+          # no checks and its body says so plainly. Set a BACKMERGE_TOKEN
+          # secret -- a GitHub App token or a fine-grained PAT scoped to this
+          # repository with contents:write, pull-requests:write and
+          # issues:write -- and checks start running with no change here.
+          token: ${{ secrets.BACKMERGE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Configure the committer
+        # Identity for the merge commit, and the DCO sign-off derives from it.
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Open the pull request, or track why it could not be opened
+        env:
+          GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BACKMERGE_HAS_CI: ${{ secrets.BACKMERGE_TOKEN != '' }}
+          # On the pull request that edits this workflow, run every real step --
+          # fetch, count, merge, conflict detection -- but announce the writes
+          # instead of performing them. Otherwise testing a change here would
+          # open a genuine back-merge pull request off the branch under review.
+          BACKMERGE_DRY_RUN: ${{ github.event_name == 'pull_request' }}
+        run: python .github/workflows/scripts/backmerge.py

--- a/.github/workflows/scripts/backmerge.py
+++ b/.github/workflows/scripts/backmerge.py
@@ -1,0 +1,636 @@
+#!/usr/bin/env python3
+"""Open the ``main`` -> ``dev`` back-merge pull request, or record why one could not be.
+
+Anything merged directly into ``main`` -- a hotfix, a docs fix, a LICENSE --
+leaves ``dev`` behind until a human remembers to back-merge. Nothing on the
+GitHub side notices, so the drift is silent from the moment it happens until
+the next release cut trips over it, which can be days later and is diagnosed by
+whoever happens to be cutting rather than by whoever caused it.
+
+``release.py release-pr`` already refuses to cut while ``origin/main`` carries
+commits absent from ``origin/dev``. That guard turns a silent hazard into a hard
+failure, but only at the *next* release -- the drift still persists for however
+long passes before someone tries. This closes that window from the other side:
+the reconciliation is waiting for review instead of waiting to be remembered.
+
+Two constraints shape the design, both worth knowing before editing:
+
+* **A pull request is mandatory.** The repository ruleset requires one, with an
+  approving review, on both ``main`` and ``dev``, and blocks non-fast-forward
+  pushes and deletion. This cannot push to ``dev`` and cannot merge its own
+  pull request -- a human approval is the point. The job is to make sure the
+  pull request *exists*.
+* **A conflict is a normal outcome, not an error.** Release drift conflicts on
+  ``CHANGELOG.md`` by construction (``main`` carries the stamped ``## [X.Y.Z]``
+  heading while ``dev`` still has those entries under ``## [Unreleased]``), and
+  binary assets conflict whenever both branches touched one. Neither is
+  resolvable here: ``-X ours`` and ``-X theirs`` both silently discard real
+  work. A conflict routes to the tracking issue and the run still exits zero,
+  because a red run on every release trains people to ignore the signal.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+DEV_BRANCH = "dev"
+MAIN_BRANCH = "main"
+
+# The tracking issue is found by label rather than by title, so the title stays
+# free to carry the live commit count.
+LABEL = "back-merge"
+
+# Deterministic per ``main`` head, which is what makes a re-run idempotent: the
+# same drift resolves to the same branch name, so an existing branch is
+# recognized rather than pushed over.
+BRANCH_PREFIX = "rc-dev/chore/back-merge-main-"
+
+# Embedded in every issue body and comment. A re-run that would say exactly the
+# same thing finds its own marker and stays quiet, so an unresolved divergence
+# does not accumulate one identical comment per scheduled run.
+STATE_MARKER_PREFIX = "<!-- backmerge-state:"
+
+# Set from ``BACKMERGE_DRY_RUN`` so the pull request that edits this workflow
+# exercises it for real -- the fetch, the count, the merge, the conflict
+# detection -- while every push, pull request and issue write is announced
+# instead of performed. Without it, testing a change to this file would open a
+# genuine back-merge pull request off the branch under review.
+DRY_RUN = False
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Echo and run a command in the repo root, raising on non-zero exit."""
+    print(f"$ {' '.join(cmd)}", flush=True)
+    return subprocess.run(cmd, cwd=REPO_ROOT, check=True, **kwargs)
+
+
+def capture(cmd: list[str]) -> str:
+    """Run a command in the repo root and return its stripped stdout."""
+    result = subprocess.run(
+        cmd, cwd=REPO_ROOT, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def mutate(cmd: list[str]) -> int:
+    """Run a command that changes remote or issue state, unless dry-running.
+
+    Returns an exit code so callers can route a rejection to the tracking
+    issue; a dry run reports success, since the point is to reach the code
+    paths beyond it.
+    """
+    if DRY_RUN:
+        print(f"[dry run] would run: {' '.join(cmd)}", flush=True)
+        return 0
+    return try_run(cmd)
+
+
+def try_run(cmd: list[str]) -> int:
+    """Run a command that is allowed to fail, returning its exit code.
+
+    Used for the merge (a conflict is an expected outcome) and for ``gh pr
+    create`` (which is denied outright when the repository forbids Actions from
+    creating pull requests). Both route to the tracking issue instead of
+    aborting the run.
+    """
+    print(f"$ {' '.join(cmd)}", flush=True)
+    return subprocess.run(cmd, cwd=REPO_ROOT).returncode
+
+
+def main_only_count() -> int:
+    """How many commits ``origin/main`` carries that ``origin/dev`` does not."""
+    return int(
+        capture(
+            ["git", "rev-list", "--count", f"origin/{DEV_BRANCH}..origin/{MAIN_BRANCH}"]
+        )
+    )
+
+
+def main_head() -> str:
+    """The short SHA of ``origin/main``."""
+    return capture(["git", "rev-parse", "--short", f"origin/{MAIN_BRANCH}"])
+
+
+def branch_for(sha: str) -> str:
+    """The back-merge branch name for a given ``origin/main`` head."""
+    return f"{BRANCH_PREFIX}{sha}"
+
+
+def carried_commits() -> list[str]:
+    """One ``<short-sha> <subject>`` line per commit being carried into ``dev``."""
+    return capture(
+        ["git", "log", "--format=%h %s", f"origin/{DEV_BRANCH}..origin/{MAIN_BRANCH}"]
+    ).splitlines()
+
+
+def signoff_trailer() -> str:
+    """A DCO trailer for the merge commit, matching the configured git identity.
+
+    The DCO workflow runs on every pull request with no path filter, so a merge
+    commit without this fails the check on the very pull request this exists to
+    open.
+    """
+    name = capture(["git", "config", "user.name"])
+    email = capture(["git", "config", "user.email"])
+    return f"Signed-off-by: {name} <{email}>"
+
+
+def merge_message(behind: int, signoff: str) -> str:
+    """The merge commit subject and its DCO trailer."""
+    plural = "" if behind == 1 else "s"
+    return f"chore: back-merge {MAIN_BRANCH} into {DEV_BRANCH} ({behind} commit{plural})\n\n{signoff}"
+
+
+def attempt_merge(branch: str, message: str) -> list[str]:
+    """Cut ``branch`` from ``dev`` and merge ``main`` into it.
+
+    Returns the conflicting paths; an empty list means the merge is clean and
+    the branch is ready to push.
+
+    The direction is load-bearing. The head branch must contain ``dev`` plus
+    ``main`` so the pull request's base can be ``dev``; merging the other way
+    would produce a branch that cannot be proposed into ``dev`` at all.
+    """
+    run(["git", "checkout", "-B", branch, f"origin/{DEV_BRANCH}"])
+    merge = ["git", "merge", "--no-ff", "-m", message, f"origin/{MAIN_BRANCH}"]
+    if try_run(merge) == 0:
+        return []
+    conflicts = capture(["git", "diff", "--name-only", "--diff-filter=U"]).splitlines()
+    run(["git", "merge", "--abort"])
+    return conflicts
+
+
+def is_ancestry_only() -> bool:
+    """Whether the merge on ``HEAD`` changes no files relative to ``dev``.
+
+    True when ``main``'s content already reached ``dev`` by another route, which
+    makes the pull request purely a history reconciliation. Worth saying in the
+    body: it is the one fact that tells a reviewer the merge is safe to take.
+    """
+    return try_run(["git", "diff", "--quiet", f"origin/{DEV_BRANCH}", "HEAD"]) == 0
+
+
+def remote_branch_exists(branch: str) -> bool:
+    """Whether ``branch`` is already on the remote."""
+    return bool(capture(["git", "ls-remote", "--heads", "origin", branch]))
+
+
+def existing_pr(branch: str) -> tuple[str, str]:
+    """The number and state of any pull request for ``branch``, or ``("", "")``.
+
+    Searched across every state, because the two answers differ. An open one is
+    the finished outcome. A closed one was closed by a human decision, which
+    this must not overrule by reopening it or re-pushing the branch -- but the
+    drift it left behind still has to surface somewhere.
+    """
+    found = capture(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--state",
+            "all",
+            "--limit",
+            "1",
+            "--json",
+            "number,state",
+            "--jq",
+            r'.[0] // empty | "\(.number) \(.state)"',
+        ]
+    )
+    number, _, state = found.partition(" ")
+    return number, state
+
+
+def open_tracking_issue() -> str:
+    """The number of the open tracking issue, or ``""``."""
+    return capture(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--label",
+            LABEL,
+            "--state",
+            "open",
+            "--limit",
+            "1",
+            "--json",
+            "number",
+            "--jq",
+            ".[0].number // empty",
+        ]
+    )
+
+
+def ensure_label() -> None:
+    """Create the tracking label if it is absent.
+
+    Idempotent, so the label needs no manual repository setup and a rename
+    cannot leave this step failing on a missing label.
+    """
+    mutate(
+        [
+            "gh",
+            "label",
+            "create",
+            LABEL,
+            "--color",
+            "fbca04",
+            "--description",
+            "origin/main carries commits absent from origin/dev",
+            "--force",
+        ]
+    )
+
+
+def issue_title(behind: int) -> str:
+    """The tracking issue title, carrying the live commit count."""
+    plural = "" if behind == 1 else "s"
+    return (
+        f"Back-merge {MAIN_BRANCH} into {DEV_BRANCH} ({behind} commit{plural} behind)"
+    )
+
+
+def state_marker(sha: str, behind: int, conflicts: list[str]) -> str:
+    """A fingerprint of the drift, so an unchanged re-run posts nothing."""
+    paths = ",".join(sorted(conflicts))
+    return f"{STATE_MARKER_PREFIX} {sha} behind={behind} conflicts={paths} -->"
+
+
+def already_reported(issue: str, marker: str) -> bool:
+    """Whether the issue body or any of its comments already carries ``marker``."""
+    seen = capture(
+        [
+            "gh",
+            "issue",
+            "view",
+            issue,
+            "--json",
+            "body,comments",
+            "--jq",
+            ".body, (.comments[].body)",
+        ]
+    )
+    return marker in seen
+
+
+def pr_body(
+    commits: list[str], behind: int, has_ci: bool, ancestry_only: bool = False
+) -> str:
+    """The back-merge pull request body."""
+    plural = "" if behind == 1 else "s"
+    listing = "\n".join(f"- `{line}`" for line in commits)
+    ancestry = (
+        "\nThis merge changes no files. `main`'s content already reached `dev` by "
+        "another route, so what is left to reconcile is history alone.\n"
+        if ancestry_only
+        else ""
+    )
+    checks = (
+        "This pull request was opened by a token that triggers workflows, so its checks run normally."
+        if has_ci
+        else (
+            "**This pull request carries no CI checks.** It was opened by `GITHUB_TOKEN`, and GitHub "
+            "deliberately does not trigger `on: pull_request` workflows for events raised by it — an "
+            "unchecked pull request that merely *looks* green would be worse. To run them, close and "
+            "reopen this pull request, or push any commit to its branch. Setting a `BACKMERGE_TOKEN` "
+            "secret makes checks run on their own; see RELEASE.md."
+        )
+    )
+    return f"""\
+`origin/{MAIN_BRANCH}` carries {behind} commit{plural} that `origin/{DEV_BRANCH}` does not. Until they are back-merged, `{DEV_BRANCH}` is missing work that has already shipped, and `release.py release-pr` refuses to cut a release at all.
+
+These commits reached `{MAIN_BRANCH}` outside the release flow — a hotfix, a docs fix, or anything else merged straight into the default branch.
+{ancestry}
+## Merge this with a merge commit, not a squash
+
+**Use "Create a merge commit".** A squash or a rebase discards the second parent, so `{DEV_BRANCH}` gains the *content* of these commits but never their *ancestry*. `git rev-list --count origin/{DEV_BRANCH}..origin/{MAIN_BRANCH}` would still report {behind}, `release-pr` would still refuse to cut, and the next run of this workflow would open this same pull request again. A squash merge here does not converge.
+
+## Commits being carried over
+
+{listing}
+
+## Checks
+
+{checks}
+
+---
+
+Opened automatically by `.github/workflows/backmerge.yml`. The merge was clean; review it as you would any other pull request.
+"""
+
+
+def issue_body(
+    sha: str,
+    behind: int,
+    branch: str,
+    conflicts: list[str],
+    commits: list[str],
+    marker: str,
+    run_url: str,
+    reason: str,
+) -> str:
+    """The tracking issue body, for drift that could not become a pull request."""
+    plural = "" if behind == 1 else "s"
+    listing = "\n".join(f"- `{line}`" for line in commits)
+
+    if conflicts:
+        paths = "\n".join(f"- `{path}`" for path in conflicts)
+        detail = f"""\
+## Conflicting paths
+
+{paths}
+
+Nothing was pushed. Resolving a conflict is a human decision — `-X ours` and `-X theirs` both silently discard real work, so this workflow will not attempt it.
+"""
+        if "CHANGELOG.md" in conflicts:
+            detail += """
+`CHANGELOG.md` conflicts are the expected shape of *release* drift: `main` carries the stamped `## [X.Y.Z]` heading while `dev` still has those entries under `## [Unreleased]`. The resolution is stable — keep `main`'s stamped heading and reopen an empty `## [Unreleased]` above it.
+"""
+    else:
+        detail = f"{reason}\n"
+
+    return f"""\
+`origin/{MAIN_BRANCH}` is {behind} commit{plural} ahead of `origin/{DEV_BRANCH}`, and the back-merge could not be opened automatically.
+
+Until this is reconciled, `release.py release-pr` refuses to cut a release, so this blocks the next one.
+
+## Commits waiting to be carried over
+
+{listing}
+
+{detail}
+## Resolving it by hand
+
+```bash
+git fetch origin {MAIN_BRANCH} {DEV_BRANCH}
+git checkout -b {branch} origin/{DEV_BRANCH}
+git merge origin/{MAIN_BRANCH}
+# resolve, commit with a sign-off, then:
+git push -u origin {branch}
+gh pr create --base {DEV_BRANCH} --head {branch} \\
+  --title "chore: back-merge {MAIN_BRANCH} into {DEV_BRANCH}"
+```
+
+Run: {run_url}
+
+This issue closes on its own once `origin/{MAIN_BRANCH}` and `origin/{DEV_BRANCH}` are back in sync.
+
+{marker}
+"""
+
+
+def track(
+    sha: str,
+    behind: int,
+    branch: str,
+    conflicts: list[str],
+    commits: list[str],
+    run_url: str,
+    reason: str,
+) -> bool:
+    """Open the tracking issue, or comment on the open one when the state changed.
+
+    Returns whether the drift is now recorded where a human will see it. The
+    caller turns a ``False`` into a failed run: exiting zero on a conflict is
+    only defensible while this issue is the compensating signal, so a run that
+    produces neither a pull request nor an issue must not stay green.
+    """
+    ensure_label()
+    marker = state_marker(sha, behind, conflicts)
+    body = issue_body(sha, behind, branch, conflicts, commits, marker, run_url, reason)
+    title = issue_title(behind)
+    issue = open_tracking_issue()
+    if not issue:
+        return (
+            mutate(
+                [
+                    "gh",
+                    "issue",
+                    "create",
+                    "--title",
+                    title,
+                    "--label",
+                    LABEL,
+                    "--body",
+                    body,
+                ]
+            )
+            == 0
+        )
+    if already_reported(issue, marker):
+        print(f"Issue #{issue} already describes this exact state; nothing to add.")
+        return True
+    recorded = mutate(["gh", "issue", "comment", issue, "--body", body]) == 0
+    # The title carries the live count, which is why the issue is found by label
+    # rather than by title. A stale count in the title reads as a stale issue.
+    # Cosmetic, so a failure here does not make the drift unrecorded.
+    mutate(["gh", "issue", "edit", issue, "--title", title])
+    return recorded
+
+
+def close_tracking_issue(comment: str) -> None:
+    """Close the open tracking issue, if there is one."""
+    issue = open_tracking_issue()
+    if issue:
+        mutate(["gh", "issue", "close", issue, "--comment", comment])
+
+
+def supersede_tracking_issue(branch: str) -> None:
+    """Close a tracking issue that a freshly-opened pull request has answered.
+
+    An issue filed for an earlier, conflicting ``main`` head otherwise stays open
+    beside the pull request that fixed it, telling a reader the back-merge could
+    not be opened while it demonstrably was. One thread means one live answer.
+    """
+    close_tracking_issue(
+        f"A back-merge pull request is open for `{branch}`, which supersedes this "
+        "issue. A new one is filed if the divergence outlives that pull request."
+    )
+
+
+def open_pr(
+    branch: str,
+    commits: list[str],
+    behind: int,
+    has_ci: bool,
+    ancestry_only: bool = False,
+) -> int:
+    """Open the back-merge pull request. Returns the ``gh`` exit code."""
+    plural = "" if behind == 1 else "s"
+    return mutate(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            DEV_BRANCH,
+            "--head",
+            branch,
+            "--title",
+            f"chore: back-merge {MAIN_BRANCH} into {DEV_BRANCH} ({behind} commit{plural})",
+            "--body",
+            pr_body(commits, behind, has_ci, ancestry_only),
+        ]
+    )
+
+
+def main() -> int:
+    global DRY_RUN
+    DRY_RUN = os.environ.get("BACKMERGE_DRY_RUN", "").lower() == "true"
+    if DRY_RUN:
+        print("Dry run: no branch, pull request or issue will be written.")
+
+    # Explicit refspecs, not `git fetch origin main dev`: `actions/checkout`
+    # configures `remote.origin.fetch` for the one branch it checked out, and
+    # under that a bare fetch updates FETCH_HEAD without ever creating
+    # `refs/remotes/origin/dev` -- every range below would then fail to resolve.
+    run(
+        [
+            "git",
+            "fetch",
+            "--quiet",
+            "origin",
+            f"+refs/heads/{MAIN_BRANCH}:refs/remotes/origin/{MAIN_BRANCH}",
+            f"+refs/heads/{DEV_BRANCH}:refs/remotes/origin/{DEV_BRANCH}",
+        ]
+    )
+
+    behind = main_only_count()
+    run_url = os.environ.get("RUN_URL", "(not a workflow run)")
+    has_ci = os.environ.get("BACKMERGE_HAS_CI", "").lower() == "true"
+
+    if behind == 0:
+        close_tracking_issue(
+            f"`origin/{MAIN_BRANCH}` and `origin/{DEV_BRANCH}` are back in sync. "
+            "Closing automatically."
+        )
+        print(
+            f"origin/{DEV_BRANCH} contains every commit on origin/{MAIN_BRANCH}; "
+            "nothing to back-merge."
+        )
+        return 0
+
+    sha = main_head()
+    branch = branch_for(sha)
+    commits = carried_commits()
+    print(f"origin/{MAIN_BRANCH} is {behind} commit(s) ahead at {sha}.")
+
+    # Idempotency, in the order the states can occur.
+    pr, pr_state = existing_pr(branch)
+    if pr and pr_state == "OPEN":
+        print(f"Pull request #{pr} already covers {sha}; leaving it alone.")
+        return 0
+
+    if pr:
+        # A pull request exists for this head but is not open, and the drift is
+        # still here. Reopening it or re-pushing its branch would overrule a
+        # human decision, so neither happens -- but going quiet is the exact
+        # failure this workflow exists to end, so the drift is recorded either
+        # way. The two states need different diagnoses.
+        print(f"Pull request #{pr} for {sha} is {pr_state}; recording the drift.")
+        if pr_state == "MERGED":
+            # Merged, yet `dev` still does not contain `main`. That only happens
+            # when the pull request was squashed or rebased: the second parent is
+            # discarded, so the content lands but the ancestry never does.
+            reason = (
+                f"Pull request #{pr} for this `{MAIN_BRANCH}` head is already "
+                f"merged, yet `origin/{MAIN_BRANCH}` is still {behind} commit(s) "
+                f"ahead of `origin/{DEV_BRANCH}`.\n\n"
+                "That is what a **squash or rebase merge** does to a back-merge: "
+                "it discards the second parent, so `dev` gained the content of "
+                "those commits but never their ancestry. The count cannot reach "
+                "zero this way, `release-pr` stays blocked, and this repeats.\n\n"
+                "The fix is to redo the back-merge and land it with a merge "
+                "commit:\n\n"
+                "```bash\n"
+                f"git fetch origin {MAIN_BRANCH} {DEV_BRANCH}\n"
+                f"git checkout -b rc-dev/chore/back-merge-main-{sha}-merge "
+                f"origin/{DEV_BRANCH}\n"
+                f"git merge --no-ff origin/{MAIN_BRANCH}\n"
+                f"git push -u origin rc-dev/chore/back-merge-main-{sha}-merge\n"
+                "```\n\n"
+                'Then use **"Create a merge commit"**, not squash.'
+            )
+        else:
+            reason = (
+                f"Pull request #{pr} for this `{MAIN_BRANCH}` head was closed "
+                "without merging. Reopening it, or re-pushing its branch, would "
+                "overrule that decision, so this workflow does neither. The "
+                "divergence is still unresolved and still blocks a release."
+            )
+        recorded = track(sha, behind, branch, [], commits, run_url, reason)
+        return 0 if recorded else 1
+
+    if remote_branch_exists(branch):
+        # A previous run pushed the branch but did not get as far as the pull
+        # request. Finish the job without touching the branch: the ruleset
+        # blocks non-fast-forward pushes, and rewriting a branch under review
+        # destroys the incremental diff a reviewer is working through.
+        print(f"Branch {branch} is already pushed; opening its pull request.")
+        if open_pr(branch, commits, behind, has_ci) != 0:
+            recorded = track(
+                sha,
+                behind,
+                branch,
+                [],
+                commits,
+                run_url,
+                f"The branch `{branch}` is already pushed, but opening its pull "
+                "request failed.",
+            )
+            return 0 if recorded else 1
+        supersede_tracking_issue(branch)
+        return 0
+
+    conflicts = attempt_merge(branch, merge_message(behind, signoff_trailer()))
+    ancestry_only = not conflicts and is_ancestry_only()
+    if conflicts:
+        print(f"Merge conflicts in {len(conflicts)} path(s); pushing nothing.")
+        recorded = track(sha, behind, branch, conflicts, commits, run_url, "")
+        return 0 if recorded else 1
+
+    if mutate(["git", "push", "origin", branch]) != 0:
+        # Without this check the tracking issue below would claim the branch is
+        # pushed and ready while nothing reached the remote.
+        print("Pushing the branch failed; there is nothing to propose.")
+        recorded = track(
+            sha,
+            behind,
+            branch,
+            [],
+            commits,
+            run_url,
+            "The merge was clean, but pushing the branch failed. Nothing reached "
+            "the remote, so there is no branch to open a pull request against.",
+        )
+        return 0 if recorded else 1
+
+    if open_pr(branch, commits, behind, has_ci, ancestry_only) != 0:
+        recorded = track(
+            sha,
+            behind,
+            branch,
+            [],
+            commits,
+            run_url,
+            "The merge was clean and the branch is pushed, but `gh pr create` was "
+            "rejected. The usual cause is the repository forbidding GitHub Actions "
+            "from creating pull requests (Settings -> Actions -> General). Opening "
+            "the pull request by hand is all that is left.",
+        )
+        return 0 if recorded else 1
+
+    supersede_tracking_issue(branch)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backmerge.py
+++ b/tests/test_backmerge.py
@@ -1,0 +1,626 @@
+"""Tests for .github/workflows/scripts/backmerge.py decision logic.
+
+The workflow itself is three steps of YAML; every decision worth getting wrong
+lives in the script. What these cover is the part that is expensive to discover
+in production: the merge direction, the idempotency rules that stop a scheduled
+run from filing a duplicate every morning, and the dry run that keeps the pull
+request editing this workflow from opening a real back-merge.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "scripts"
+    / "backmerge.py"
+)
+_spec = importlib.util.spec_from_file_location("backmerge", _SCRIPT)
+assert _spec and _spec.loader
+_backmerge = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_backmerge)
+
+
+@pytest.fixture(autouse=True)
+def _forbid_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail loudly if a test reaches a real ``git``/``gh`` command.
+
+    These tests exercise back-merge *decisions*, not the commands they
+    authorize. A guard that stopped working would otherwise let a test fall
+    through into a real ``git checkout``/``git merge`` against the working tree,
+    or a real ``gh issue create`` against the repository. Tests that need a
+    command stub one explicitly; their ``setattr`` wins over this.
+    """
+
+    def _forbid(cmd, **kwargs):
+        raise AssertionError(f"test reached a real subprocess: {cmd}")
+
+    monkeypatch.setattr(_backmerge, "run", _forbid)
+    monkeypatch.setattr(_backmerge, "capture", _forbid)
+    monkeypatch.setattr(_backmerge, "try_run", _forbid)
+
+
+@pytest.fixture(autouse=True)
+def _reset_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the module-level dry-run flag from leaking between tests."""
+    monkeypatch.setattr(_backmerge, "DRY_RUN", False)
+
+
+def test_main_only_count_reads_the_rev_list_range(monkeypatch) -> None:
+    # The range must be dev..main. Reversed, it would count dev's own work and
+    # propose a back-merge on every commit that lands on dev.
+    seen: list[list[str]] = []
+    monkeypatch.setattr(_backmerge, "capture", lambda cmd: (seen.append(cmd), "3")[1])
+    assert _backmerge.main_only_count() == 3
+    assert seen == [["git", "rev-list", "--count", "origin/dev..origin/main"]]
+
+
+def test_branch_name_is_deterministic_per_main_head() -> None:
+    # Idempotency rests on this: the same drift must resolve to the same branch
+    # name, or every run pushes a new branch and opens a duplicate.
+    assert _backmerge.branch_for("abc1234") == "rc-dev/chore/back-merge-main-abc1234"
+    assert _backmerge.branch_for("abc1234") == _backmerge.branch_for("abc1234")
+    assert _backmerge.branch_for("abc1234") != _backmerge.branch_for("def5678")
+
+
+def test_merge_cuts_from_dev_and_merges_main(monkeypatch) -> None:
+    # The head branch must contain dev plus main so the PR's base can be dev.
+    # Cutting from main instead would produce a branch that cannot be proposed
+    # into dev at all.
+    seen: list[list[str]] = []
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: seen.append(cmd))
+    monkeypatch.setattr(_backmerge, "try_run", lambda cmd: (seen.append(cmd), 0)[1])
+
+    assert _backmerge.attempt_merge("some-branch", "msg") == []
+    assert seen[0] == ["git", "checkout", "-B", "some-branch", "origin/dev"]
+    assert seen[1] == ["git", "merge", "--no-ff", "-m", "msg", "origin/main"]
+
+
+def test_merge_conflict_collects_paths_then_aborts(monkeypatch) -> None:
+    # The paths must be read *before* the abort: `git merge --abort` clears the
+    # unmerged index, so reading them afterwards would always return nothing and
+    # the tracking issue would name no files.
+    seen: list[list[str]] = []
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: seen.append(cmd))
+    monkeypatch.setattr(_backmerge, "try_run", lambda cmd: (seen.append(cmd), 1)[1])
+    monkeypatch.setattr(
+        _backmerge,
+        "capture",
+        lambda cmd: (seen.append(cmd), "CHANGELOG.md\ndocs/banner.png")[1],
+    )
+
+    assert _backmerge.attempt_merge("b", "msg") == ["CHANGELOG.md", "docs/banner.png"]
+    diff_at = seen.index(["git", "diff", "--name-only", "--diff-filter=U"])
+    abort_at = seen.index(["git", "merge", "--abort"])
+    assert diff_at < abort_at
+
+
+def test_merge_message_carries_a_signoff() -> None:
+    # The DCO workflow runs on every pull request with no path filter, so a
+    # merge commit without this fails the check on the pull request this exists
+    # to open.
+    msg = _backmerge.merge_message(9, "Signed-off-by: bot <bot@example.com>")
+    assert msg.startswith("chore: back-merge main into dev (9 commits)")
+    assert msg.endswith("Signed-off-by: bot <bot@example.com>")
+
+
+def test_merge_message_singular() -> None:
+    assert "(1 commit)" in _backmerge.merge_message(1, "Signed-off-by: x <y>")
+
+
+def test_state_marker_is_order_independent() -> None:
+    # Conflicting paths arrive in git's order, which is not stable across
+    # versions. Unsorted, a re-run would look like a new state and comment again.
+    a = _backmerge.state_marker("abc1234", 2, ["b.md", "a.md"])
+    b = _backmerge.state_marker("abc1234", 2, ["a.md", "b.md"])
+    assert a == b
+
+
+def test_state_marker_changes_with_the_drift() -> None:
+    base = _backmerge.state_marker("abc1234", 2, ["a.md"])
+    assert base != _backmerge.state_marker("def5678", 2, ["a.md"])
+    assert base != _backmerge.state_marker("abc1234", 3, ["a.md"])
+    assert base != _backmerge.state_marker("abc1234", 2, ["a.md", "b.md"])
+
+
+def test_existing_pr_search_spans_every_state(monkeypatch) -> None:
+    # A closed back-merge pull request was closed by a human decision. Searching
+    # open-only would reopen that argument on the next scheduled run.
+    seen: list[list[str]] = []
+    monkeypatch.setattr(_backmerge, "capture", lambda cmd: (seen.append(cmd), "")[1])
+    _backmerge.existing_pr("some-branch")
+    assert "--state" in seen[0]
+    assert seen[0][seen[0].index("--state") + 1] == "all"
+
+
+def test_pr_body_states_plainly_when_there_are_no_checks() -> None:
+    body = _backmerge.pr_body(["abc1234 docs: fix"], 1, has_ci=False)
+    assert "carries no CI checks" in body
+    assert "close and reopen" in body.lower()
+    assert "`abc1234 docs: fix`" in body
+
+
+def test_pr_body_demands_a_merge_commit() -> None:
+    # A squash or rebase drops the second parent, so `dev` gains the content but
+    # never the ancestry: the count stays put, `release-pr` stays blocked, and the
+    # next run reopens the same pull request. #577 was squash-merged and the drift
+    # did not move, which is how this was found.
+    body = _backmerge.pr_body(["abc1234 docs: fix"], 9, has_ci=False)
+    assert "Create a merge commit" in body
+    assert "does not converge" in body
+
+
+def test_pr_body_flags_an_ancestry_only_merge() -> None:
+    listing = ["abc1234 docs: fix"]
+    assert "changes no files" in _backmerge.pr_body(
+        listing, 9, has_ci=False, ancestry_only=True
+    )
+    assert "changes no files" not in _backmerge.pr_body(listing, 9, has_ci=False)
+
+
+def test_ancestry_only_compares_the_merge_against_dev(monkeypatch) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.setattr(_backmerge, "try_run", lambda cmd: (seen.append(cmd), 0)[1])
+    assert _backmerge.is_ancestry_only()
+    assert seen == [["git", "diff", "--quiet", "origin/dev", "HEAD"]]
+
+    monkeypatch.setattr(_backmerge, "try_run", lambda cmd: 1)
+    assert not _backmerge.is_ancestry_only()
+
+
+def test_pr_body_does_not_claim_missing_checks_when_a_token_is_set() -> None:
+    body = _backmerge.pr_body(["abc1234 docs: fix"], 1, has_ci=True)
+    assert "carries no CI checks" not in body
+    assert "checks run normally" in body
+
+
+def test_issue_body_names_the_conflicting_paths() -> None:
+    body = _backmerge.issue_body(
+        "abc1234",
+        2,
+        "rc-dev/chore/back-merge-main-abc1234",
+        ["docs/images/banner.png"],
+        ["abc1234 docs: banner"],
+        "<!-- marker -->",
+        "https://example.test/run/1",
+        "",
+    )
+    assert "`docs/images/banner.png`" in body
+    assert "rc-dev/chore/back-merge-main-abc1234" in body
+    assert "<!-- marker -->" in body
+    # The CHANGELOG recipe is wrong for a binary conflict; it must stay
+    # conditional on CHANGELOG.md actually being one of the conflicting paths.
+    assert "## [Unreleased]" not in body
+
+
+def test_issue_body_adds_the_changelog_recipe_only_when_it_conflicts() -> None:
+    body = _backmerge.issue_body(
+        "abc1234",
+        2,
+        "branch",
+        ["CHANGELOG.md"],
+        ["abc1234 chore: release"],
+        "<!-- marker -->",
+        "https://example.test/run/1",
+        "",
+    )
+    assert "## [Unreleased]" in body
+
+
+def test_issue_body_explains_a_clean_merge_that_could_not_be_proposed() -> None:
+    body = _backmerge.issue_body(
+        "abc1234",
+        1,
+        "branch",
+        [],
+        ["abc1234 docs: fix"],
+        "<!-- marker -->",
+        "https://example.test/run/1",
+        "The merge was clean, but `gh pr create` was rejected.",
+    )
+    # With no conflicts the reason stands on its own, so each caller can say what
+    # actually happened -- a rejected pull request, a failed push, or a closed
+    # one -- instead of inheriting one hardcoded explanation that fits only some.
+    assert "The merge was clean, but `gh pr create` was rejected." in body
+    assert "Conflicting paths" not in body
+
+
+def test_in_sync_closes_the_tracking_issue(monkeypatch) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: seen.append(cmd))
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 0)
+    monkeypatch.setattr(_backmerge, "open_tracking_issue", lambda: "42")
+    monkeypatch.setattr(_backmerge, "try_run", lambda cmd: (seen.append(cmd), 0)[1])
+
+    assert _backmerge.main() == 0
+    close = [c for c in seen if c[:3] == ["gh", "issue", "close"]]
+    assert close and close[0][3] == "42"
+
+
+def test_in_sync_with_no_open_issue_does_nothing(monkeypatch) -> None:
+    seen: list[list[str]] = []
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: seen.append(cmd))
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 0)
+    monkeypatch.setattr(_backmerge, "open_tracking_issue", lambda: "")
+
+    assert _backmerge.main() == 0
+    # Explicit refspecs, not bare branch names: `actions/checkout` configures
+    # `remote.origin.fetch` for the one branch it checked out, and under that a
+    # bare fetch updates FETCH_HEAD without creating `refs/remotes/origin/dev`.
+    assert seen == [
+        [
+            "git",
+            "fetch",
+            "--quiet",
+            "origin",
+            "+refs/heads/main:refs/remotes/origin/main",
+            "+refs/heads/dev:refs/remotes/origin/dev",
+        ]
+    ]
+
+
+def test_an_open_pull_request_stops_the_run(monkeypatch) -> None:
+    # Re-running against an unchanged main head must not open a second pull
+    # request, push over the branch, or file a duplicate issue.
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: None)
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 2)
+    monkeypatch.setattr(_backmerge, "main_head", lambda: "abc1234")
+    monkeypatch.setattr(_backmerge, "carried_commits", lambda: ["abc1234 docs: fix"])
+    monkeypatch.setattr(_backmerge, "existing_pr", lambda branch: ("77", "OPEN"))
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("must not act while a pull request is already open")
+
+    monkeypatch.setattr(_backmerge, "attempt_merge", _explode)
+    monkeypatch.setattr(_backmerge, "open_pr", _explode)
+    monkeypatch.setattr(_backmerge, "track", _explode)
+
+    assert _backmerge.main() == 0
+
+
+def test_a_closed_pull_request_still_surfaces_the_drift(monkeypatch) -> None:
+    # #564 and #565 were both closed without merging, and the divergence then sat
+    # unnoticed for days. Treating a closed pull request as "handled" reproduces
+    # exactly that: no pull request, no issue, and a green run.
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: None)
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 2)
+    monkeypatch.setattr(_backmerge, "main_head", lambda: "abc1234")
+    monkeypatch.setattr(_backmerge, "carried_commits", lambda: ["abc1234 docs: fix"])
+    monkeypatch.setattr(_backmerge, "existing_pr", lambda branch: ("77", "CLOSED"))
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("must not reopen or re-push a closed pull request")
+
+    monkeypatch.setattr(_backmerge, "attempt_merge", _explode)
+    monkeypatch.setattr(_backmerge, "open_pr", _explode)
+
+    reasons: list[str] = []
+    monkeypatch.setattr(
+        _backmerge,
+        "track",
+        lambda sha, behind, branch, conflicts, commits, url, reason: (
+            reasons.append(reason),
+            True,
+        )[1],
+    )
+
+    assert _backmerge.main() == 0
+    assert reasons and "#77" in reasons[0]
+    assert "closed without" in reasons[0]
+
+
+def test_a_merged_pull_request_with_drift_left_diagnoses_the_squash(
+    monkeypatch,
+) -> None:
+    # Merged, yet dev still does not contain main. That only happens when the
+    # pull request was squashed or rebased: the second parent is discarded, so
+    # the content lands but the ancestry never does and the count cannot reach
+    # zero. #577 was squash-merged and the drift stayed at 9.
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: None)
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 9)
+    monkeypatch.setattr(_backmerge, "main_head", lambda: "abc1234")
+    monkeypatch.setattr(_backmerge, "carried_commits", lambda: ["abc1234 docs: fix"])
+    monkeypatch.setattr(_backmerge, "existing_pr", lambda branch: ("577", "MERGED"))
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("must not re-merge or re-push behind a merged PR")
+
+    monkeypatch.setattr(_backmerge, "attempt_merge", _explode)
+    monkeypatch.setattr(_backmerge, "open_pr", _explode)
+
+    reasons: list[str] = []
+    monkeypatch.setattr(
+        _backmerge,
+        "track",
+        lambda sha, behind, branch, conflicts, commits, url, reason: (
+            reasons.append(reason),
+            True,
+        )[1],
+    )
+
+    assert _backmerge.main() == 0
+    assert reasons
+    assert "squash or rebase merge" in reasons[0]
+    assert "--no-ff" in reasons[0]
+    # The closed-without-merging copy would be false here.
+    assert "closed without" not in reasons[0]
+
+
+def test_a_pushed_branch_without_a_pull_request_is_not_pushed_again(
+    monkeypatch,
+) -> None:
+    # The ruleset blocks non-fast-forward pushes, and rewriting a branch under
+    # review destroys the incremental diff. Finish the job, do not redo it.
+    calls: list[str] = []
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: calls.append(cmd[0]))
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 2)
+    monkeypatch.setattr(_backmerge, "main_head", lambda: "abc1234")
+    monkeypatch.setattr(_backmerge, "carried_commits", lambda: ["abc1234 docs: fix"])
+    monkeypatch.setattr(_backmerge, "existing_pr", lambda branch: ("", ""))
+    monkeypatch.setattr(_backmerge, "remote_branch_exists", lambda branch: True)
+    monkeypatch.setattr(_backmerge, "open_tracking_issue", lambda: "")
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("must not re-merge or re-push an existing branch")
+
+    monkeypatch.setattr(_backmerge, "attempt_merge", _explode)
+    opened: list[str] = []
+    monkeypatch.setattr(
+        _backmerge, "open_pr", lambda b, c, n, ci, ao=False: (opened.append(b), 0)[1]
+    )
+
+    assert _backmerge.main() == 0
+    assert opened == ["rc-dev/chore/back-merge-main-abc1234"]
+
+
+def test_a_conflict_pushes_nothing_and_tracks(monkeypatch) -> None:
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: None)
+    mutated: list[list[str]] = []
+    monkeypatch.setattr(_backmerge, "mutate", lambda cmd: (mutated.append(cmd), 0)[1])
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 2)
+    monkeypatch.setattr(_backmerge, "main_head", lambda: "abc1234")
+    monkeypatch.setattr(_backmerge, "carried_commits", lambda: ["abc1234 docs: fix"])
+    monkeypatch.setattr(_backmerge, "existing_pr", lambda branch: ("", ""))
+    monkeypatch.setattr(_backmerge, "remote_branch_exists", lambda branch: False)
+    monkeypatch.setattr(_backmerge, "signoff_trailer", lambda: "Signed-off-by: b <b@e>")
+    monkeypatch.setattr(_backmerge, "attempt_merge", lambda b, m: ["CHANGELOG.md"])
+
+    tracked: list[list[str]] = []
+    monkeypatch.setattr(
+        _backmerge,
+        "track",
+        lambda sha, behind, branch, conflicts, commits, url, reason: (
+            tracked.append(conflicts),
+            True,
+        )[1],
+    )
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("must not open a pull request for a conflicted merge")
+
+    monkeypatch.setattr(_backmerge, "open_pr", _explode)
+
+    assert _backmerge.main() == 0
+    assert tracked == [["CHANGELOG.md"]]
+    assert not [cmd for cmd in mutated if "push" in cmd]
+
+
+def test_a_rejected_pull_request_falls_through_to_the_issue(monkeypatch) -> None:
+    # If the repository forbids Actions from creating pull requests, the drift
+    # must still surface somewhere rather than vanishing into a green run.
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: None)
+    monkeypatch.setattr(_backmerge, "mutate", lambda cmd: 0)
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 2)
+    monkeypatch.setattr(_backmerge, "main_head", lambda: "abc1234")
+    monkeypatch.setattr(_backmerge, "carried_commits", lambda: ["abc1234 docs: fix"])
+    monkeypatch.setattr(_backmerge, "existing_pr", lambda branch: ("", ""))
+    monkeypatch.setattr(_backmerge, "remote_branch_exists", lambda branch: False)
+    monkeypatch.setattr(_backmerge, "signoff_trailer", lambda: "Signed-off-by: b <b@e>")
+    monkeypatch.setattr(_backmerge, "attempt_merge", lambda b, m: [])
+    monkeypatch.setattr(_backmerge, "is_ancestry_only", lambda: False)
+    monkeypatch.setattr(_backmerge, "open_pr", lambda b, c, n, ci, ao=False: 1)
+
+    reasons: list[str] = []
+    monkeypatch.setattr(
+        _backmerge,
+        "track",
+        lambda sha, behind, branch, conflicts, commits, url, reason: (
+            reasons.append(reason),
+            True,
+        )[1],
+    )
+
+    assert _backmerge.main() == 0
+    assert reasons and "gh pr create" in reasons[0]
+
+
+def test_a_failed_tracking_issue_write_fails_the_run(monkeypatch) -> None:
+    # Exiting zero on a conflict is only defensible while the tracking issue is
+    # the compensating signal. If that write also fails, Actions would otherwise
+    # stay green with no pull request and no issue -- the silent drift this
+    # workflow exists to end.
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: None)
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 2)
+    monkeypatch.setattr(_backmerge, "main_head", lambda: "abc1234")
+    monkeypatch.setattr(_backmerge, "carried_commits", lambda: ["abc1234 docs: fix"])
+    monkeypatch.setattr(_backmerge, "existing_pr", lambda branch: ("", ""))
+    monkeypatch.setattr(_backmerge, "remote_branch_exists", lambda branch: False)
+    monkeypatch.setattr(_backmerge, "signoff_trailer", lambda: "Signed-off-by: b <b@e>")
+    monkeypatch.setattr(_backmerge, "attempt_merge", lambda b, m: ["CHANGELOG.md"])
+    monkeypatch.setattr(_backmerge, "ensure_label", lambda: None)
+    monkeypatch.setattr(_backmerge, "open_tracking_issue", lambda: "")
+    # `gh issue create` rejected.
+    monkeypatch.setattr(_backmerge, "mutate", lambda cmd: 1)
+
+    assert _backmerge.main() == 1
+
+
+def test_a_failed_issue_comment_fails_the_run(monkeypatch) -> None:
+    monkeypatch.setattr(_backmerge, "ensure_label", lambda: None)
+    monkeypatch.setattr(_backmerge, "open_tracking_issue", lambda: "42")
+    monkeypatch.setattr(_backmerge, "already_reported", lambda issue, marker: False)
+    monkeypatch.setattr(_backmerge, "mutate", lambda cmd: 1)
+
+    assert not _backmerge.track(
+        "abc1234", 2, "branch", ["a.md"], ["abc1234 x"], "url", ""
+    )
+
+
+def test_a_title_edit_failure_does_not_fail_the_run(monkeypatch) -> None:
+    # The title only carries the live count. The drift is recorded either way, so
+    # a cosmetic failure must not turn the run red.
+    monkeypatch.setattr(_backmerge, "ensure_label", lambda: None)
+    monkeypatch.setattr(_backmerge, "open_tracking_issue", lambda: "42")
+    monkeypatch.setattr(_backmerge, "already_reported", lambda issue, marker: False)
+    monkeypatch.setattr(
+        _backmerge, "mutate", lambda cmd: 1 if cmd[:3] == ["gh", "issue", "edit"] else 0
+    )
+
+    assert _backmerge.track("abc1234", 2, "branch", ["a.md"], ["abc1234 x"], "url", "")
+
+
+def test_a_failed_push_does_not_claim_the_branch_is_ready(monkeypatch) -> None:
+    # A failed push followed by a failed `gh pr create` used to file an issue
+    # saying the branch was pushed and ready to propose.
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: None)
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 2)
+    monkeypatch.setattr(_backmerge, "main_head", lambda: "abc1234")
+    monkeypatch.setattr(_backmerge, "carried_commits", lambda: ["abc1234 docs: fix"])
+    monkeypatch.setattr(_backmerge, "existing_pr", lambda branch: ("", ""))
+    monkeypatch.setattr(_backmerge, "remote_branch_exists", lambda branch: False)
+    monkeypatch.setattr(_backmerge, "signoff_trailer", lambda: "Signed-off-by: b <b@e>")
+    monkeypatch.setattr(_backmerge, "attempt_merge", lambda b, m: [])
+    monkeypatch.setattr(_backmerge, "is_ancestry_only", lambda: False)
+    monkeypatch.setattr(_backmerge, "mutate", lambda cmd: 1 if "push" in cmd else 0)
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("must not propose a branch that never reached the remote")
+
+    monkeypatch.setattr(_backmerge, "open_pr", _explode)
+
+    reasons: list[str] = []
+    monkeypatch.setattr(
+        _backmerge,
+        "track",
+        lambda sha, behind, branch, conflicts, commits, url, reason: (
+            reasons.append(reason),
+            True,
+        )[1],
+    )
+
+    assert _backmerge.main() == 0
+    assert reasons and "pushing the branch failed" in reasons[0]
+    assert "pushed and ready" not in reasons[0]
+
+
+def test_a_clean_merge_pushes_then_opens_the_pull_request(monkeypatch) -> None:
+    # The primary happy path: pin the push argv and the ordering.
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: None)
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 2)
+    monkeypatch.setattr(_backmerge, "main_head", lambda: "abc1234")
+    monkeypatch.setattr(_backmerge, "carried_commits", lambda: ["abc1234 docs: fix"])
+    monkeypatch.setattr(_backmerge, "existing_pr", lambda branch: ("", ""))
+    monkeypatch.setattr(_backmerge, "remote_branch_exists", lambda branch: False)
+    monkeypatch.setattr(_backmerge, "signoff_trailer", lambda: "Signed-off-by: b <b@e>")
+    monkeypatch.setattr(_backmerge, "attempt_merge", lambda b, m: [])
+    monkeypatch.setattr(_backmerge, "is_ancestry_only", lambda: False)
+    monkeypatch.setattr(_backmerge, "open_tracking_issue", lambda: "")
+
+    order: list[str] = []
+    monkeypatch.setattr(
+        _backmerge, "mutate", lambda cmd: (order.append(" ".join(cmd)), 0)[1]
+    )
+    monkeypatch.setattr(
+        _backmerge,
+        "open_pr",
+        lambda b, c, n, ci, ao=False: (order.append(f"open_pr {b}"), 0)[1],
+    )
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("must not track a successful back-merge")
+
+    monkeypatch.setattr(_backmerge, "track", _explode)
+
+    assert _backmerge.main() == 0
+    branch = "rc-dev/chore/back-merge-main-abc1234"
+    assert order[0] == f"git push origin {branch}"
+    assert order[1] == f"open_pr {branch}"
+
+
+def test_a_new_pull_request_supersedes_a_stale_tracking_issue(monkeypatch) -> None:
+    # An issue filed for an earlier conflicting head otherwise stays open beside
+    # the pull request that fixed it, saying the back-merge could not be opened.
+    monkeypatch.setattr(_backmerge, "run", lambda cmd, **kw: None)
+    monkeypatch.setattr(_backmerge, "main_only_count", lambda: 2)
+    monkeypatch.setattr(_backmerge, "main_head", lambda: "abc1234")
+    monkeypatch.setattr(_backmerge, "carried_commits", lambda: ["abc1234 docs: fix"])
+    monkeypatch.setattr(_backmerge, "existing_pr", lambda branch: ("", ""))
+    monkeypatch.setattr(_backmerge, "remote_branch_exists", lambda branch: False)
+    monkeypatch.setattr(_backmerge, "signoff_trailer", lambda: "Signed-off-by: b <b@e>")
+    monkeypatch.setattr(_backmerge, "attempt_merge", lambda b, m: [])
+    monkeypatch.setattr(_backmerge, "is_ancestry_only", lambda: False)
+    monkeypatch.setattr(_backmerge, "open_pr", lambda b, c, n, ci, ao=False: 0)
+    monkeypatch.setattr(_backmerge, "open_tracking_issue", lambda: "42")
+
+    closed: list[list[str]] = []
+    monkeypatch.setattr(_backmerge, "mutate", lambda cmd: (closed.append(cmd), 0)[1])
+
+    assert _backmerge.main() == 0
+    close = [c for c in closed if c[:3] == ["gh", "issue", "close"]]
+    assert close and close[0][3] == "42"
+
+
+def test_track_stays_silent_when_the_state_is_unchanged(monkeypatch) -> None:
+    # The scheduled run fires daily. Without this, an unresolved divergence
+    # accumulates one identical comment per morning.
+    monkeypatch.setattr(_backmerge, "ensure_label", lambda: None)
+    monkeypatch.setattr(_backmerge, "open_tracking_issue", lambda: "42")
+    monkeypatch.setattr(_backmerge, "already_reported", lambda issue, marker: True)
+
+    def _explode(cmd):
+        raise AssertionError("must not comment when nothing changed")
+
+    monkeypatch.setattr(_backmerge, "mutate", _explode)
+    _backmerge.track("abc1234", 2, "branch", ["a.md"], ["abc1234 x"], "url", "")
+
+
+def test_track_comments_when_the_state_changed(monkeypatch) -> None:
+    monkeypatch.setattr(_backmerge, "ensure_label", lambda: None)
+    monkeypatch.setattr(_backmerge, "open_tracking_issue", lambda: "42")
+    monkeypatch.setattr(_backmerge, "already_reported", lambda issue, marker: False)
+    seen: list[list[str]] = []
+    monkeypatch.setattr(_backmerge, "mutate", lambda cmd: (seen.append(cmd), 0)[1])
+
+    _backmerge.track("abc1234", 3, "branch", ["a.md"], ["abc1234 x"], "url", "")
+    assert seen[0][:3] == ["gh", "issue", "comment"]
+    assert seen[0][3] == "42"
+
+
+def test_track_opens_the_issue_when_none_is_open(monkeypatch) -> None:
+    monkeypatch.setattr(_backmerge, "ensure_label", lambda: None)
+    monkeypatch.setattr(_backmerge, "open_tracking_issue", lambda: "")
+    seen: list[list[str]] = []
+    monkeypatch.setattr(_backmerge, "mutate", lambda cmd: (seen.append(cmd), 0)[1])
+
+    _backmerge.track("abc1234", 3, "branch", ["a.md"], ["abc1234 x"], "url", "")
+    assert seen[0][:3] == ["gh", "issue", "create"]
+    assert "--label" in seen[0]
+    assert seen[0][seen[0].index("--label") + 1] == _backmerge.LABEL
+
+
+def test_dry_run_announces_instead_of_writing(monkeypatch, capsys) -> None:
+    # The pull request editing this workflow must not open a real back-merge.
+    monkeypatch.setattr(_backmerge, "DRY_RUN", True)
+
+    def _explode(cmd):
+        raise AssertionError("dry run must not reach a real command")
+
+    monkeypatch.setattr(_backmerge, "try_run", _explode)
+    assert _backmerge.mutate(["gh", "pr", "create"]) == 0
+    assert "[dry run]" in capsys.readouterr().out


### PR DESCRIPTION
## Motivation

The back-merge automation from #576 has never run. It landed on `dev` alone, and every trigger that would run it for real resolves the workflow file somewhere it is not:

- `push: branches: [main]` resolves the workflow from the pushed commit **on `main`**. The file is not there.
- `schedule` and `workflow_dispatch` are read from the **default branch**, which is `main`. The file is not there either. `.github/workflows/backmerge.yml:25-27` already says this about those two.

The run history is the proof — two runs, both `pull_request` dry runs on the branch that introduced the workflow:

```
$ gh run list --workflow=backmerge.yml
pull_request  rc-dev/ci/backmerge-main-to-dev  success  2026-08-05
pull_request  rc-dev/ci/backmerge-main-to-dev  success  2026-08-04
```

Zero scheduled runs in the five days since it merged, against a `cron: "37 6 * * *"`. The `back-merge` label does not exist in the repository either, which agrees: `ensure_label()` creates it on the first real run, and there has not been one.

The fix for `main`/`dev` drift is stranded on `dev` by that drift.

## Outcome

`.github/workflows/backmerge.yml`, `.github/workflows/scripts/backmerge.py`, and `tests/test_backmerge.py` now exist on `main`, so `push`, `schedule`, and `workflow_dispatch` all resolve to a real file.

All three are copied **verbatim** from `dev` (`git checkout origin/dev -- <paths>`), so the two copies are byte-identical and the next back-merge is a no-op on these paths rather than a conflict.

`RELEASE.md` and `CHANGELOG.md` were also touched by #576. Those stay on `dev` and reach `main` through the usual release pull request — carrying them here would put a stamped-changelog edit on `main` outside a release, which is the shape of drift this whole mechanism exists to prevent.

## Scope

This restores the trigger. It does **not** by itself clear the current 9-commit divergence, because that divergence is an ancestry problem, not a content one: #577 and #570 were squash-merged, so `main`'s commits are on `dev` in content but not as ancestors, and `git rev-list --count origin/dev..origin/main` stays at 9 no matter how many times the workflow runs. A follow-up pull request repairs the ancestry with a real two-parent merge.

## Verification

| # | Check | Result |
|---|---|---|
| 1 | The three paths are absent from `origin/main` before this change | Confirmed via `git ls-tree origin/main .github/workflows/` |
| 2 | Files are byte-identical to `origin/dev` | Staged with `git checkout origin/dev -- <paths>`; no edits after |
| 3 | `tests/test_backmerge.py` passes against `main`'s tree | 35 passed |
| 4 | The test needs nothing that is `dev`-only | It loads the script by path and stubs every subprocess call; only `pytest` is required |
| 5 | Nothing else is staged | `git status --short` shows exactly three added paths |

## After this merges

`BACKMERGE_TOKEN` is not set, so back-merge pull requests will open with no checks on them. That is the documented behaviour from #576, not a regression: GitHub does not trigger `on: pull_request` for a pull request opened with `GITHUB_TOKEN`, and the generated body says so. Setting the secret turns checks on with no change to the workflow.

Refs #561, #576.
