### PR TITLE
docs: add the authoring guideline and the architecture decision records

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - **`docs/uninstall.md`**. `uninstall.sh --scan` and teardown, and switching between the hosted, local, and plugin channels. The two root scripts are colocated so `install.sh` and `uninstall.sh` stay reviewable side by side. A test asserts every file the installer writes is one the teardown accounts for.
 - **`docs/contributing/architecture.md`**. The map of the architecture. The quality requirements and the constraints that shape it, the boundary with its diagram, and the decomposition into applications, packages, and layers. Then the tool surface, the response shape, one runtime scenario, the rules that cross every package, the known debt, and the glossary.
 - **`docs/contributing/conventions.md`**. The code conventions, as rules with permanent IDs. A rule belongs there when a reviewer applies it by judgment to one unit of code.
+- **`docs/contributing/authoring.md`**. How the docs tree is organized, the audience and Diataxis cuts, and where a new doc goes.
 - **`docs/mcp/tools/`**. Per-area MCP tool reference (parameters, edge cases, cross-cutting behavior). Includes `identifiers.md`, the canonical map of which tool/argument expects slug vs `internal_id` vs uuid vs numeric id.
 - **`docs/cli/`**. CLI-specific guides, for example introspect-then-execute.
 - **`docs/sdk/README.md`**. Using `pipefy` as a library.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Human-facing guides for the **[pipefy/ai-toolkit](https://github.com/pipefy/ai-t
 | [`contributing/dependencies.md`](contributing/dependencies.md) | Why each runtime dependency exists |
 | [`contributing/architecture.md`](contributing/architecture.md) | Map of the architecture: the quality requirements and constraints that shape it, the boundary with its diagram, the decomposition into applications, packages, and layers, one runtime scenario, the rules that cross every package, the known debt, and the glossary |
 | [`contributing/conventions.md`](contributing/conventions.md) | Code conventions, as rules with permanent IDs. A rule belongs there when a reviewer applies it by judgment to one unit of code |
+| [`contributing/authoring.md`](contributing/authoring.md) | How the docs tree is organized and where a new doc goes |
 | [`ipaas.md`](ipaas.md) | iPaaS (Advanced Automations) tools: meta-tool pattern, flow overview, vocabulary |
 | [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Contributing skills (Markdown playbooks) |
 | [`../RELEASE.md`](../RELEASE.md) | Versioning and GitHub Releases |

--- a/docs/contributing/adr/0001-layered-responsibility.md
+++ b/docs/contributing/adr/0001-layered-responsibility.md
@@ -1,0 +1,22 @@
+# ADR-0001: Layered responsibility
+
+Status: proposed
+Date: 2026-07-20
+
+## Context
+
+The SDK, the MCP server, and the CLI all touch the same domain. Without a stated rule, multi-step logic and product decisions drifted into whichever layer was open. A hidden `get_pipe` inside an SDK method is the symptom: orchestration the caller cannot see, living below the layer that owns the intent. A second question was left open: when can identifier resolution live in the SDK at all?
+
+## Decision
+
+The SDK is the deterministic execution layer. The application layer, which is the MCP tools and the CLI, owns intent, orchestration, and product policy. The SDK executes a named operation predictably. The application layer decides which operations to run to satisfy an intent.
+
+Place a behavior by its determinism. Deterministic resolution, where the scoping id makes exactly one answer correct, lives in the SDK. The technique is to require the scoping id that makes the key unique, for example resolving `(repo_id, slug)` rather than a bare slug. Genuine ambiguity, where choosing an answer is a judgment call, lives in the application layer.
+
+This split covers the three applications (SDK, CLI, MCP server) and the shared support libraries (`auth`, `infra`). A shared library is not an application. It owns no driving port. It adds a driven port only where there is payoff, so a pure-utility library holds none.
+
+## Consequences
+
+A reader locates any behavior by one question: is it how to execute an operation (SDK) or what the user wants (application layer). This is the mainstream hexagonal split, so the model is recognizable to any contributor. Resolution placement is the sharpest rule and the least standardized, so it carries the highest teaching burden. A newcomer will not arrive knowing it, and mis-classifying an ambiguous resolution as deterministic puts a judgment call in the wrong layer.
+
+The current rule lives in [`architecture.md`](../architecture.md).

--- a/docs/contributing/adr/0002-typed-single-form-contract.md
+++ b/docs/contributing/adr/0002-typed-single-form-contract.md
@@ -1,0 +1,22 @@
+# ADR-0002: Typed, single-form contract
+
+Status: proposed. The arguments and identifiers parts are ready. The typed-output rollout is a later step.
+Date: 2026-07-23
+
+## Context
+
+The SDK was a thin GraphQL passthrough. Most facade methods returned a bare `dict`, mutators accepted `**attrs: Any`, and identifiers were `str | int` pockets. Wire shape leaked into both client products: key casing, `edges`/`node` envelopes, and dict keys the caller had to know by string. The clients re-dug the same shapes and re-validated data the SDK already held. Arguments compounded the problem when one parameter accepted an id, a uuid, or a slug and sniffed which form it received.
+
+## Decision
+
+The SDK public contract is explicit, single-form, and typed in both directions.
+
+An argument names exactly one form and never branches on a runtime value to guess intent. A second form is a separate named field, a `_by_*` sibling, or a caller-constructed sum type (`PipeRef = ById | ByUuid`) matched exhaustively. Identifier form is a per-application choice: the SDK is numeric-first, the CLI takes deterministic ids with name resolution behind an opt-in flag, and the MCP server takes the human intent with an id fast-path field.
+
+Methods return domain models named in Pipefy vocabulary, not wire dicts. Wire concerns terminate at the SDK: casing settles to one Python-idiomatic form, `edges`/`node` is dropped, and an id is carried as the `str` the GraphQL `ID` scalar promises. The wire-to-domain mapping is a `from_wire` classmethod invoked at the facade, the same boundary that runs deterministic resolution. A thin per-domain wire mirror stays a pure passthrough and doubles as the uuid fast-path, added only where a caller earns it.
+
+## Consequences
+
+Each application is homogeneous on its own terms, and both client products shed the dict-shuffling glue. The cost is more fields and more methods than a polymorphic argument would need. If uuid-first were ever wanted, the two-tier structure makes it a reskin, not a rewrite. The typed-output change is breaking, so it rolls out resource by resource behind the stable facade, with Card first. The resource sequence is tracked in the typed-output rollout epic.
+
+The current rules live in [`conventions.md`](../conventions.md).

--- a/docs/contributing/adr/0003-mcp-tools-express-outcomes.md
+++ b/docs/contributing/adr/0003-mcp-tools-express-outcomes.md
@@ -1,0 +1,20 @@
+# ADR-0003: MCP tools express outcomes
+
+Status: proposed. The contract standards are ready. The outcome-tool consolidation is deferred.
+Date: 2026-07-20
+
+## Context
+
+The MCP surface was close to a one-to-one map of the GraphQL API. A tool per endpoint pushes orchestration into the model context, where it is slow, expensive, and unreliable. Tools also leaned on `extra_input` and `**attrs` passthroughs and returned raw GraphQL envelopes, so the model had to parse wire noise and got nothing actionable from an error.
+
+## Decision
+
+An MCP tool expresses one user outcome and orchestrates the underlying steps in code, not in the model context. Do not fragment one goal into atomic operations the model must chain. Expose a discovery tool only where listing is itself the user's goal, never as a mandatory input-feeder for an action tool.
+
+Tool contracts follow four standards. Arguments are flat and explicit: typed primitives, `Literal` for a closed set, one form per field, no guess-the-shape passthroughs. Responses are shaped and bounded, carrying pagination metadata. Errors are typed and actionable. Write gates use protocol-native elicitation, which fires when the client declares support and otherwise fails closed, so a headless client never waits on a prompt nobody can answer.
+
+## Consequences
+
+A full tool-surface audit is its own epic, so the outcome-shaping is deferred while the contract hygiene is adopted now. Keep primitive escape hatches beside the high-level tools, so consolidation does not hide expressiveness a caller needs. MCP design is young, so treat the outcome-shaped tool as a strong heuristic, not a settled recipe.
+
+The current rules live in [`mcp/README.md`](../../mcp/README.md).

--- a/docs/contributing/adr/0004-vertical-slice-structure.md
+++ b/docs/contributing/adr/0004-vertical-slice-structure.md
@@ -1,0 +1,38 @@
+# ADR-0004: Vertical-slice structure and naming
+
+Status: proposed, deferred to its own initiative
+Date: 2026-07-20
+
+## Context
+
+The SDK is organized horizontally: `services/`, `models/`, and `queries/`, with about twenty homeless cross-cutting modules at the package root. The primitive layer is named `services/` although it holds only wire wrappers, so the name misdescribes it. A horizontal split tells a reader what kind of file each module is, not what the package is about.
+
+## Decision
+
+Organize each package by domain vertical slice, not by technical layer. The horizontal split is only the boundary between the SDK, the MCP server, and the CLI. Within a package the top level names the domain (`members/`, `pipes/`).
+
+The domain-type, primitive, use-case, and facade distinction is a dependency contract, not a folder axis. The four are roles inside a slice (`models.py`, `client.py`, `usecases.py`, `facade.py`), held by an import-linter contract that keeps `models.py` free of transport and framework and points imports from facade to use case to client to model. Name on merits in Pipefy vocabulary, borrowing only the narrow DDD terms that cut something: anti-corruption layer, application service, domain service, and entity versus value object. The SDK exposes a facade per domain under a thin `Pipefy` composition root, which frees the name `client` for the primitive layer.
+
+## Consequences
+
+This is the largest bet. It spans three packages and changes the SDK public surface, including a `PipefyClient` to `Pipefy` rename that touches hundreds of references. It is deferred to its own initiative. The service-by-service split work-list is tracked in that rollout epic.
+
+No living doc carries a rule from this decision while it stays deferred. [`architecture.md`](../architecture.md) maps the structure that holds today, which is the horizontal one. This record is the only place that describes the target.
+
+## Target slices
+
+The slice names are the sub-domains of Pipefy's own domain model, which is maintained outside this repository, and not names chosen here. A slice boundary therefore follows a boundary that the business already draws. The two cross-cutting exclusions below come from the same model. Its tenth sub-domain, Electronic Signature, has no tool in this repository.
+
+The SDK divides into these vertical slices:
+
+- Work Execution
+- Process Modeling
+- Business Records
+- Request Intake
+- Identity and Access Management
+- Governance and Audit
+- Performance and Oversight
+- Billing
+- System Integration
+
+Two capabilities stay cross-cutting, not slices: Communication (email) and the Identity facet (`packages/auth`).

--- a/docs/contributing/adr/README.md
+++ b/docs/contributing/adr/README.md
@@ -1,0 +1,24 @@
+# Decision records
+
+These are the decision records behind the toolkit design: how the SDK, MCP server, and CLI are layered, how their contracts are shaped, and how the code is structured. Each record holds one decision with its context and reasoning. A record becomes immutable once it is adopted.
+
+There are four records, one per principle. Today all four are proposed. None is adopted yet. The rule each decision produces lives in a living doc, and that is what a contributor follows day to day. A deferred decision has no living rule yet, and its row says so. The record keeps the why. To change an adopted decision, add a new record that supersedes the old one. Do not edit an adopted record. See [`authoring.md`](../authoring.md).
+
+| ADR | Decision | Status | Current rule |
+|---|---|---|---|
+| [0001](0001-layered-responsibility.md) | Layered responsibility | proposed | [`architecture.md`](../architecture.md) |
+| [0002](0002-typed-single-form-contract.md) | Typed, single-form contract | proposed, typed-output rollout later | [`conventions.md`](../conventions.md) |
+| [0003](0003-mcp-tools-express-outcomes.md) | MCP tools express outcomes | proposed, consolidation deferred | [`mcp/README.md`](../../mcp/README.md) |
+| [0004](0004-vertical-slice-structure.md) | Vertical-slice structure and naming | proposed, deferred | none while deferred |
+
+The governance rule that a self-imposed constraint is a refactor candidate lives in [`conventions.md`](../conventions.md), not as a separate record.
+
+## Rollout epics
+
+Three decisions carry deferred work, tracked as epics rather than in these records:
+
+- Outcome-tool audit and consolidation (0003).
+- Vertical-slice refactor and the `Pipefy` root rename (0004).
+- Typed-output rollout, resource by resource with Card first (0002).
+
+The step-by-step exploration behind these decisions is in the repository history.

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -8,7 +8,7 @@ These readers arrive here:
 - A reviewer wants the rule and the ID to cite, and both live in [`conventions.md`](conventions.md).
 - A consumer of one application wants its interface instead of the layer model, in [`docs/mcp`](../mcp/README.md), [`docs/cli`](../cli/README.md), or [`docs/sdk`](../sdk/README.md).
 
-The map explains rather than instructs. It points at the owner of a fact rather than repeat it: a check, a schema, or another document. A copy appears only where the argument here depends on it. The reader pays one hop for that. Where the code does not match the map, [Known gaps](#known-gaps) names the difference.
+The map explains rather than instructs. It points at the owner of a fact rather than repeat it: a check, a schema, or a record under [`adr/`](adr/README.md). A copy appears only where the argument here depends on it. The reader pays one hop for that. Where the code does not match the map, [Known gaps](#known-gaps) names the difference.
 
 ## Quality requirements
 
@@ -112,7 +112,7 @@ An application is what a consumer uses. Each one exposes the same domain, and ea
 
 That match of application to consumer decides the layer split. The SDK executes. The CLI and the MCP server own intent, orchestration, and outcomes. The determinism of a behavior decides where that behavior lives. Deterministic resolution, such as a friendly identifier to a uuid, lives in the SDK. Ambiguous resolution lives in the CLI and the MCP server, where a human or an LLM can decide.
 
-Each application decides its own identifier form, and there is no global choice. The SDK takes numeric identifiers first. The CLI takes deterministic identifiers. If the CLI resolves a name, it does so behind an explicit flag that fails closed under automation. An identifier that can match more than one resource therefore never resolves silently, which is what `QR-7` requires. `ARG-1` in [`conventions.md`](conventions.md) holds each argument to one form, and [`docs/mcp/tools/identifiers.md`](../mcp/tools/identifiers.md) names which one, per tool and per argument.
+Each application decides its own identifier form, and there is no global choice. The SDK takes numeric identifiers first. The CLI takes deterministic identifiers. If the CLI resolves a name, it does so behind an explicit flag that fails closed under automation. An identifier that can match more than one resource therefore never resolves silently, which is what `QR-7` requires. `ARG-1` in [`conventions.md`](conventions.md) holds each argument to one form, and [`docs/mcp/tools/identifiers.md`](../mcp/tools/identifiers.md) names which one, per tool and per argument. These identifier rules come from the decision record [ADR-0002](adr/0002-typed-single-form-contract.md).
 
 The MCP server takes the human intent as the primary input. When the client declares the capability, the MCP server resolves ambiguity by elicitation. The declared capability of the client decides between interactive behavior and ambient behavior, so a headless caller stays deterministic, which is what `QR-3` requires.
 
@@ -120,7 +120,7 @@ A destructive operation carries the same split. `QR-6` asks that the operation n
 
 The path that holds today does not read that capability. A destructive tool previews what it affects, and it acts only after an explicit confirmation from the caller. One explicit answer therefore serves the interactive case and the ambient case alike, and [Known gaps](#known-gaps) carries the design question. [`packages/mcp/AGENTS.md`](../../packages/mcp/AGENTS.md) owns the protocol, and it records two limits. The guard protects against accident and not against intent, because a caller can confirm without a preview. Authorization stays the API's.
 
-The MCP layer prefers a tool that expresses an outcome over one tool per API endpoint, which is what `QR-5` asks for. The tool count tracks user intent, not the wire. The per-tool outcome design lives in the MCP docs. `SURF-1` in [`conventions.md`](conventions.md) is the rule that admits a new tool, method, or flag.
+The MCP layer prefers a tool that expresses an outcome over one tool per API endpoint, which is what `QR-5` asks for. The tool count tracks user intent, not the wire. The per-tool outcome design lives in the MCP docs. `SURF-1` in [`conventions.md`](conventions.md) is the rule that admits a new tool, method, or flag. The reasoning is in the decision record [ADR-0003](adr/0003-mcp-tools-express-outcomes.md).
 
 ## Tool surface
 
@@ -162,7 +162,7 @@ The layers of the MCP package map onto those roles, and their names come from it
 - The `auth` layer is a driven adapter over network and keychain I/O.
 - `settings` is parsed configuration at the innermost point.
 
-The CLI has no such layers, so this mapping belongs to the MCP package alone. The module list stays in the import-linter contract at `packages/mcp/pyproject.toml`, which CI runs.
+The CLI has no such layers, so this mapping belongs to the MCP package alone. The module list stays in the import-linter contract at `packages/mcp/pyproject.toml`, which CI runs. The reasoning behind the model is in the decision record [ADR-0001](adr/0001-layered-responsibility.md).
 
 ## Dependency rule
 

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -8,7 +8,7 @@ These readers arrive here:
 - A reviewer wants the rule and the ID to cite, and both live in [`conventions.md`](conventions.md).
 - A consumer of one application wants its interface instead of the layer model, in [`docs/mcp`](../mcp/README.md), [`docs/cli`](../cli/README.md), or [`docs/sdk`](../sdk/README.md).
 
-The map explains rather than instructs. It points at the owner of a fact rather than repeat it: a check, a schema, or a record under [`adr/`](adr/README.md). A copy appears only where the argument here depends on it. The reader pays one hop for that. Where the code does not match the map, [Known gaps](#known-gaps) names the difference.
+The map explains rather than instructs. It points at the owner of a fact rather than repeat it: a check, a schema, or a record under [`adr/`](adr/README.md). A copy appears only where the argument here depends on it. The reader pays one hop for that, and [`authoring.md`](authoring.md) states the rule for the whole tree. Where the code does not match the map, [Known gaps](#known-gaps) names the difference.
 
 ## Quality requirements
 

--- a/docs/contributing/authoring.md
+++ b/docs/contributing/authoring.md
@@ -1,0 +1,51 @@
+# Documentation authoring
+
+This guide describes the target structure for the `docs/` tree and where a new doc goes. Its siblings are [`architecture.md`](architecture.md) and [`conventions.md`](conventions.md).
+
+The tree is mid-migration to this target. Where a file still sits in the wrong place, an open issue tracks the move.
+
+## Where a doc goes
+
+Sort by audience first, then by kind.
+
+- Contributor docs live under `docs/contributing/`.
+- Consumer docs live by application under `docs/mcp/`, `docs/cli/`, and `docs/sdk/`.
+- A durable, cross-cutting consumer doc lives at the `docs/` root. A fast-changing one is generated instead (see below).
+
+Then keep a doc to one kind where practical. The Diataxis kinds are tutorial, how-to, reference, and explanation. A file that mixes several is a split candidate.
+
+## Decision records
+
+A decision record is contributor explanation of a distinct kind: one architectural decision, immutable once adopted. The set lives under `docs/contributing/adr/`, one file per decision. To change a decision, add a record that supersedes the old one. Do not edit an adopted record. The rule a record produces graduates to `architecture.md` or `conventions.md`, where a contributor reads the current rule. The record keeps the reasoning.
+
+## Authoring a convention
+
+[`conventions.md`](conventions.md) is a rule reference, and every rule takes the same form:
+
+- A permanent ID, such as `PARSE-3`. A retired rule keeps its ID, so a citation never changes meaning.
+- One rule line, which states the commitment.
+- A `Do` list and a `Do not` list.
+- A `Why` line, capped at three sentences.
+- An optional `Weighed` line, which names the alternative that was rejected.
+
+The `Why` line exists so that a later reader can tell when the reason stopped holding. It is part of the rule entry, so a rule reference stays one kind of document.
+
+A new rule earns its place by correcting something that happened. A rule written against a hypothetical costs every reader and catches nobody.
+
+A code example names no shipped symbol. A symbol in an example rots on the next refactor. A reader who greps a name that no longer exists stops trusting the whole document.
+
+## Where a gap is documented
+
+`conventions.md` states what we commit to, and it names no gap. A convention governs the next change, so older code that predates it is legacy rather than a shortfall.
+
+[`architecture.md`](architecture.md) is a map rather than a rule set, so it works the other way. A map claim is either true of the code or not, and the document owes the reader every place the code is behind it. Those places gather in one final section, `Known gaps`, and each entry names the artifact that closes it. A disabled import-linter contract is one such artifact, because it sits beside the live contracts and one edit enables it. This split follows the arc42 template, which keeps the building block view apart from risks and technical debt.
+
+Neither document carries the inventory or the remediation plan for a gap. A concrete step is closeable work, so it belongs in an issue.
+
+## Generate fast-changing reference from code
+
+A hand-maintained doc that mirrors a code list will drift. Make the code the single source of truth, and generate the doc from it: docstrings, pydantic `Field(description=...)`, the tool registry, or Typer help. Hand-author only where there is no code source, such as a concept doc. Do not keep a generated table and durable prose in the same file.
+
+## Keep it small
+
+Keep recognizable names: `README`, `CHANGELOG`, `CONTRIBUTING`, `SECURITY`, `MIGRATION`, `DEPRECATION`, and `ARCHITECTURE` (as `docs/contributing/architecture.md`). A directory earns its keep by file count and homogeneity, so do not invent a `guides/` or `reference/` bucket for a few files. A concrete cleanup or migration step is a closeable task, so open an issue instead of listing it here.

--- a/docs/contributing/authoring.md
+++ b/docs/contributing/authoring.md
@@ -42,9 +42,11 @@ A code example names no shipped symbol. A symbol in an example rots on the next 
 
 Neither document carries the inventory or the remediation plan for a gap. A concrete step is closeable work, so it belongs in an issue.
 
-## Generate fast-changing reference from code
+## Point at the owner of a fact
 
-A hand-maintained doc that mirrors a code list will drift. Make the code the single source of truth, and generate the doc from it: docstrings, pydantic `Field(description=...)`, the tool registry, or Typer help. Hand-author only where there is no code source, such as a concept doc. Do not keep a generated table and durable prose in the same file.
+Every fact has one owner: the code, a schema, an enforced contract, or another document. A document that restates a fact it does not own holds a copy, and that copy drifts. A reader then cannot tell which copy is current, so name the owner and point there. [`architecture.md`](architecture.md) names the import-linter contract rather than listing the layer modules, and it names the GraphQL schema rather than describing entity shape.
+
+Where the code owns a list, generate the document from that code: docstrings, pydantic `Field(description=...)`, the tool registry, or Typer help. Hand-author only where there is no code source, such as a concept doc. Do not keep a generated table and durable prose in the same file.
 
 ## Keep it small
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -2,6 +2,18 @@
 
 Material in this tree describes **`pipefy-mcp-server`**: the MCP process, tool behavior, and client wiring.
 
+## Tool design
+
+An MCP tool expresses one user outcome, not one API endpoint. It orchestrates the underlying steps in code, so the model does not chain calls in its context. Five rules follow:
+
+- One outcome tool per user goal. Do not fragment a goal into atomic operations the model must sequence.
+- Arguments are flat and explicit: typed primitives, `Literal` for a closed set, one form per field, no guess-the-shape passthroughs.
+- Responses are shaped and bounded, carrying pagination metadata rather than raw wire envelopes.
+- Errors are typed and actionable. They tell the model what to try next.
+- Write gates use protocol-native elicitation. The gate fires when the client declares elicitation support. Otherwise it fails closed, so a headless client never waits on a prompt nobody can answer.
+
+The reasoning is in the decision record [ADR-0003](../contributing/adr/0003-mcp-tools-express-outcomes.md).
+
 ## Contents
 
 | Path | Description |


### PR DESCRIPTION
## Why

A living document holds the rule that a contributor follows today. A record holds the reasoning that produced that rule. A living document changes as the code moves, and an adopted record does not change. The split keeps the durable reasoning out of the file that goes stale.

The docs tree also stated no rule for where a new document goes. A contributor had to infer the rule from the tree, and an inferred rule produces a misplaced document.

## Outcomes

- Four decision records ship. Each one links to the living document that carries its rule, and the index maps every record to that document.
- Every record ships as proposed, because the code does not match the records yet. A proposed record stays editable in place. After adoption, a record becomes immutable, and only a later record can supersede it. A decision that reads wrong is therefore cheap to correct now.
- One record carries no living rule, because its decision stays deferred. That is a property of a deferred decision, and not a gap in the set.
- One guideline states where a new document goes, by audience and by kind. It also states the form of a convention, so the next rule arrives as a rule and not as a paragraph.
- The guideline rules on where a gap is documented. A convention states practice, so older code that predates it is legacy and the convention names no gap. The map states a claim about the code, so the map owes the reader every deviation.
- The map gains a back-link to each record that explains one of its decisions. A reader who asks why a decision holds reaches the reasoning in one step.
- The MCP reference gains the tool-design section that the map points to.
- This PR changes documentation only. No code path and no test path changed.
