### PR TITLE
feat(mcp): require signed preview token before destructive confirm

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_agent_tools.py
@@ -612,17 +612,20 @@ class AiAgentTools:
             meta=REMOTE,
         )
         async def delete_ai_agent(
-            ctx: Context, uuid: str, confirm: bool = False
+            ctx: Context,
+            uuid: str,
+            confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict:
             """Delete an AI Agent permanently. This action is irreversible.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 uuid: Agent UUID.
-                confirm: Must be ``True`` to run the delete mutation.
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
             """
             client = get_pipefy_client(ctx)
             agent_uuid = uuid.strip()
@@ -634,6 +637,9 @@ class AiAgentTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"AI agent (UUID: {agent_uuid})",
+                resource_identity={"uuid": agent_uuid},
+                tool_name="delete_ai_agent",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ai_automation_tools.py
@@ -245,17 +245,19 @@ class AiAutomationTools:
             ctx: Context,
             automation_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict:
             """Delete an AI automation rule permanently.
 
-            Uses the same public GraphQL deletion as ``delete_automation``. Two-step flow:
-            preview with ``confirm=False`` (default), then execute with ``confirm=True`` after
-            explicit approval.
+            Uses the same public GraphQL deletion as ``delete_automation``. Two-step
+            operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 automation_id: Automation rule ID to delete.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id on errors.
 
             Returns:
@@ -275,6 +277,9 @@ class AiAutomationTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"AI automation (ID: {automation_id})",
+                resource_identity={"automation_id": rid},
+                tool_name="delete_ai_automation",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/automation_tools.py
@@ -719,17 +719,18 @@ class AutomationTools:
             ctx: Context,
             automation_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete an automation rule permanently.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 automation_id: Automation rule ID to delete.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -741,6 +742,9 @@ class AutomationTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"automation (ID: {automation_id})",
+                resource_identity={"automation_id": rid},
+                tool_name="delete_automation",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/src/pipefy_mcp/tools/destructive_confirmation_token.py
+++ b/packages/mcp/src/pipefy_mcp/tools/destructive_confirmation_token.py
@@ -6,9 +6,14 @@ import base64
 import hashlib
 import hmac
 import json
-from typing import Any
+import re
+from typing import Any, Literal
 
 DESTRUCTIVE_CONFIRMATION_TTL_SECONDS = 300
+_TOKEN_VERSION = "v1"
+_B64URL_SEGMENT_RE = re.compile(r"[A-Za-z0-9_-]*")
+
+ConfirmationTokenFailure = Literal["missing", "invalid_or_expired", "identity_mismatch"]
 
 
 def mint_confirmation_token(
@@ -31,8 +36,10 @@ def mint_confirmation_token(
         identity=_canonical_identity(resource_identity),
         exp=now + DESTRUCTIVE_CONFIRMATION_TTL_SECONDS,
     )
-    mac = hmac.new(key, payload_bytes, hashlib.sha256).digest()
-    return "v1." + _b64url_nopad(payload_bytes) + "." + _b64url_nopad(mac)
+    mac = hmac.new(key, _mac_message(payload_bytes), hashlib.sha256).digest()
+    return (
+        f"{_TOKEN_VERSION}." + _b64url_nopad(payload_bytes) + "." + _b64url_nopad(mac)
+    )
 
 
 def verify_confirmation_token(
@@ -57,16 +64,8 @@ def verify_confirmation_token(
     try:
         if not isinstance(token, str):
             return False
-        parts = token.split(".")
-        if len(parts) != 3 or parts[0] != "v1":
-            return False
-        payload_bytes = _b64url_decode(parts[1])
-        given_mac = _b64url_decode(parts[2])
-        expected_mac = hmac.new(key, payload_bytes, hashlib.sha256).digest()
-        if not hmac.compare_digest(given_mac, expected_mac):
-            return False
-        payload = json.loads(payload_bytes)
-        if not isinstance(payload, dict):
+        payload = _authenticated_payload(token, key)
+        if payload is None:
             return False
         exp = payload.get("exp")
         if isinstance(exp, bool) or not isinstance(exp, int) or exp <= now:
@@ -76,6 +75,54 @@ def verify_confirmation_token(
         return payload.get("identity") == _canonical_identity(resource_identity)
     except Exception:  # noqa: BLE001
         return False
+
+
+def classify_confirmation_token_failure(
+    token: str | None,
+    *,
+    tool_name: str,
+    resource_identity: dict[str, Any],
+    key: bytes,
+) -> ConfirmationTokenFailure:
+    """Say why verify would fail. Never use this to authorize proceed.
+
+    Decoding and MAC checks here are diagnostic only. Proceed remains behind
+    :func:`verify_confirmation_token`.
+    """
+    if token is None or token == "":
+        return "missing"
+    payload = _authenticated_payload(token, key)
+    if payload is None:
+        return "invalid_or_expired"
+    if payload.get("tool") != tool_name:
+        return "identity_mismatch"
+    if payload.get("identity") != _canonical_identity(resource_identity):
+        return "identity_mismatch"
+    return "invalid_or_expired"
+
+
+def _authenticated_payload(token: str, key: bytes) -> dict[str, Any] | None:
+    try:
+        parts = token.split(".")
+        if len(parts) != 3 or parts[0] != _TOKEN_VERSION:
+            return None
+        payload_bytes = _b64url_decode(parts[1])
+        given_mac = _b64url_decode(parts[2])
+        expected_mac = hmac.new(
+            key, _mac_message(payload_bytes), hashlib.sha256
+        ).digest()
+        if not hmac.compare_digest(given_mac, expected_mac):
+            return None
+        payload = json.loads(payload_bytes)
+        if not isinstance(payload, dict):
+            return None
+        return payload
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _mac_message(payload_bytes: bytes) -> bytes:
+    return f"{_TOKEN_VERSION}.".encode("ascii") + payload_bytes
 
 
 def _canonical_identity(resource_identity: dict[str, Any]) -> dict[str, Any]:
@@ -107,6 +154,7 @@ def _payload_bytes(*, tool_name: str, identity: dict[str, Any], exp: int) -> byt
         {"exp": exp, "identity": identity, "tool": tool_name},
         sort_keys=True,
         separators=(",", ":"),
+        default=str,
     ).encode("utf-8")
 
 
@@ -115,5 +163,13 @@ def _b64url_nopad(data: bytes) -> str:
 
 
 def _b64url_decode(part: str) -> bytes:
+    """Decode one token segment, accepting only the base64url alphabet.
+
+    Rejects whitespace and the standard-alphabet ``+`` and ``/`` so a segment
+    has exactly one textual form. Raises on anything else; callers treat a
+    raised decode as a failed verification.
+    """
+    if not _B64URL_SEGMENT_RE.fullmatch(part):
+        raise ValueError("token segment is not canonical base64url")
     padding = "=" * ((4 - len(part) % 4) % 4)
     return base64.urlsafe_b64decode(part + padding)

--- a/packages/mcp/src/pipefy_mcp/tools/destructive_confirmation_token.py
+++ b/packages/mcp/src/pipefy_mcp/tools/destructive_confirmation_token.py
@@ -133,6 +133,14 @@ def _canonical_identity(resource_identity: dict[str, Any]) -> dict[str, Any]:
 
 
 def _canonical_value(value: Any) -> Any:
+    """Reduce one identity value to a JSON-native, order-stable form.
+
+    Numbers and any other non-JSON type become their string form, so ``1`` and
+    ``"1"`` bind the same token. Canonicalising here rather than at serialisation
+    keeps mint and verify on one definition: a value that reaches the payload as
+    a string must also compare as a string, or the minted token could never
+    verify and the caller would preview forever.
+    """
     if isinstance(value, dict):
         return {key: _canonical_value(value[key]) for key in sorted(value)}
     if isinstance(value, list):
@@ -140,9 +148,9 @@ def _canonical_value(value: Any) -> Any:
         return sorted(items, key=_list_sort_key)
     if isinstance(value, bool) or value is None:
         return value
-    if isinstance(value, int | float):
-        return str(value)
-    return value
+    if isinstance(value, str):
+        return value
+    return str(value)
 
 
 def _list_sort_key(item: Any) -> str:
@@ -154,7 +162,6 @@ def _payload_bytes(*, tool_name: str, identity: dict[str, Any], exp: int) -> byt
         {"exp": exp, "identity": identity, "tool": tool_name},
         sort_keys=True,
         separators=(",", ":"),
-        default=str,
     ).encode("utf-8")
 
 
@@ -165,9 +172,10 @@ def _b64url_nopad(data: bytes) -> str:
 def _b64url_decode(part: str) -> bytes:
     """Decode one token segment, accepting only the base64url alphabet.
 
-    Rejects whitespace and the standard-alphabet ``+`` and ``/`` so a segment
-    has exactly one textual form. Raises on anything else; callers treat a
-    raised decode as a failed verification.
+    Rejects whitespace and the standard-alphabet ``+`` and ``/``. Base64 leaves
+    trailing bits free, so a segment still has more than one accepted spelling;
+    the MAC comparison is what settles authenticity. Raises on anything else,
+    and callers treat a raised decode as a failed verification.
     """
     if not _B64URL_SEGMENT_RE.fullmatch(part):
         raise ValueError("token segment is not canonical base64url")

--- a/packages/mcp/src/pipefy_mcp/tools/destructive_confirmation_token.py
+++ b/packages/mcp/src/pipefy_mcp/tools/destructive_confirmation_token.py
@@ -1,0 +1,119 @@
+"""Pure planner that mints and verifies HMAC confirmation tokens."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from typing import Any
+
+DESTRUCTIVE_CONFIRMATION_TTL_SECONDS = 300
+
+
+def mint_confirmation_token(
+    *,
+    tool_name: str,
+    resource_identity: dict[str, Any],
+    key: bytes,
+    now: int,
+) -> str:
+    """Mint a time-limited HMAC token bound to a tool and resource identity.
+
+    Args:
+        tool_name: Destructive tool this token authorises.
+        resource_identity: Resource ids; canonicalised before signing.
+        key: HMAC-SHA256 secret. Never included in the token.
+        now: Unix timestamp in seconds; expiry is now plus the TTL.
+    """
+    payload_bytes = _payload_bytes(
+        tool_name=tool_name,
+        identity=_canonical_identity(resource_identity),
+        exp=now + DESTRUCTIVE_CONFIRMATION_TTL_SECONDS,
+    )
+    mac = hmac.new(key, payload_bytes, hashlib.sha256).digest()
+    return "v1." + _b64url_nopad(payload_bytes) + "." + _b64url_nopad(mac)
+
+
+def verify_confirmation_token(
+    token: str | None,
+    *,
+    tool_name: str,
+    resource_identity: dict[str, Any],
+    key: bytes,
+    now: int,
+) -> bool:
+    """Return True when the token binds this tool and identity and is unexpired.
+
+    Malformed or mismatched input returns False rather than raising.
+
+    Args:
+        token: Wire token, or None.
+        tool_name: Tool that must match the payload.
+        resource_identity: Resource ids that must match after canonicalisation.
+        key: HMAC-SHA256 secret used to mint the token.
+        now: Unix timestamp in seconds; valid only while exp is strictly later.
+    """
+    try:
+        if not isinstance(token, str):
+            return False
+        parts = token.split(".")
+        if len(parts) != 3 or parts[0] != "v1":
+            return False
+        payload_bytes = _b64url_decode(parts[1])
+        given_mac = _b64url_decode(parts[2])
+        expected_mac = hmac.new(key, payload_bytes, hashlib.sha256).digest()
+        if not hmac.compare_digest(given_mac, expected_mac):
+            return False
+        payload = json.loads(payload_bytes)
+        if not isinstance(payload, dict):
+            return False
+        exp = payload.get("exp")
+        if isinstance(exp, bool) or not isinstance(exp, int) or exp <= now:
+            return False
+        if payload.get("tool") != tool_name:
+            return False
+        return payload.get("identity") == _canonical_identity(resource_identity)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _canonical_identity(resource_identity: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: _canonical_value(resource_identity[key])
+        for key in sorted(resource_identity)
+    }
+
+
+def _canonical_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _canonical_value(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        items = [_canonical_value(item) for item in value]
+        return sorted(items, key=_list_sort_key)
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, int | float):
+        return str(value)
+    return value
+
+
+def _list_sort_key(item: Any) -> str:
+    return json.dumps(item, sort_keys=True, separators=(",", ":"))
+
+
+def _payload_bytes(*, tool_name: str, identity: dict[str, Any], exp: int) -> bytes:
+    return json.dumps(
+        {"exp": exp, "identity": identity, "tool": tool_name},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _b64url_nopad(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(part: str) -> bytes:
+    padding = "=" * ((4 - len(part) % 4) % 4)
+    return base64.urlsafe_b64decode(part + padding)

--- a/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -30,6 +30,13 @@ from pipefy_mcp.tools.destructive_confirmation_token import (
 
 _PROCESS_SIGNING_KEY = secrets.token_bytes(32)
 
+_TokenStatus = Literal["missing", "invalid_or_expired"]
+
+_TOKEN_STATUS_SENTENCE: dict[_TokenStatus, str] = {
+    "missing": "The confirmation token is missing. ",
+    "invalid_or_expired": "The previous confirmation token was invalid or expired. ",
+}
+
 
 class DestructivePreviewPayload(TypedDict):
     """Returned when the tool needs confirmation before deletion."""
@@ -85,9 +92,9 @@ async def check_destructive_confirmation(
             base preview is still returned.
 
     Returns:
-        ``None`` when ``confirm=True`` and the token verifies — the caller
+        ``None`` when ``confirm=True`` and the token verifies: the caller
         should proceed with the deletion.
-        A preview payload otherwise — the caller must return it as-is.
+        A preview payload otherwise: the caller must return it as-is.
     """
     identity = dict(resource_identity)
     key = signing_key_for(ctx)
@@ -101,13 +108,20 @@ async def check_destructive_confirmation(
     ):
         return None
 
+    token_status: _TokenStatus | None = None
+    if confirm:
+        token_status = "missing" if confirmation_token is None else "invalid_or_expired"
     minted = mint_confirmation_token(
         tool_name=tool_name,
         resource_identity=identity,
         key=key,
         now=now,
     )
-    preview = _build_preview_payload(resource_descriptor, confirmation_token=minted)
+    preview = _build_preview_payload(
+        resource_descriptor,
+        confirmation_token=minted,
+        token_status=token_status,
+    )
     if dependents_resolver is not None:
         try:
             deps = await dependents_resolver()
@@ -122,7 +136,11 @@ def _build_preview_payload(
     resource_descriptor: str,
     *,
     confirmation_token: str,
+    token_status: _TokenStatus | None = None,
 ) -> DestructivePreviewPayload:
+    status_sentence = (
+        _TOKEN_STATUS_SENTENCE[token_status] if token_status is not None else ""
+    )
     return {
         "success": False,
         "requires_confirmation": True,
@@ -130,6 +148,7 @@ def _build_preview_payload(
         "confirmation_token": confirmation_token,
         "message": (
             f"⚠️ Deleting {resource_descriptor} is permanent and cannot be undone. "
+            f"{status_sentence}"
             "Show this preview to the user and get their explicit approval before continuing. "
             "Once they approve, call again with confirm=True "
             f'and confirmation_token="{confirmation_token}".'

--- a/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -32,11 +32,6 @@ _PROCESS_SIGNING_KEY = secrets.token_bytes(32)
 
 _TokenStatus = Literal["missing", "invalid_or_expired"]
 
-_TOKEN_STATUS_SENTENCE: dict[_TokenStatus, str] = {
-    "missing": "The confirmation token is missing. ",
-    "invalid_or_expired": "The previous confirmation token was invalid or expired. ",
-}
-
 
 class DestructivePreviewPayload(TypedDict):
     """Returned when the tool needs confirmation before deletion."""
@@ -92,9 +87,9 @@ async def check_destructive_confirmation(
             base preview is still returned.
 
     Returns:
-        ``None`` when ``confirm=True`` and the token verifies: the caller
+        ``None`` when ``confirm=True`` and the token verifies. The caller
         should proceed with the deletion.
-        A preview payload otherwise: the caller must return it as-is.
+        A preview payload otherwise. The caller must return it as-is.
     """
     identity = dict(resource_identity)
     key = signing_key_for(ctx)
@@ -138,21 +133,26 @@ def _build_preview_payload(
     confirmation_token: str,
     token_status: _TokenStatus | None = None,
 ) -> DestructivePreviewPayload:
-    status_sentence = (
-        _TOKEN_STATUS_SENTENCE[token_status] if token_status is not None else ""
+    sentences = [
+        f"⚠️ Deleting {resource_descriptor} is permanent and cannot be undone.",
+    ]
+    if token_status == "missing":
+        sentences.append("The confirmation token is missing.")
+    elif token_status == "invalid_or_expired":
+        sentences.append("The previous confirmation token was invalid or expired.")
+    sentences.append(
+        "Show this preview to the user and get their explicit approval before continuing."
+    )
+    sentences.append(
+        "Once they approve, call again with confirm=True "
+        f'and confirmation_token="{confirmation_token}".'
     )
     return {
         "success": False,
         "requires_confirmation": True,
         "resource": resource_descriptor,
         "confirmation_token": confirmation_token,
-        "message": (
-            f"⚠️ Deleting {resource_descriptor} is permanent and cannot be undone. "
-            f"{status_sentence}"
-            "Show this preview to the user and get their explicit approval before continuing. "
-            "Once they approve, call again with confirm=True "
-            f'and confirmation_token="{confirmation_token}".'
-        ),
+        "message": " ".join(sentences),
     }
 
 

--- a/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -3,20 +3,32 @@
 Every tool with ``destructiveHint=True`` should call
 :func:`check_destructive_confirmation` **before** executing the deletion.
 
-* ``confirm=False`` → returns a preview payload; **never** deletes. Some MCP clients
-  auto-accept elicitation prompts when tools are invoked programmatically; this
-  guard therefore does **not** use elicitation to authorize deletion—only an
-  explicit follow-up call with ``confirm=True`` does.
-* ``confirm=True`` → returns ``None`` so the caller proceeds with the deletion.
+MCP elicitation is unused: some clients auto-accept elicitation prompts when
+tools are invoked programmatically.
+
+Proceed requires ``confirm=True`` and a verified confirmation token. The token
+orders the two-step protocol (preview, then confirm); it is not an authorization
+control. API permission remains the boundary that allows or denies the deletion.
 """
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+import hashlib
+import secrets
+import time
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, Literal
 
 from mcp.server.mcpserver import Context
 from typing_extensions import NotRequired, TypedDict
+
+from pipefy_mcp.auth.request_identity import require_request_bearer
+from pipefy_mcp.tools.destructive_confirmation_token import (
+    mint_confirmation_token,
+    verify_confirmation_token,
+)
+
+_PROCESS_SIGNING_KEY = secrets.token_bytes(32)
 
 
 class DestructivePreviewPayload(TypedDict):
@@ -26,49 +38,76 @@ class DestructivePreviewPayload(TypedDict):
     requires_confirmation: Literal[True]
     resource: str
     message: str
+    confirmation_token: str
     dependents: NotRequired[dict[str, Any]]
 
 
 DependentsResolver = Callable[[], Awaitable[dict[str, Any] | None]]
 
 
-class DestructiveCancelledPayload(TypedDict):
-    success: Literal[False]
-    error: str
+def signing_key_for(ctx: Context) -> bytes:
+    """HMAC key for this request: SHA-256 of the bearer, else a process key."""
+    try:
+        bearer = require_request_bearer(ctx.request_context.request)
+    except Exception:  # noqa: BLE001
+        return _PROCESS_SIGNING_KEY
+    return hashlib.sha256(bearer.encode("utf-8")).digest()
 
 
 async def check_destructive_confirmation(
-    _ctx: Context,
+    ctx: Context,
     *,
     confirm: bool,
     resource_descriptor: str,
+    resource_identity: Mapping[str, Any],
+    tool_name: str,
+    confirmation_token: str | None = None,
     dependents_resolver: DependentsResolver | None = None,
 ) -> DestructivePreviewPayload | None:
-    """Gate a destructive operation behind explicit ``confirm=True``.
+    """Gate a destructive operation behind ``confirm=True`` and a verified token.
 
     Call this **after** fetching resource info but **before** executing the
     deletion.
 
     Args:
-        _ctx: MCP request context (reserved for future use / logging).
-        confirm: Must be ``True`` to allow the deletion to run.
+        ctx: MCP request context; used to derive the HMAC signing key.
+        confirm: Must be ``True`` together with a verified token to proceed.
         resource_descriptor: Human-readable description of the resource about
             to be deleted (e.g. ``"phase 'Initial' (ID: 42)"``). Used in
-            preview payloads.
+            preview payloads; never signed.
+        resource_identity: Resource ids bound into the confirmation token.
+        tool_name: Destructive tool name bound into the confirmation token.
+        confirmation_token: Token from a prior preview, or ``None``.
         dependents_resolver: Optional async callable (no arguments) that returns
             a dict to attach under ``dependents`` on the preview, or ``None`` /
-            empty dict to skip enrichment. Never invoked when ``confirm=True``.
-            Exceptions are swallowed so the base preview is still returned.
+            empty dict to skip enrichment. Invoked on every preview path;
+            never invoked when proceeding. Exceptions are swallowed so the
+            base preview is still returned.
 
     Returns:
-        ``None`` when the caller should proceed with the deletion.
-        A preview payload when ``confirm`` is false — the caller must return
-        it as-is.
+        ``None`` when ``confirm=True`` and the token verifies — the caller
+        should proceed with the deletion.
+        A preview payload otherwise — the caller must return it as-is.
     """
-    if confirm:
+    identity = dict(resource_identity)
+    key = signing_key_for(ctx)
+    now = int(time.time())
+    if confirm and verify_confirmation_token(
+        confirmation_token,
+        tool_name=tool_name,
+        resource_identity=identity,
+        key=key,
+        now=now,
+    ):
         return None
 
-    preview = _build_preview_payload(resource_descriptor)
+    minted = mint_confirmation_token(
+        tool_name=tool_name,
+        resource_identity=identity,
+        key=key,
+        now=now,
+    )
+    preview = _build_preview_payload(resource_descriptor, confirmation_token=minted)
     if dependents_resolver is not None:
         try:
             deps = await dependents_resolver()
@@ -79,21 +118,28 @@ async def check_destructive_confirmation(
     return preview
 
 
-def _build_preview_payload(resource_descriptor: str) -> DestructivePreviewPayload:
+def _build_preview_payload(
+    resource_descriptor: str,
+    *,
+    confirmation_token: str,
+) -> DestructivePreviewPayload:
     return {
         "success": False,
         "requires_confirmation": True,
         "resource": resource_descriptor,
+        "confirmation_token": confirmation_token,
         "message": (
-            f"⚠️ You are about to permanently delete {resource_descriptor}. "
-            "This action is irreversible. Set 'confirm=True' to proceed."
+            f"⚠️ Deleting {resource_descriptor} is permanent and cannot be undone. "
+            "Show this preview to the user and get their explicit approval before continuing. "
+            "Once they approve, call again with confirm=True "
+            f'and confirmation_token="{confirmation_token}".'
         ),
     }
 
 
 __all__ = [
     "DependentsResolver",
-    "DestructiveCancelledPayload",
     "DestructivePreviewPayload",
     "check_destructive_confirmation",
+    "signing_key_for",
 ]

--- a/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -24,13 +24,13 @@ from typing_extensions import NotRequired, TypedDict
 
 from pipefy_mcp.auth.request_identity import require_request_bearer
 from pipefy_mcp.tools.destructive_confirmation_token import (
+    ConfirmationTokenFailure,
+    classify_confirmation_token_failure,
     mint_confirmation_token,
     verify_confirmation_token,
 )
 
 _PROCESS_SIGNING_KEY = secrets.token_bytes(32)
-
-_TokenStatus = Literal["missing", "invalid_or_expired"]
 
 
 class DestructivePreviewPayload(TypedDict):
@@ -103,9 +103,14 @@ async def check_destructive_confirmation(
     ):
         return None
 
-    token_status: _TokenStatus | None = None
+    token_status: ConfirmationTokenFailure | None = None
     if confirm:
-        token_status = "missing" if confirmation_token is None else "invalid_or_expired"
+        token_status = classify_confirmation_token_failure(
+            confirmation_token,
+            tool_name=tool_name,
+            resource_identity=identity,
+            key=key,
+        )
     minted = mint_confirmation_token(
         tool_name=tool_name,
         resource_identity=identity,
@@ -131,7 +136,7 @@ def _build_preview_payload(
     resource_descriptor: str,
     *,
     confirmation_token: str,
-    token_status: _TokenStatus | None = None,
+    token_status: ConfirmationTokenFailure | None = None,
 ) -> DestructivePreviewPayload:
     sentences = [
         f"⚠️ Deleting {resource_descriptor} is permanent and cannot be undone.",
@@ -140,6 +145,10 @@ def _build_preview_payload(
         sentences.append("The confirmation token is missing.")
     elif token_status == "invalid_or_expired":
         sentences.append("The previous confirmation token was invalid or expired.")
+    elif token_status == "identity_mismatch":
+        sentences.append(
+            "The previous confirmation token does not match this tool and resource identity."
+        )
     sentences.append(
         "Show this preview to the user and get their explicit approval before continuing."
     )
@@ -160,5 +169,4 @@ __all__ = [
     "DependentsResolver",
     "DestructivePreviewPayload",
     "check_destructive_confirmation",
-    "signing_key_for",
 ]

--- a/packages/mcp/src/pipefy_mcp/tools/field_condition_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/field_condition_tools.py
@@ -643,18 +643,19 @@ class FieldConditionTools:
             ctx: Context,
             condition_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a field condition permanently.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 ctx: MCP context for debug logging.
                 condition_id: Field condition ID to delete.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -669,6 +670,9 @@ class FieldConditionTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"field condition (ID: {condition_id})",
+                resource_identity={"condition_id": cid_str},
+                tool_name="delete_field_condition",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/src/pipefy_mcp/tools/knowledge_base_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/knowledge_base_tools.py
@@ -300,18 +300,20 @@ class KnowledgeBaseTools:
             plain_text_id: str,
             pipe_uuid: str,
             confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict[str, Any]:
             """Delete a pipe-scoped knowledge base plain text permanently. This action is irreversible.
 
-            Two-step operation: preview with `confirm=False` (default), then execute
-            with `confirm=True` after explicit human approval. Elicitation does not
-            authorize deletion (only `confirm=True` does). Requires manage_ai_agents
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2. Elicitation does not
+            authorize deletion (only ``confirm=True`` does). Requires manage_ai_agents
             on the pipe.
 
             Args:
                 plain_text_id: Plain text ID to delete (from `get_ai_knowledge_bases`).
                 pipe_uuid: Pipe UUID (not the numeric ID).
-                confirm: Must be `True` to run the delete mutation.
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
             """
             client = get_pipefy_client(ctx)
             err = _blank_error(plain_text_id, "plain_text_id") or _blank_error(
@@ -326,6 +328,12 @@ class KnowledgeBaseTools:
                 resource_descriptor=(
                     f"knowledge base plain text (ID: {plain_text_id.strip()})"
                 ),
+                resource_identity={
+                    "plain_text_id": plain_text_id.strip(),
+                    "pipe_uuid": pipe_uuid.strip(),
+                },
+                tool_name="delete_ai_knowledge_base_plain_text",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -490,18 +498,20 @@ class KnowledgeBaseTools:
             document_id: str,
             pipe_uuid: str,
             confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict[str, Any]:
             """Delete a pipe-scoped knowledge base document permanently. This action is irreversible.
 
-            Two-step operation: preview with `confirm=False` (default), then
-            execute with `confirm=True` after explicit human approval.
-            Elicitation does not authorize deletion (only `confirm=True` does).
-            Requires manage_ai_agents on the pipe.
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2. Elicitation does not
+            authorize deletion (only ``confirm=True`` does). Requires manage_ai_agents
+            on the pipe.
 
             Args:
                 document_id: Document ID to delete (from `get_ai_knowledge_bases`).
                 pipe_uuid: Pipe UUID (not the numeric ID).
-                confirm: Must be `True` to run the delete mutation.
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
             """
             client = get_pipefy_client(ctx)
             err = _blank_error(document_id, "document_id") or _blank_error(
@@ -516,6 +526,12 @@ class KnowledgeBaseTools:
                 resource_descriptor=(
                     f"knowledge base document (ID: {document_id.strip()})"
                 ),
+                resource_identity={
+                    "document_id": document_id.strip(),
+                    "pipe_uuid": pipe_uuid.strip(),
+                },
+                tool_name="delete_ai_knowledge_base_document",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -709,18 +725,20 @@ class KnowledgeBaseTools:
             data_lookup_id: str,
             pipe_uuid: str,
             confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict[str, Any]:
             """Delete a pipe-scoped knowledge base data lookup permanently. This action is irreversible.
 
-            Two-step operation: preview with `confirm=False` (default), then
-            execute with `confirm=True` after explicit human approval.
-            Elicitation does not authorize deletion (only `confirm=True` does).
-            Requires manage_ai_agents on the pipe.
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2. Elicitation does not
+            authorize deletion (only ``confirm=True`` does). Requires manage_ai_agents
+            on the pipe.
 
             Args:
                 data_lookup_id: Data lookup ID to delete (from `get_ai_knowledge_bases`).
                 pipe_uuid: Pipe UUID (not the numeric ID).
-                confirm: Must be `True` to run the delete mutation.
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
             """
             client = get_pipefy_client(ctx)
             err = _blank_error(data_lookup_id, "data_lookup_id") or _blank_error(
@@ -735,6 +753,12 @@ class KnowledgeBaseTools:
                 resource_descriptor=(
                     f"knowledge base data lookup (ID: {data_lookup_id.strip()})"
                 ),
+                resource_identity={
+                    "data_lookup_id": data_lookup_id.strip(),
+                    "pipe_uuid": pipe_uuid.strip(),
+                },
+                tool_name="delete_ai_knowledge_base_data_lookup",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/src/pipefy_mcp/tools/knowledge_base_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/knowledge_base_tools.py
@@ -305,8 +305,7 @@ class KnowledgeBaseTools:
             """Delete a pipe-scoped knowledge base plain text permanently. This action is irreversible.
 
             Two-step operation: preview with ``confirm=False`` (default), then echo
-            ``confirmation_token`` from the preview on step 2. Elicitation does not
-            authorize deletion (only ``confirm=True`` does). Requires manage_ai_agents
+            ``confirmation_token`` from the preview on step 2. Requires manage_ai_agents
             on the pipe.
 
             Args:
@@ -503,8 +502,7 @@ class KnowledgeBaseTools:
             """Delete a pipe-scoped knowledge base document permanently. This action is irreversible.
 
             Two-step operation: preview with ``confirm=False`` (default), then echo
-            ``confirmation_token`` from the preview on step 2. Elicitation does not
-            authorize deletion (only ``confirm=True`` does). Requires manage_ai_agents
+            ``confirmation_token`` from the preview on step 2. Requires manage_ai_agents
             on the pipe.
 
             Args:
@@ -730,8 +728,7 @@ class KnowledgeBaseTools:
             """Delete a pipe-scoped knowledge base data lookup permanently. This action is irreversible.
 
             Two-step operation: preview with ``confirm=False`` (default), then echo
-            ``confirmation_token`` from the preview on step 2. Elicitation does not
-            authorize deletion (only ``confirm=True`` does). Requires manage_ai_agents
+            ``confirmation_token`` from the preview on step 2. Requires manage_ai_agents
             on the pipe.
 
             Args:

--- a/packages/mcp/src/pipefy_mcp/tools/llm_provider_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/llm_provider_tools.py
@@ -430,19 +430,20 @@ class LlmProviderTools:
             provider_id: str,
             organization_uuid: str,
             confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict[str, Any]:
             """Delete a custom (BYOM) LLM provider permanently. This action is irreversible. Requires manage_ai_providers and an eligible plan.
 
-            Two-step operation: preview with `confirm=False` (default), then execute
-            with `confirm=True` after explicit human approval. Elicitation does not
-            authorize deletion (only `confirm=True` does). Check
+            Two-step operation: preview with `confirm=False` (default), then echo
+            `confirmation_token` from the preview on step 2. Check
             `get_llm_provider_dependencies` first — owners that still reference the
             provider are blockers.
 
             Args:
                 provider_id: Provider ID to delete (from `get_llm_providers`).
                 organization_uuid: Organization UUID (not the numeric ID).
-                confirm: Must be `True` to run the delete mutation.
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
             """
             client = get_pipefy_client(ctx)
             provider_id, id_err = validate_tool_id(provider_id, "provider_id")
@@ -451,18 +452,25 @@ class LlmProviderTools:
             err = _blank_error(organization_uuid, "organization_uuid")
             if err is not None:
                 return err
+            organization_uuid = organization_uuid.strip()
 
             guard = await check_destructive_confirmation(
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"LLM provider (ID: {provider_id})",
+                resource_identity={
+                    "provider_id": provider_id,
+                    "organization_uuid": organization_uuid,
+                },
+                tool_name="delete_llm_provider",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
 
             try:
                 result = await client.delete_llm_provider(
-                    provider_id, organization_uuid.strip()
+                    provider_id, organization_uuid
                 )
             except Exception as exc:  # noqa: BLE001
                 return _provider_tool_error_from_exception(exc)

--- a/packages/mcp/src/pipefy_mcp/tools/member_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/member_tools.py
@@ -182,19 +182,21 @@ class MemberTools:
             pipe_id: PipefyId,
             user_ids: list[PipefyId],
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Permanently remove one or more users from a pipe.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2. Elicitation does not authorize
             deletion (only ``confirm=True`` does).
 
             Args:
                 pipe_id: ID of the pipe.
                 user_ids: User ids to remove. Prefer numeric ``user.id`` from
                     ``get_pipe_members``; a user UUID is also accepted.
-                confirm: Set to True to execute the removal (step 2).
+                confirm: Set to True with the preview token to execute the removal (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -214,6 +216,9 @@ class MemberTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"{len(user_ids)} member(s) from pipe {pipe_id}",
+                resource_identity={"pipe_id": pipe_id, "user_ids": user_ids},
+                tool_name="remove_member_from_pipe",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/src/pipefy_mcp/tools/member_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/member_tools.py
@@ -188,8 +188,7 @@ class MemberTools:
             """Permanently remove one or more users from a pipe.
 
             Two-step operation: preview with ``confirm=False`` (default), then echo
-            ``confirmation_token`` from the preview on step 2. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 pipe_id: ID of the pipe.

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tool_helpers.py
@@ -10,15 +10,7 @@ from pipefy_mcp.core.tool_error_envelope import ToolErrorDetail, tool_error
 from pipefy_mcp.tools.graphql_error_helpers import (
     handle_tool_graphql_error,
 )
-from pipefy_mcp.tools.validation_helpers import UUID_RE, format_json_preview
-
-
-class DeletePipePreviewPayload(TypedDict):
-    success: Literal[False]
-    requires_confirmation: Literal[True]
-    pipe_id: str | int
-    message: str
-    pipe_summary: str
+from pipefy_mcp.tools.validation_helpers import UUID_RE
 
 
 class DeletePipeSuccessPayload(TypedDict):
@@ -32,9 +24,7 @@ class DeletePipeErrorPayload(TypedDict):
     error: ToolErrorDetail
 
 
-DeletePipePayload = (
-    DeletePipePreviewPayload | DeletePipeSuccessPayload | DeletePipeErrorPayload
-)
+DeletePipePayload = DeletePipeSuccessPayload | DeletePipeErrorPayload
 
 
 class PipeMutationSuccessPayload(TypedDict):
@@ -170,38 +160,6 @@ def build_field_condition_delete_payload(
     return {
         "success": False,
         "message": "Field condition could not be deleted.",
-    }
-
-
-def build_delete_pipe_preview_payload(
-    *,
-    pipe_id: str | int,
-    pipe_name: str,
-    pipe_data: dict[str, Any],
-) -> DeletePipePreviewPayload:
-    """Two-step delete: preview before ``confirm=True``.
-
-    Args:
-        pipe_id: Target pipe id.
-        pipe_name: Display name for messaging.
-        pipe_data: Subset serialized into ``pipe_summary``.
-    """
-    return {
-        "success": False,
-        "requires_confirmation": True,
-        "pipe_id": pipe_id,
-        "pipe_summary": format_json_preview(
-            {
-                "id": pipe_data.get("id"),
-                "name": pipe_name,
-                "phases": pipe_data.get("phases"),
-            }
-        ),
-        "message": (
-            "Warning: You are about to permanently delete pipe "
-            f"'{pipe_name}' (ID: {pipe_id}). "
-            "This cannot be undone. Confirm with the user, then call again with confirm=True."
-        ),
     }
 
 
@@ -621,7 +579,6 @@ def normalize_phase_cards_list(raw: dict[str, Any]) -> dict[str, Any] | None:
 __all__ = [
     "DeletePipeErrorPayload",
     "DeletePipePayload",
-    "DeletePipePreviewPayload",
     "DeletePipeSuccessPayload",
     "FieldConditionDeleteFailurePayload",
     "FieldConditionDeletePayload",
@@ -629,7 +586,6 @@ __all__ = [
     "FieldConditionMutationSuccessPayload",
     "PipeMutationSuccessPayload",
     "build_delete_pipe_error_payload",
-    "build_delete_pipe_preview_payload",
     "build_delete_pipe_success_payload",
     "build_field_condition_delete_payload",
     "build_field_condition_success_payload",

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_config_tools.py
@@ -240,16 +240,18 @@ class PipeConfigTools:
             ctx: Context,
             pipe_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a pipe permanently.
 
             Without confirmation, returns a preview of the pipe and does not delete.
-            Always confirm the impact with the human user before calling with confirm=True.
+            Echo ``confirmation_token`` from the preview on step 2.
 
             Args:
                 pipe_id: Pipe ID to delete.
-                confirm: When True, performs the deletion after explicit user confirmation.
+                confirm: When True with the preview token, performs the deletion.
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -283,6 +285,9 @@ class PipeConfigTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"pipe '{pipe_name}' (ID: {pipe_id_str})",
+                resource_identity={"pipe_id": pipe_id_str},
+                tool_name="delete_pipe",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -726,20 +731,21 @@ class PipeConfigTools:
             phase_id: PipefyId,
             pipe_id: PipefyId | None = None,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a phase permanently.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 phase_id: Phase ID to delete.
                 pipe_id: Pipe the phase belongs to; when set, the preview may list conditions,
                     automations targeting this phase, a card count, and phase field count
                     (``confirm=False`` only; extra API calls).
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -764,6 +770,9 @@ class PipeConfigTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"phase (ID: {phase_id})",
+                resource_identity={"phase_id": phase_id},
+                tool_name="delete_phase",
+                confirmation_token=confirmation_token,
                 dependents_resolver=_resolve_phase_deps,
             )
             if guard is not None:
@@ -992,6 +1001,7 @@ class PipeConfigTools:
             ctx: Context,
             field_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             pipe_uuid: str | None = None,
             pipe_id: PipefyId | None = None,
             phase_id: PipefyId | None = None,
@@ -999,9 +1009,8 @@ class PipeConfigTools:
         ) -> dict[str, Any]:
             """Delete a phase field permanently.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             ``field_id`` is the field slug (e.g. ``"prioridade"``) or uuid.
             When the slug is shared across phases, pass ``pipe_uuid`` to
@@ -1022,7 +1031,8 @@ class PipeConfigTools:
             Args:
                 field_id: Field slug or uuid (from create_phase_field or get_phase_fields).
                     Discover via: ``get_phase_fields(phase_id)[].id`` or ``.uuid``.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 pipe_uuid: Pipe UUID for disambiguation when the slug is not unique across phases.
                 pipe_id: Numeric pipe ID; enables cascade-aware error diagnosis when set.
                     Discover via: ``search_pipes`` or ``get_organization``.
@@ -1077,6 +1087,9 @@ class PipeConfigTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"phase field (ID: {field_id})",
+                resource_identity={"field_id": field_id, "pipe_uuid": pipe_uuid},
+                tool_name="delete_phase_field",
+                confirmation_token=confirmation_token,
                 dependents_resolver=_resolve_deps,
             )
             if guard is not None:
@@ -1244,19 +1257,20 @@ class PipeConfigTools:
             label_id: PipefyId,
             pipe_id: PipefyId | None = None,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a label permanently.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 label_id: Label ID to delete.
                 pipe_id: Pipe that owns the label; when set, the preview may include a sample
                     of cards using this label (``confirm=False`` only).
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -1296,6 +1310,9 @@ class PipeConfigTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"label (ID: {label_id})",
+                resource_identity={"label_id": label_id},
+                tool_name="delete_label",
+                confirmation_token=confirmation_token,
                 dependents_resolver=_resolve_deps,
             )
             if guard is not None:

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tool_helpers.py
@@ -21,10 +21,7 @@ from pipefy_mcp.core.tool_error_envelope import (
     tool_error,
     tool_success,
 )
-from pipefy_mcp.tools.destructive_tool_guard import (
-    DestructiveCancelledPayload,
-    DestructivePreviewPayload,
-)
+from pipefy_mcp.tools.destructive_tool_guard import DestructivePreviewPayload
 from pipefy_mcp.tools.graphql_error_helpers import extract_error_strings
 
 
@@ -130,7 +127,6 @@ class DeleteCardErrorPayload(TypedDict):
 
 DeleteCardPayload = (
     DestructivePreviewPayload
-    | DestructiveCancelledPayload
     | LegacyDeleteCardSuccessPayload
     | ToolSuccessPayload
     | DeleteCardErrorPayload

--- a/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/pipe_tools.py
@@ -512,18 +512,17 @@ class PipeTools:
             ctx: Context,
             comment_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> DeleteCommentPayload:
             """Delete a comment from Pipefy.
 
-            Two-step operation:
-
-            1. **Preview** — call with ``confirm=False`` (default). Returns a preview payload;
-               nothing is deleted. Elicitation is **not** used to authorize deletion.
-            2. **Execute** — call again with ``confirm=True`` after explicit human approval.
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 comment_id: The ID of the comment to delete.
-                confirm: Must be ``True`` to run the delete mutation.
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
             """
             client = get_pipefy_client(ctx)
             try:
@@ -538,6 +537,9 @@ class PipeTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"comment (ID: {delete_input.comment_id})",
+                resource_identity={"comment_id": delete_input.comment_id},
+                tool_name="delete_comment",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -564,13 +566,13 @@ class PipeTools:
             parent_id: PipefyId,
             source_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict:
             """Remove a link between two related cards.
 
             ``source_id`` is the **pipe relation** id from ``get_pipe_relations`` (same as
-            ``create_card_relation``). Two-step flow: preview with ``confirm=False`` (default),
-            then execute with ``confirm=True`` after explicit approval.
+            ``create_card_relation``). Echo ``confirmation_token`` from the preview on step 2.
 
             The ``deleteCardRelation`` mutation is only available on the Internal API,
             not the public GraphQL schema; it runs with the session's credential like
@@ -580,7 +582,8 @@ class PipeTools:
                 child_id: Child card ID in the relation.
                 parent_id: Parent card ID in the relation.
                 source_id: Pipe relation ID defining the pipe-to-pipe link.
-                confirm: Must be ``True`` to run the delete mutation.
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
 
             Returns:
@@ -608,6 +611,13 @@ class PipeTools:
                 resource_descriptor=(
                     f"card relation (child: {cid}, parent: {pid}, source: {sid})"
                 ),
+                resource_identity={
+                    "child_id": cid,
+                    "parent_id": pid,
+                    "source_id": sid,
+                },
+                tool_name="delete_card_relation",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -1335,20 +1345,19 @@ class PipeTools:
             ctx: Context,
             card_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> DeleteCardPayload:
             """Delete a card from Pipefy.
 
-            Two-step operation:
-
-            1. **Preview** — call with ``confirm=False`` (default). Returns a preview payload;
-               nothing is deleted. Elicitation is **not** used to authorize deletion (automated
-               clients may auto-accept prompts).
-            2. **Execute** — call again with ``confirm=True`` after explicit human approval.
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2. Elicitation is **not**
+            used to authorize deletion (automated clients may auto-accept prompts).
 
             Args:
                 card_id: The ID of the card to delete.
-                confirm: Must be ``True`` to run the delete mutation.
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When true, appends GraphQL error codes and correlation_id to the error message.
 
             Returns:
@@ -1385,6 +1394,9 @@ class PipeTools:
                 resource_descriptor=(
                     f"card '{card_title}' (ID: {card_id_str}) from pipe '{pipe_name}'"
                 ),
+                resource_identity={"card_id": card_id_str},
+                tool_name="delete_card",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/src/pipefy_mcp/tools/portal_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/portal_tools.py
@@ -235,8 +235,7 @@ class PortalTools:
             """Delete a portal interface (irreversible).
 
             Two-step operation: preview with ``confirm=False`` (default), then echo
-            ``confirmation_token`` from the preview on step 2. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 portal_uuid: Portal interface UUID to delete.

--- a/packages/mcp/src/pipefy_mcp/tools/portal_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/portal_tools.py
@@ -230,16 +230,18 @@ class PortalTools:
             ctx: Context,
             portal_uuid: str,
             confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict[str, Any]:
             """Delete a portal interface (irreversible).
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2. Elicitation does not authorize
             deletion (only ``confirm=True`` does).
 
             Args:
                 portal_uuid: Portal interface UUID to delete.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
             """
             client = get_pipefy_client(ctx)
             portal_uuid, err = validate_tool_id(portal_uuid, "portal_uuid")
@@ -250,6 +252,9 @@ class PortalTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"portal (UUID: {portal_uuid})",
+                resource_identity={"portal_uuid": portal_uuid},
+                tool_name="delete_portal",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -400,16 +405,18 @@ class PortalTools:
             portal_uuid: str,
             page_id: str,
             confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict[str, Any]:
             """Delete a portal page (irreversible).
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval.
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 portal_uuid: Parent portal interface UUID.
                 page_id: Page UUID to delete.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
             """
             client = get_pipefy_client(ctx)
             portal_uuid, err = validate_tool_id(portal_uuid, "portal_uuid")
@@ -427,6 +434,9 @@ class PortalTools:
                 resource_descriptor=(
                     f"portal page (UUID: {page_id}) in portal (UUID: {portal_uuid})"
                 ),
+                resource_identity={"page_id": page_id, "portal_uuid": portal_uuid},
+                tool_name="delete_portal_page",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -682,16 +692,18 @@ class PortalTools:
             element_id: str,
             page_id: str,
             confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict[str, Any]:
             """Delete a portal page element (irreversible).
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute
-            with ``confirm=True`` after explicit human approval.
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 element_id: Element UUID to delete.
                 page_id: Parent page UUID.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
             """
             client = get_pipefy_client(ctx)
             element_id, err = validate_tool_id(element_id, "element_id")
@@ -709,6 +721,9 @@ class PortalTools:
                 resource_descriptor=(
                     f"portal element (UUID: {element_id}) on page (UUID: {page_id})"
                 ),
+                resource_identity={"element_id": element_id, "page_id": page_id},
+                tool_name="delete_portal_element",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -955,17 +970,19 @@ class PortalTools:
             portal_uuid: str,
             element_id: str,
             confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict[str, Any]:
             """Detach sub-portal wiring from a main portal page element.
 
-            Two-step operation: preview with ``confirm=False`` (default), then
-            execute with ``confirm=True`` after explicit human approval. Uses
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2. Uses
             ``deleteSubPortalElement`` (internal API).
 
             Args:
                 portal_uuid: Main portal interface UUID.
                 element_id: Page element UUID to detach.
-                confirm: Set to True to execute the detach (step 2).
+                confirm: Set to True with the preview token to execute the detach (step 2).
+                confirmation_token: Token from the preview response.
             """
             client = get_pipefy_client(ctx)
             ids, err = validate_tool_ids(
@@ -984,6 +1001,12 @@ class PortalTools:
                     f"sub-portal element link (element UUID: {ids['element_id']}) "
                     f"in portal (UUID: {ids['portal_uuid']})"
                 ),
+                resource_identity={
+                    "element_id": ids["element_id"],
+                    "portal_uuid": ids["portal_uuid"],
+                },
+                tool_name="delete_sub_portal_element",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -1016,16 +1039,18 @@ class PortalTools:
             ctx: Context,
             sub_portal_uuid: str,
             confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict[str, Any]:
             """Delete a sub-portal entity (irreversible).
 
-            Two-step operation: preview with ``confirm=False`` (default), then
-            execute with ``confirm=True`` after explicit human approval.
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
             Removes the sub-portal interface via ``deleteSubPortalInterface``.
 
             Args:
                 sub_portal_uuid: Sub-portal UUID to delete permanently.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
             """
             client = get_pipefy_client(ctx)
             ids, err = validate_tool_ids({"sub_portal_uuid": sub_portal_uuid})
@@ -1038,6 +1063,9 @@ class PortalTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"sub-portal (UUID: {ids['sub_portal_uuid']})",
+                resource_identity={"sub_portal_uuid": ids["sub_portal_uuid"]},
+                tool_name="delete_sub_portal",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/src/pipefy_mcp/tools/relation_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/relation_tools.py
@@ -229,18 +229,19 @@ class RelationTools:
             ctx: Context,
             relation_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Permanently delete a pipe relation by ID.
 
             ``relation_id`` is the **pipe relation** id from ``get_pipe_relations`` (not a table relation id).
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 relation_id: Pipe relation ID to delete.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -252,6 +253,9 @@ class RelationTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"pipe relation (ID: {relation_id})",
+                resource_identity={"relation_id": relation_id},
+                tool_name="delete_pipe_relation",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/src/pipefy_mcp/tools/report_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/report_tools.py
@@ -512,17 +512,18 @@ class ReportTools:
             ctx: Context,
             report_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a pipe report. This action is irreversible.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 report_id: Pipe report ID to delete.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -534,6 +535,9 @@ class ReportTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"pipe report (ID: {report_id})",
+                resource_identity={"report_id": report_id},
+                tool_name="delete_pipe_report",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -678,17 +682,18 @@ class ReportTools:
             ctx: Context,
             report_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete an organization report. This action is irreversible.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 report_id: Organization report ID to delete.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -700,6 +705,9 @@ class ReportTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"organization report (ID: {report_id})",
+                resource_identity={"report_id": report_id},
+                tool_name="delete_organization_report",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/src/pipefy_mcp/tools/service_account_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/service_account_tools.py
@@ -180,20 +180,21 @@ class ServiceAccountTools:
             organization_uuid: str,
             service_account_uuid: str,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Permanently delete an organization service account.
 
-            Two-step operation: preview with ``confirm=False`` (default), then
-            execute with ``confirm=True`` after explicit human approval. Deleting
-            the account revokes its credentials — any integration using it stops
-            working.
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2. Deleting the account
+            revokes its credentials — any integration using it stops working.
 
             Args:
                 organization_uuid: The organization UUID.
                 service_account_uuid: The service account UUID (from
                     `create_service_account`).
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -210,19 +211,27 @@ class ServiceAccountTools:
                     "Invalid 'service_account_uuid': provide the service account UUID.",
                     code="INVALID_ARGUMENTS",
                 )
+            organization_uuid = organization_uuid.strip()
+            service_account_uuid = service_account_uuid.strip()
 
             guard = await check_destructive_confirmation(
                 ctx,
                 confirm=confirm,
-                resource_descriptor=f"service account {service_account_uuid.strip()}",
+                resource_descriptor=f"service account {service_account_uuid}",
+                resource_identity={
+                    "service_account_uuid": service_account_uuid,
+                    "organization_uuid": organization_uuid,
+                },
+                tool_name="delete_service_account",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
 
             try:
                 raw = await client.delete_service_account(
-                    organization_uuid=organization_uuid.strip(),
-                    service_account_uuid=service_account_uuid.strip(),
+                    organization_uuid=organization_uuid,
+                    service_account_uuid=service_account_uuid,
                 )
             except Exception as exc:  # noqa: BLE001
                 return handle_tool_graphql_error(

--- a/packages/mcp/src/pipefy_mcp/tools/service_account_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/service_account_tools.py
@@ -187,7 +187,7 @@ class ServiceAccountTools:
 
             Two-step operation: preview with ``confirm=False`` (default), then echo
             ``confirmation_token`` from the preview on step 2. Deleting the account
-            revokes its credentials — any integration using it stops working.
+            revokes its credentials: any integration using it stops working.
 
             Args:
                 organization_uuid: The organization UUID.

--- a/packages/mcp/src/pipefy_mcp/tools/service_account_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/service_account_tools.py
@@ -187,7 +187,7 @@ class ServiceAccountTools:
 
             Two-step operation: preview with ``confirm=False`` (default), then echo
             ``confirmation_token`` from the preview on step 2. Deleting the account
-            revokes its credentials: any integration using it stops working.
+            revokes its credentials. Any integration using it stops working.
 
             Args:
                 organization_uuid: The organization UUID.

--- a/packages/mcp/src/pipefy_mcp/tools/table_tool_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/table_tool_helpers.py
@@ -10,7 +10,6 @@ from pipefy_mcp.core.tool_error_envelope import ToolErrorDetail, tool_error
 from pipefy_mcp.tools.graphql_error_helpers import (
     handle_tool_graphql_error,
 )
-from pipefy_mcp.tools.validation_helpers import format_json_preview
 
 
 class TableReadSuccessPayload(TypedDict):
@@ -24,14 +23,6 @@ class TableMutationSuccessPayload(TypedDict):
     success: Literal[True]
     message: str
     result: dict[str, Any]
-
-
-class DeleteTablePreviewPayload(TypedDict):
-    success: Literal[False]
-    requires_confirmation: Literal[True]
-    table_id: str | int
-    message: str
-    table_summary: str
 
 
 class DeleteTableSuccessPayload(TypedDict):
@@ -117,39 +108,6 @@ def build_table_mutation_success_payload(
     )
 
 
-def build_delete_table_preview_payload(
-    *,
-    table_id: str | int,
-    table_name: str,
-    table_data: dict[str, Any],
-) -> DeleteTablePreviewPayload:
-    """Two-step delete: preview before ``confirm=True``.
-
-    Args:
-        table_id: Target table id.
-        table_name: Display name for messaging.
-        table_data: Subset serialized into ``table_summary``.
-    """
-    return {
-        "success": False,
-        "requires_confirmation": True,
-        "table_id": table_id,
-        "table_summary": format_json_preview(
-            {
-                "id": table_data.get("id"),
-                "name": table_name,
-                "description": table_data.get("description"),
-                "table_fields": table_data.get("table_fields"),
-            }
-        ),
-        "message": (
-            "⚠️ You are about to permanently delete database table "
-            f"'{table_name}' (ID: {table_id}). "
-            "This cannot be undone. Confirm with the user, then call again with confirm=True."
-        ),
-    }
-
-
 def build_delete_table_success_payload(
     *, table_id: str | int
 ) -> DeleteTableSuccessPayload:
@@ -226,12 +184,10 @@ def handle_table_tool_graphql_error(
 
 __all__ = [
     "DeleteTableErrorPayload",
-    "DeleteTablePreviewPayload",
     "DeleteTableSuccessPayload",
     "TableMutationSuccessPayload",
     "TableReadSuccessPayload",
     "build_delete_table_error_payload",
-    "build_delete_table_preview_payload",
     "build_delete_table_success_payload",
     "build_table_error_payload",
     "build_table_mutation_error_payload",

--- a/packages/mcp/src/pipefy_mcp/tools/table_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/table_tools.py
@@ -521,16 +521,18 @@ class TableTools:
             ctx: Context,
             table_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a database table permanently.
 
-            Without confirmation, returns a preview and does not delete.
-            Always confirm with the human user before calling with confirm=True.
+            Without confirmation, returns a preview of the table and does not delete.
+            Echo ``confirmation_token`` from the preview on step 2.
 
             Args:
                 table_id: Table ID to delete.
-                confirm: When True, performs deletion after explicit user confirmation.
+                confirm: When True with the preview token, performs the deletion.
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -564,6 +566,9 @@ class TableTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"table '{table_name}' (ID: {table_id})",
+                resource_identity={"table_id": table_id},
+                tool_name="delete_table",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -746,17 +751,18 @@ class TableTools:
             ctx: Context,
             record_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a table record permanently.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 record_id: Record ID to delete.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -770,6 +776,9 @@ class TableTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"table record (ID: {record_id})",
+                resource_identity={"record_id": record_id},
+                tool_name="delete_table_record",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard
@@ -1019,18 +1028,19 @@ class TableTools:
             field_id: PipefyId,
             table_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a database table field (column) permanently.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 field_id: Table field ID to delete.
                 table_id: Table ID containing this field (required by the Pipefy API).
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -1049,6 +1059,9 @@ class TableTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"table field (ID: {field_id})",
+                resource_identity={"field_id": field_id, "table_id": table_id},
+                tool_name="delete_table_field",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/src/pipefy_mcp/tools/validation_helpers.py
+++ b/packages/mcp/src/pipefy_mcp/tools/validation_helpers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import re
 from typing import Any
 
@@ -11,15 +10,6 @@ from pipefy_mcp.core.tool_error_envelope import tool_error
 UUID_RE = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
-
-
-def format_json_preview(data: Any) -> str:
-    """Pretty-print arbitrary data for MCP confirmation summaries (UTF-8, non-ASCII preserved).
-
-    Args:
-        data: Any JSON-serializable or stringifiable structure.
-    """
-    return json.dumps(data, indent=2, default=str, ensure_ascii=False)
 
 
 def valid_repo_id(value: object) -> bool:
@@ -147,7 +137,6 @@ def mutation_error_if_not_optional_dict(
 
 __all__ = [
     "UUID_RE",
-    "format_json_preview",
     "mutation_error_if_not_optional_dict",
     "valid_repo_id",
     "validate_optional_tool_id",

--- a/packages/mcp/src/pipefy_mcp/tools/webhook_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/webhook_tools.py
@@ -475,18 +475,19 @@ class WebhookTools:
             ctx: Context,
             webhook_id: PipefyId,
             confirm: bool = False,
+            confirmation_token: str | None = None,
             debug: bool = False,
         ) -> dict[str, Any]:
             """Delete a webhook permanently.
 
-            Two-step operation: preview with ``confirm=False`` (default), then execute with
-            ``confirm=True`` after explicit human approval. Elicitation does not authorize
-            deletion (only ``confirm=True`` does).
+            Two-step operation: preview with ``confirm=False`` (default), then echo
+            ``confirmation_token`` from the preview on step 2.
 
             Args:
                 ctx: MCP context for debug logging.
                 webhook_id: ID of the webhook to delete.
-                confirm: Set to True to execute the deletion (step 2).
+                confirm: Set to True with the preview token to execute the deletion (step 2).
+                confirmation_token: Token from the preview response.
                 debug: When True, append GraphQL codes and correlation_id to errors.
             """
             client = get_pipefy_client(ctx)
@@ -498,6 +499,9 @@ class WebhookTools:
                 ctx,
                 confirm=confirm,
                 resource_descriptor=f"webhook (ID: {webhook_id})",
+                resource_identity={"webhook_id": wid},
+                tool_name="delete_webhook",
+                confirmation_token=confirmation_token,
             )
             if guard is not None:
                 return guard

--- a/packages/mcp/tests/tools/conftest.py
+++ b/packages/mcp/tests/tools/conftest.py
@@ -55,7 +55,7 @@ def envelope_flag(request, monkeypatch):
     return request.param
 
 
-def _extract_payload_impl(result):
+def extract_tool_payload(result):
     """Extract tool payload from CallToolResult across MCP SDK versions."""
     structured = getattr(result, "structuredContent", None)
     if structured is not None:
@@ -85,7 +85,7 @@ def _extract_payload_impl(result):
 @pytest.fixture
 def extract_payload():
     """Return the shared extractor as a callable fixture (back-compat)."""
-    return _extract_payload_impl
+    return extract_tool_payload
 
 
 def assert_invalid_arguments_envelope(result):
@@ -102,7 +102,7 @@ def assert_invalid_arguments_envelope(result):
         "Expected a tool-error envelope (isError=False), got a transport error: "
         f"{result}"
     )
-    payload = _extract_payload_impl(result)
+    payload = extract_tool_payload(result)
     assert payload.get("success") is False, (
         f"Expected envelope success=False, got payload: {payload!r}"
     )

--- a/packages/mcp/tests/tools/destructive_confirm_test_support.py
+++ b/packages/mcp/tests/tools/destructive_confirm_test_support.py
@@ -1,6 +1,6 @@
 """Two-step confirmation helper for destructive MCP tool tests."""
 
-from tools.conftest import _extract_payload_impl
+from tools.conftest import extract_tool_payload
 
 
 async def confirm_after_preview(session, tool_name, arguments):
@@ -11,7 +11,7 @@ async def confirm_after_preview(session, tool_name, arguments):
     preview_args = {
         key: value for key, value in arguments.items() if key != "confirmation_token"
     }
-    preview = _extract_payload_impl(await session.call_tool(tool_name, preview_args))
+    preview = extract_tool_payload(await session.call_tool(tool_name, preview_args))
     token = preview.get("confirmation_token")
     if not token:
         raise AssertionError(
@@ -21,4 +21,4 @@ async def confirm_after_preview(session, tool_name, arguments):
         tool_name,
         {**preview_args, "confirm": True, "confirmation_token": token},
     )
-    return _extract_payload_impl(confirm_result)
+    return extract_tool_payload(confirm_result)

--- a/packages/mcp/tests/tools/destructive_confirm_test_support.py
+++ b/packages/mcp/tests/tools/destructive_confirm_test_support.py
@@ -1,0 +1,24 @@
+"""Two-step confirmation helper for destructive MCP tool tests."""
+
+from tools.conftest import _extract_payload_impl
+
+
+async def confirm_after_preview(session, tool_name, arguments):
+    """First call without a valid token (or confirm=False), read confirmation_token
+    from structured content, second call with confirm=True and that token.
+    Return the second payload dict (not CallToolResult).
+    """
+    preview_args = {
+        key: value for key, value in arguments.items() if key != "confirmation_token"
+    }
+    preview = _extract_payload_impl(await session.call_tool(tool_name, preview_args))
+    token = preview.get("confirmation_token")
+    if not token:
+        raise AssertionError(
+            f"preview payload missing non-empty confirmation_token: {preview!r}"
+        )
+    confirm_result = await session.call_tool(
+        tool_name,
+        {**preview_args, "confirm": True, "confirmation_token": token},
+    )
+    return _extract_payload_impl(confirm_result)

--- a/packages/mcp/tests/tools/test_ai_agent_tools.py
+++ b/packages/mcp/tests/tools/test_ai_agent_tools.py
@@ -25,6 +25,7 @@ from tools.conftest import (
     assert_invalid_arguments_envelope,
     build_tool_test_server,
 )
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 
 @pytest.fixture
@@ -1283,17 +1284,15 @@ class TestDeleteAiAgent:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         mock_pipefy_client.delete_ai_agent.return_value = {"success": True}
         async with client_session as session:
-            result = await session.call_tool(
+            payload = await confirm_after_preview(
+                session,
                 "delete_ai_agent",
                 {"uuid": "to-delete", "confirm": True},
             )
-        assert result.is_error is False
         mock_pipefy_client.delete_ai_agent.assert_awaited_once_with("to-delete")
-        payload = extract_payload(result)
         assert payload["success"] is True
         assert isinstance(payload["message"], str)
         assert len(payload["message"]) > 0
@@ -1302,14 +1301,12 @@ class TestDeleteAiAgent:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         mock_pipefy_client.delete_ai_agent.return_value = {"success": False}
         async with client_session as session:
-            result = await session.call_tool(
-                "delete_ai_agent", {"uuid": "fail", "confirm": True}
+            payload = await confirm_after_preview(
+                session, "delete_ai_agent", {"uuid": "fail", "confirm": True}
             )
-        payload = extract_payload(result)
         assert payload["success"] is False
         assert "success=false" in tool_error_message(payload).lower()
 
@@ -1327,18 +1324,16 @@ class TestDeleteAiAgent:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         mock_pipefy_client.delete_ai_agent.side_effect = PipefyGraphQLError(
             [{"message": "gone"}]
         )
         async with client_session as session:
-            result = await session.call_tool(
+            payload = await confirm_after_preview(
+                session,
                 "delete_ai_agent",
                 {"uuid": "bad", "confirm": True},
             )
-        assert result.is_error is False
-        payload = extract_payload(result)
         assert payload["success"] is False
         assert "gone" in tool_error_message(payload)
 
@@ -1468,14 +1463,12 @@ class TestDeleteAiAgentConfirmationGuard:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         mock_pipefy_client.delete_ai_agent.side_effect = RuntimeError("network")
         async with client_session as session:
-            result = await session.call_tool(
-                "delete_ai_agent", {"uuid": "agent-uuid", "confirm": True}
+            payload = await confirm_after_preview(
+                session, "delete_ai_agent", {"uuid": "agent-uuid", "confirm": True}
             )
-        payload = extract_payload(result)
         assert payload["success"] is False
         assert "network" in tool_error_message(payload)
 

--- a/packages/mcp/tests/tools/test_ai_automation_tools.py
+++ b/packages/mcp/tests/tools/test_ai_automation_tools.py
@@ -15,6 +15,7 @@ from tools.conftest import (
     assert_invalid_arguments_envelope,
     build_tool_test_server,
 )
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 
 @pytest.fixture
@@ -411,70 +412,64 @@ class TestDeleteAiAutomation:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         mock_pipefy_client.delete_automation.return_value = {"success": True}
         async with client_session as session:
-            result = await session.call_tool(
+            payload = await confirm_after_preview(
+                session,
                 "delete_ai_automation",
                 {"automation_id": "rm-1", "confirm": True},
             )
-        assert result.is_error is False
         mock_pipefy_client.delete_automation.assert_awaited_once_with("rm-1")
-        p = extract_payload(result)
-        assert p["success"] is True
+        assert payload["success"] is True
 
     async def test_graphql_error(
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         mock_pipefy_client.delete_automation.side_effect = PipefyGraphQLError(
             [{"message": "forbidden"}]
         )
         async with client_session as session:
-            result = await session.call_tool(
+            payload = await confirm_after_preview(
+                session,
                 "delete_ai_automation",
                 {"automation_id": "z", "confirm": True},
             )
-        p = extract_payload(result)
-        assert p["success"] is False
-        assert "forbidden" in tool_error_message(p)
+        assert payload["success"] is False
+        assert "forbidden" in tool_error_message(payload)
 
     async def test_works_without_oauth_config(
         self,
         client_session_no_ai,
         mock_pipefy_client_no_ai,
-        extract_payload,
     ):
         """Delete uses public GraphQL, not the Internal API. OAuth is not required."""
         mock_pipefy_client_no_ai.delete_automation.return_value = {"success": True}
         async with client_session_no_ai as session:
-            result = await session.call_tool(
+            payload = await confirm_after_preview(
+                session,
                 "delete_ai_automation",
                 {"automation_id": "1", "confirm": True},
             )
-        assert result.is_error is False
         mock_pipefy_client_no_ai.delete_automation.assert_awaited_once_with("1")
-        p = extract_payload(result)
-        assert p["success"] is True
+        assert payload["success"] is True
 
     async def test_api_success_false_returns_error_payload(
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         mock_pipefy_client.delete_automation.return_value = {"success": False}
         async with client_session as session:
-            result = await session.call_tool(
+            payload = await confirm_after_preview(
+                session,
                 "delete_ai_automation",
                 {"automation_id": "x", "confirm": True},
             )
-        p = extract_payload(result)
-        assert p["success"] is False
-        assert "did not succeed" in tool_error_message(p).lower()
+        assert payload["success"] is False
+        assert "did not succeed" in tool_error_message(payload).lower()
 
     async def test_rejects_invalid_automation_id(
         self,
@@ -1017,15 +1012,15 @@ class TestPipefyIdCoercion:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         mock_pipefy_client.delete_automation.return_value = {"success": True}
         async with client_session as session:
-            result = await session.call_tool(
+            payload = await confirm_after_preview(
+                session,
                 "delete_ai_automation",
                 {"automation_id": 501, "confirm": True},
             )
-        assert extract_payload(result)["success"] is True
+        assert payload["success"] is True
         mock_pipefy_client.delete_automation.assert_awaited_once_with("501")
 
 

--- a/packages/mcp/tests/tools/test_ai_automation_tools_live.py
+++ b/packages/mcp/tests/tools/test_ai_automation_tools_live.py
@@ -2,7 +2,7 @@
 
 Exercises **create_ai_automation** without ``condition`` (default placeholder) through
 the full **pipefy_mcp.server.mcp** app (ToolRegistry + real **PipefyClient**), then
-tears down with **delete_automation** (``confirm=True``).
+tears down with **delete_automation** (preview, then confirm with token).
 
 Skips without **PIPEFY_*** OAuth or when **PIPE_AI_AUTOMATION_LIVE_PIPE_ID** /
 **PIPE_AI_AUTOMATION_LIVE_FIELD_ID** are unset.
@@ -36,6 +36,7 @@ from _shared.live_settings import pipefy_live_configured, require_live_creds
 
 from pipefy_mcp.server import build_pipefy_mcp_server
 from pipefy_mcp.settings import settings
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 # Building the app now resolves the Pipefy credential (the runtime wires its
 # client at construction), so this credential-dependent module skips itself
@@ -96,10 +97,9 @@ async def test_live_create_ai_automation_omits_condition_uses_default_placeholde
             read_timeout_seconds=timedelta(seconds=120),
             raise_exceptions=True,
         ) as session:
-            delete_result = await session.call_tool(
+            del_payload = await confirm_after_preview(
+                session,
                 "delete_automation",
                 {"automation_id": automation_id, "confirm": True},
             )
-    assert delete_result.is_error is False, delete_result
-    del_payload = extract_payload(delete_result)
     assert del_payload.get("success") is True, del_payload

--- a/packages/mcp/tests/tools/test_automation_tools.py
+++ b/packages/mcp/tests/tools/test_automation_tools.py
@@ -12,6 +12,7 @@ from pipefy_sdk import AutomationConditionInput, PipefyClient, PipefyGraphQLErro
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.automation_tools import AutomationTools
 from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 
 @pytest.fixture
@@ -784,38 +785,35 @@ async def test_update_automation_error(
 
 
 @pytest.mark.anyio
-async def test_delete_automation_success(
-    automation_session, mock_automation_client, extract_payload
-):
+async def test_delete_automation_success(automation_session, mock_automation_client):
     mock_automation_client.delete_automation.return_value = {"success": True}
 
     async with automation_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_automation",
             {"automation_id": "rm-1", "confirm": True, "debug": False},
         )
 
-    assert result.is_error is False
     mock_automation_client.delete_automation.assert_awaited_once_with("rm-1")
-    assert extract_payload(result)["success"] is True
+    assert payload["success"] is True
 
 
 @pytest.mark.anyio
-async def test_delete_automation_error(
-    automation_session, mock_automation_client, extract_payload
-):
+async def test_delete_automation_error(automation_session, mock_automation_client):
     mock_automation_client.delete_automation.side_effect = PipefyGraphQLError(
         [{"message": "forbidden"}]
     )
 
     async with automation_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_automation",
             {"automation_id": "z", "confirm": True},
         )
 
-    assert extract_payload(result)["success"] is False
-    assert "forbidden" in tool_error_message(extract_payload(result))
+    assert payload["success"] is False
+    assert "forbidden" in tool_error_message(payload)
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_destructive_confirmation_token.py
+++ b/packages/mcp/tests/tools/test_destructive_confirmation_token.py
@@ -10,6 +10,7 @@ import pytest
 
 from pipefy_mcp.tools.destructive_confirmation_token import (
     DESTRUCTIVE_CONFIRMATION_TTL_SECONDS,
+    classify_confirmation_token_failure,
     mint_confirmation_token,
     verify_confirmation_token,
 )
@@ -371,6 +372,149 @@ def test_mint_stringifies_non_json_identity_values():
     assert token.startswith("v1.")
     payload = json.loads(_b64url_decode(token.split(".")[1]))
     assert payload["identity"]["field_id"] == "not-json"
+
+
+def test_non_json_identity_value_round_trips_to_verify():
+    """A stringified identity must still verify, or the caller previews forever."""
+
+    class NotJson:
+        def __str__(self):
+            return "not-json"
+
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity={"field_id": NotJson()},
+        key=KEY,
+        now=NOW,
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity={"field_id": NotJson()},
+            key=KEY,
+            now=NOW + 1,
+        )
+        is True
+    )
+
+
+def test_old_format_token_signed_over_payload_only_is_rejected():
+    """A token whose MAC omits the version prefix predates the version binding."""
+    payload_bytes = json.dumps(
+        {"exp": NOW + 300, "identity": IDENTITY, "tool": TOOL},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    legacy_mac = hmac.new(KEY, payload_bytes, hashlib.sha256).digest()
+    legacy_token = (
+        "v1."
+        + base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode("ascii")
+        + "."
+        + base64.urlsafe_b64encode(legacy_mac).rstrip(b"=").decode("ascii")
+    )
+
+    assert (
+        verify_confirmation_token(
+            legacy_token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW + 1,
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize("token", [None, ""])
+def test_classify_reports_missing_for_absent_token(token):
+    assert (
+        classify_confirmation_token_failure(
+            token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+        )
+        == "missing"
+    )
+
+
+def test_classify_reports_invalid_for_a_token_signed_with_another_key():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=IDENTITY,
+        key=OTHER_KEY,
+        now=NOW,
+    )
+
+    assert (
+        classify_confirmation_token_failure(
+            token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+        )
+        == "invalid_or_expired"
+    )
+
+
+def test_classify_reports_identity_mismatch_for_another_tool():
+    token = mint_confirmation_token(
+        tool_name="delete_label",
+        resource_identity=IDENTITY,
+        key=KEY,
+        now=NOW,
+    )
+
+    assert (
+        classify_confirmation_token_failure(
+            token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+        )
+        == "identity_mismatch"
+    )
+
+
+def test_classify_reports_identity_mismatch_for_another_resource():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity={"field_id": "99", "pipe_uuid": "abc"},
+        key=KEY,
+        now=NOW,
+    )
+
+    assert (
+        classify_confirmation_token_failure(
+            token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+        )
+        == "identity_mismatch"
+    )
+
+
+def test_tampered_version_prefix_is_rejected():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=IDENTITY,
+        key=KEY,
+        now=NOW,
+    )
+    tampered = "v2." + token.split(".", 1)[1]
+
+    assert (
+        verify_confirmation_token(
+            tampered,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW + 1,
+        )
+        is False
+    )
 
 
 def test_verify_uses_hmac_compare_digest(monkeypatch):

--- a/packages/mcp/tests/tools/test_destructive_confirmation_token.py
+++ b/packages/mcp/tests/tools/test_destructive_confirmation_token.py
@@ -1,6 +1,8 @@
-"""Contract tests for the destructive confirmation token planner (REQ-1)."""
+"""Contract tests for minting and verifying HMAC confirmation tokens."""
 
 import base64
+import hashlib
+import hmac
 import json
 from unittest.mock import MagicMock
 
@@ -123,6 +125,45 @@ def test_wrong_key_fails():
     )
 
 
+def test_spliced_payload_and_mac_from_same_key_fails():
+    identity_b = {"field_id": "2", "pipe_uuid": "abc"}
+    token_a = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=IDENTITY,
+        key=KEY,
+        now=NOW,
+    )
+    token_b = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=identity_b,
+        key=KEY,
+        now=NOW,
+    )
+    _, payload_a, _ = token_a.split(".")
+    _, _, mac_b = token_b.split(".")
+    spliced = f"v1.{payload_a}.{mac_b}"
+    assert (
+        verify_confirmation_token(
+            spliced,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW + 1,
+        )
+        is False
+    )
+    assert (
+        verify_confirmation_token(
+            spliced,
+            tool_name=TOOL,
+            resource_identity=identity_b,
+            key=KEY,
+            now=NOW + 1,
+        )
+        is False
+    )
+
+
 def test_tool_mismatch_fails():
     token = mint_confirmation_token(
         tool_name="delete_phase_field",
@@ -235,6 +276,64 @@ def test_garbage_or_none_token_returns_false(token):
     )
 
 
+def test_whitespace_in_token_part_fails():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=IDENTITY,
+        key=KEY,
+        now=NOW,
+    )
+    version, payload_b64, mac_b64 = token.split(".")
+    spaced = f"{version}.{payload_b64} .{mac_b64}"
+    assert (
+        verify_confirmation_token(
+            spaced,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW + 1,
+        )
+        is False
+    )
+
+
+def test_standard_base64_alphabet_in_token_part_fails():
+    # Non-ASCII identity so the payload segment carries base64url "-" or "_";
+    # swapping those for the standard "+" and "/" decodes to identical bytes,
+    # so only an alphabet check rejects it.
+    identity = {"pipe_id": "çãé~ÿþ"}
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=identity,
+        key=KEY,
+        now=NOW,
+    )
+    version, payload_b64, mac_b64 = token.split(".")
+    assert "-" in payload_b64 or "_" in payload_b64
+    standard = f"{version}.{payload_b64.replace('-', '+').replace('_', '/')}.{mac_b64}"
+    assert standard != token
+    assert (
+        verify_confirmation_token(
+            standard,
+            tool_name=TOOL,
+            resource_identity=identity,
+            key=KEY,
+            now=NOW + 1,
+        )
+        is False
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity=identity,
+            key=KEY,
+            now=NOW + 1,
+        )
+        is True
+    )
+
+
 def test_minted_token_wire_format():
     token = mint_confirmation_token(
         tool_name=TOOL,
@@ -252,6 +351,26 @@ def test_minted_token_wire_format():
     assert payload_raw
     assert mac_raw
     json.loads(payload_raw)
+    expected_mac = hmac.new(KEY, b"v1." + payload_raw, hashlib.sha256).digest()
+    assert hmac.compare_digest(mac_raw, expected_mac)
+    payload_only_mac = hmac.new(KEY, payload_raw, hashlib.sha256).digest()
+    assert not hmac.compare_digest(mac_raw, payload_only_mac)
+
+
+def test_mint_stringifies_non_json_identity_values():
+    class NotJson:
+        def __str__(self):
+            return "not-json"
+
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity={"field_id": NotJson()},
+        key=KEY,
+        now=NOW,
+    )
+    assert token.startswith("v1.")
+    payload = json.loads(_b64url_decode(token.split(".")[1]))
+    assert payload["identity"]["field_id"] == "not-json"
 
 
 def test_verify_uses_hmac_compare_digest(monkeypatch):
@@ -260,10 +379,7 @@ def test_verify_uses_hmac_compare_digest(monkeypatch):
     from pipefy_mcp.tools import destructive_confirmation_token as planner
 
     spy = MagicMock(wraps=hmac_mod.compare_digest)
-    if hasattr(planner, "hmac"):
-        monkeypatch.setattr(planner.hmac, "compare_digest", spy)
-    else:
-        monkeypatch.setattr(planner, "compare_digest", spy)
+    monkeypatch.setattr(planner.hmac, "compare_digest", spy)
 
     token = mint_confirmation_token(
         tool_name=TOOL,

--- a/packages/mcp/tests/tools/test_destructive_confirmation_token.py
+++ b/packages/mcp/tests/tools/test_destructive_confirmation_token.py
@@ -1,0 +1,314 @@
+"""Contract tests for the destructive confirmation token planner (REQ-1)."""
+
+import base64
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from pipefy_mcp.tools.destructive_confirmation_token import (
+    DESTRUCTIVE_CONFIRMATION_TTL_SECONDS,
+    mint_confirmation_token,
+    verify_confirmation_token,
+)
+
+KEY = b"\x01" * 32
+OTHER_KEY = b"\x02" * 32
+NOW = 1_700_000_000
+TOOL = "delete_phase_field"
+IDENTITY = {"field_id": "1", "pipe_uuid": "abc"}
+
+
+def _b64url_decode(part):
+    padding = "=" * ((4 - len(part) % 4) % 4)
+    return base64.urlsafe_b64decode(part + padding)
+
+
+def test_ttl_constant_is_300():
+    assert DESTRUCTIVE_CONFIRMATION_TTL_SECONDS == 300
+
+
+def test_mint_then_verify_same_key_succeeds():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=IDENTITY,
+        key=KEY,
+        now=NOW,
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW + 1,
+        )
+        is True
+    )
+
+
+def test_identity_key_order_does_not_matter():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity={"field_id": "1", "pipe_uuid": "abc"},
+        key=KEY,
+        now=NOW,
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity={"pipe_uuid": "abc", "field_id": "1"},
+            key=KEY,
+            now=NOW + 1,
+        )
+        is True
+    )
+
+
+def test_int_and_str_ids_are_equivalent():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity={"field_id": 1},
+        key=KEY,
+        now=NOW,
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity={"field_id": "1"},
+            key=KEY,
+            now=NOW + 1,
+        )
+        is True
+    )
+
+
+def test_list_order_does_not_matter():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity={"user_ids": ["2", "1"]},
+        key=KEY,
+        now=NOW,
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity={"user_ids": ["1", "2"]},
+            key=KEY,
+            now=NOW + 1,
+        )
+        is True
+    )
+
+
+def test_wrong_key_fails():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=IDENTITY,
+        key=KEY,
+        now=NOW,
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=OTHER_KEY,
+            now=NOW + 1,
+        )
+        is False
+    )
+
+
+def test_tool_mismatch_fails():
+    token = mint_confirmation_token(
+        tool_name="delete_phase_field",
+        resource_identity=IDENTITY,
+        key=KEY,
+        now=NOW,
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name="delete_pipe",
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW + 1,
+        )
+        is False
+    )
+
+
+def test_identity_mismatch_fails():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity={"field_id": "1", "table_id": "10"},
+        key=KEY,
+        now=NOW,
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity={"field_id": "1", "table_id": "11"},
+            key=KEY,
+            now=NOW + 1,
+        )
+        is False
+    )
+
+
+def test_dropped_identity_key_is_not_a_wildcard():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity={"field_id": "prioridade", "pipe_uuid": "A"},
+        key=KEY,
+        now=NOW,
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity={"field_id": "prioridade"},
+            key=KEY,
+            now=NOW + 1,
+        )
+        is False
+    )
+
+
+def test_token_expires_at_ttl_boundary():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=IDENTITY,
+        key=KEY,
+        now=NOW,
+    )
+    ttl = DESTRUCTIVE_CONFIRMATION_TTL_SECONDS
+    assert ttl == 300
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW + ttl - 1,
+        )
+        is True
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW + ttl,
+        )
+        is False
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW + ttl + 1,
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize("token", ["not-a-token", "", None])
+def test_garbage_or_none_token_returns_false(token):
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW,
+        )
+        is False
+    )
+
+
+def test_minted_token_wire_format():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=IDENTITY,
+        key=KEY,
+        now=NOW,
+    )
+    assert token.startswith("v1.")
+    parts = token.split(".")
+    assert len(parts) == 3
+    version, payload_b64, mac_b64 = parts
+    assert version == "v1"
+    payload_raw = _b64url_decode(payload_b64)
+    mac_raw = _b64url_decode(mac_b64)
+    assert payload_raw
+    assert mac_raw
+    json.loads(payload_raw)
+
+
+def test_verify_uses_hmac_compare_digest(monkeypatch):
+    import hmac as hmac_mod
+
+    from pipefy_mcp.tools import destructive_confirmation_token as planner
+
+    spy = MagicMock(wraps=hmac_mod.compare_digest)
+    if hasattr(planner, "hmac"):
+        monkeypatch.setattr(planner.hmac, "compare_digest", spy)
+    else:
+        monkeypatch.setattr(planner, "compare_digest", spy)
+
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=IDENTITY,
+        key=KEY,
+        now=NOW,
+    )
+    assert (
+        verify_confirmation_token(
+            token,
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW + 1,
+        )
+        is True
+    )
+    spy.assert_called()
+
+
+def test_planner_has_no_io():
+    import inspect
+
+    from pipefy_mcp.tools import destructive_confirmation_token as planner
+
+    source = inspect.getsource(planner)
+    assert "Context" not in source
+    assert "PipefyClient" not in source
+    assert "os.environ" not in source
+
+
+def test_token_payload_does_not_contain_key_and_has_canonical_fields():
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=IDENTITY,
+        key=KEY,
+        now=NOW,
+    )
+    payload_raw = _b64url_decode(token.split(".")[1])
+    payload = json.loads(payload_raw)
+    assert list(payload.keys()) == ["exp", "identity", "tool"]
+    assert isinstance(payload["identity"], dict)
+    assert not isinstance(payload["identity"], str)
+    assert "key" not in payload
+    assert KEY not in payload_raw
+    assert KEY.decode("latin-1") not in token
+    assert payload["tool"] == TOOL
+    assert payload["exp"] == NOW + DESTRUCTIVE_CONFIRMATION_TTL_SECONDS

--- a/packages/mcp/tests/tools/test_destructive_preview_dependents.py
+++ b/packages/mcp/tests/tools/test_destructive_preview_dependents.py
@@ -7,6 +7,8 @@ import pytest
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 
 RESOURCE = "phase field (ID: 99)"
+TOOL_NAME = "delete_phase_field"
+IDENTITY = {"field_id": "99"}
 
 
 def _minimal_ctx():
@@ -16,19 +18,34 @@ def _minimal_ctx():
     return ctx
 
 
+async def _check(ctx, *, confirm, dependents_resolver=None, confirmation_token=None):
+    return await check_destructive_confirmation(
+        ctx,
+        confirm=confirm,
+        resource_descriptor=RESOURCE,
+        resource_identity=IDENTITY,
+        tool_name=TOOL_NAME,
+        confirmation_token=confirmation_token,
+        dependents_resolver=dependents_resolver,
+    )
+
+
 @pytest.mark.anyio
 async def test_no_resolver_shape_unchanged():
     ctx = _minimal_ctx()
-    payload = await check_destructive_confirmation(
-        ctx, confirm=False, resource_descriptor=RESOURCE
-    )
+    payload = await _check(ctx, confirm=False)
     assert payload is not None
     assert set(payload.keys()) == {
         "success",
         "requires_confirmation",
         "resource",
         "message",
+        "confirmation_token",
     }
+    token = payload["confirmation_token"]
+    assert isinstance(token, str)
+    assert token
+    assert token.startswith("v1.")
     assert "dependents" not in payload
 
 
@@ -39,12 +56,7 @@ async def test_resolver_returns_none_no_enrichment():
     async def resolver():
         return None
 
-    payload = await check_destructive_confirmation(
-        ctx,
-        confirm=False,
-        resource_descriptor=RESOURCE,
-        dependents_resolver=resolver,
-    )
+    payload = await _check(ctx, confirm=False, dependents_resolver=resolver)
     assert payload is not None
     assert "dependents" not in payload
 
@@ -56,12 +68,7 @@ async def test_resolver_returns_empty_dict_no_enrichment():
     async def resolver():
         return {}
 
-    payload = await check_destructive_confirmation(
-        ctx,
-        confirm=False,
-        resource_descriptor=RESOURCE,
-        dependents_resolver=resolver,
-    )
+    payload = await _check(ctx, confirm=False, dependents_resolver=resolver)
     assert payload is not None
     assert "dependents" not in payload
 
@@ -74,12 +81,7 @@ async def test_resolver_returns_dict_enriches_preview():
     async def resolver():
         return deps
 
-    payload = await check_destructive_confirmation(
-        ctx,
-        confirm=False,
-        resource_descriptor=RESOURCE,
-        dependents_resolver=resolver,
-    )
+    payload = await _check(ctx, confirm=False, dependents_resolver=resolver)
     assert payload is not None
     assert payload["dependents"] == deps
     assert payload["resource"] == RESOURCE
@@ -93,12 +95,7 @@ async def test_resolver_raises_degrades_silently():
     async def resolver():
         raise RuntimeError("boom")
 
-    payload = await check_destructive_confirmation(
-        ctx,
-        confirm=False,
-        resource_descriptor=RESOURCE,
-        dependents_resolver=resolver,
-    )
+    payload = await _check(ctx, confirm=False, dependents_resolver=resolver)
     assert payload is not None
     assert "dependents" not in payload
     assert payload["resource"] == RESOURCE
@@ -114,10 +111,15 @@ async def test_confirm_true_never_invokes_resolver():
         calls += 1
         return {"should_not": "appear"}
 
-    result = await check_destructive_confirmation(
+    preview = await _check(ctx, confirm=False, dependents_resolver=resolver)
+    assert preview is not None
+    token = preview["confirmation_token"]
+    calls = 0
+
+    result = await _check(
         ctx,
         confirm=True,
-        resource_descriptor=RESOURCE,
+        confirmation_token=token,
         dependents_resolver=resolver,
     )
     assert result is None

--- a/packages/mcp/tests/tools/test_destructive_preview_dependents.py
+++ b/packages/mcp/tests/tools/test_destructive_preview_dependents.py
@@ -1,4 +1,4 @@
-"""Guard-level tests for optional ``dependents_resolver`` (REQ-1)."""
+"""Guard-level tests for optional ``dependents_resolver``."""
 
 from unittest.mock import AsyncMock, MagicMock
 

--- a/packages/mcp/tests/tools/test_destructive_tool_guard.py
+++ b/packages/mcp/tests/tools/test_destructive_tool_guard.py
@@ -40,9 +40,7 @@ def _assert_token_required_wording(message):
     lowered = message.lower()
     assert "token" in lowered
     assert "confirm=True" in message
-    has_status = any(word in lowered for word in ("missing", "invalid", "expired"))
-    has_prior = "preview" in lowered
-    assert has_status or has_prior
+    assert any(word in lowered for word in ("missing", "invalid", "expired"))
 
 
 def _make_ctx(*, can_elicit=False, request=None):

--- a/packages/mcp/tests/tools/test_destructive_tool_guard.py
+++ b/packages/mcp/tests/tools/test_destructive_tool_guard.py
@@ -68,6 +68,13 @@ def _assert_identity_mismatch_token_wording(message):
     assert "confirm=True" in message
 
 
+def _assert_no_token_status_wording(message):
+    """A first look has no earlier token, so it must not report one as faulty."""
+    assert _MISSING_TOKEN_SENTENCE not in message
+    assert _INVALID_OR_EXPIRED_TOKEN_SENTENCE not in message
+    assert _IDENTITY_MISMATCH_TOKEN_SENTENCE not in message
+
+
 def _make_ctx(*, can_elicit=False, request=None):
     ctx = MagicMock()
     ctx.session.client_params.capabilities.elicitation = can_elicit
@@ -105,6 +112,12 @@ class TestNoElicitation:
         payload = await _check(ctx, confirm=False)
         _assert_preview(payload)
         ctx.elicit.assert_not_called()
+
+    async def test_first_look_preview_reports_no_token_status(self):
+        ctx = _make_ctx(can_elicit=False)
+        payload = await _check(ctx, confirm=False)
+        _assert_preview(payload)
+        _assert_no_token_status_wording(payload["message"])
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_destructive_tool_guard.py
+++ b/packages/mcp/tests/tools/test_destructive_tool_guard.py
@@ -32,15 +32,40 @@ def _assert_preview(payload, *, resource=RESOURCE):
     assert token
     assert token.startswith("v1.")
     assert token in payload["message"]
+    assert "cannot be undone" in payload["message"]
     _assert_approval_before_confirm(payload["message"])
     return token
 
 
-def _assert_token_required_wording(message):
-    lowered = message.lower()
-    assert "token" in lowered
+_MISSING_TOKEN_SENTENCE = "The confirmation token is missing."
+_INVALID_OR_EXPIRED_TOKEN_SENTENCE = (
+    "The previous confirmation token was invalid or expired."
+)
+_IDENTITY_MISMATCH_TOKEN_SENTENCE = (
+    "The previous confirmation token does not match this tool and resource identity."
+)
+
+
+def _assert_missing_token_wording(message):
+    assert _MISSING_TOKEN_SENTENCE in message
+    assert _INVALID_OR_EXPIRED_TOKEN_SENTENCE not in message
+    assert _IDENTITY_MISMATCH_TOKEN_SENTENCE not in message
     assert "confirm=True" in message
-    assert any(word in lowered for word in ("missing", "invalid", "expired"))
+
+
+def _assert_invalid_or_expired_token_wording(message):
+    assert _INVALID_OR_EXPIRED_TOKEN_SENTENCE in message
+    assert _MISSING_TOKEN_SENTENCE not in message
+    assert _IDENTITY_MISMATCH_TOKEN_SENTENCE not in message
+    assert "confirm=True" in message
+
+
+def _assert_identity_mismatch_token_wording(message):
+    assert _IDENTITY_MISMATCH_TOKEN_SENTENCE in message
+    assert _MISSING_TOKEN_SENTENCE not in message
+    assert _INVALID_OR_EXPIRED_TOKEN_SENTENCE not in message
+    assert "expired" not in message.lower()
+    assert "confirm=True" in message
 
 
 def _make_ctx(*, can_elicit=False, request=None):
@@ -154,7 +179,7 @@ class TestTokenAwareConfirmation:
             dependents_resolver=resolver,
         )
         _assert_preview(payload)
-        _assert_token_required_wording(payload["message"])
+        _assert_missing_token_wording(payload["message"])
         resolver.assert_awaited()
         ctx.elicit.assert_not_called()
 
@@ -205,7 +230,7 @@ class TestTokenAwareConfirmation:
         )
         token = _assert_preview(payload)
         assert token != "not-a-token"
-        _assert_token_required_wording(payload["message"])
+        _assert_invalid_or_expired_token_wording(payload["message"])
 
     async def test_expired_token_previews_with_fresh_token(self, monkeypatch):
         ctx = _make_ctx(can_elicit=False)
@@ -223,7 +248,7 @@ class TestTokenAwareConfirmation:
         fresh = _assert_preview(payload)
         assert payload is not None
         assert fresh != token
-        _assert_token_required_wording(payload["message"])
+        _assert_invalid_or_expired_token_wording(payload["message"])
 
     async def test_dependents_invoked_on_failed_token_preview(self):
         ctx = _make_ctx(can_elicit=False)
@@ -236,6 +261,28 @@ class TestTokenAwareConfirmation:
         )
         _assert_preview(payload)
         resolver.assert_awaited()
+
+    async def test_empty_token_previews_as_missing(self):
+        ctx = _make_ctx(can_elicit=False)
+        payload = await _check(ctx, confirm=True, confirmation_token="")
+        _assert_preview(payload)
+        _assert_missing_token_wording(payload["message"])
+
+    async def test_identity_mismatch_previews_without_claiming_expiration(self):
+        ctx = _make_ctx(can_elicit=False)
+        preview = await _check(ctx, confirm=False)
+        token = _assert_preview(preview)
+
+        payload = await _check(
+            ctx,
+            confirm=True,
+            resource_identity={"phase_id": "99"},
+            confirmation_token=token,
+        )
+        fresh = _assert_preview(payload)
+        assert payload is not None
+        assert fresh != token
+        _assert_identity_mismatch_token_wording(payload["message"])
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_destructive_tool_guard.py
+++ b/packages/mcp/tests/tools/test_destructive_tool_guard.py
@@ -4,64 +4,94 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from _rs_fixtures import authenticated_user, request_with_user
 
+from pipefy_mcp.tools import destructive_tool_guard as guard_mod
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 
 RESOURCE = "phase 'Initial' (ID: 42)"
+TOOL_NAME = "delete_phase"
+IDENTITY = {"phase_id": "42"}
 
 
-def _make_ctx(*, can_elicit):
+def _assert_approval_before_confirm(message):
+    approval_index = message.find("explicit approval")
+    confirm_index = message.find("confirm=True")
+    assert approval_index != -1
+    assert confirm_index != -1
+    assert approval_index < confirm_index
+
+
+def _assert_preview(payload, *, resource=RESOURCE):
+    assert payload is not None
+    assert payload["success"] is False
+    assert payload["requires_confirmation"] is True
+    assert payload["resource"] == resource
+    token = payload["confirmation_token"]
+    assert isinstance(token, str)
+    assert token
+    assert token.startswith("v1.")
+    assert token in payload["message"]
+    _assert_approval_before_confirm(payload["message"])
+    return token
+
+
+def _assert_token_required_wording(message):
+    lowered = message.lower()
+    assert "token" in lowered
+    assert "confirm=True" in message
+    has_status = any(word in lowered for word in ("missing", "invalid", "expired"))
+    has_prior = "preview" in lowered
+    assert has_status or has_prior
+
+
+def _make_ctx(*, can_elicit=False, request=None):
     ctx = MagicMock()
     ctx.session.client_params.capabilities.elicitation = can_elicit
     ctx.elicit = AsyncMock()
+    if request is not None:
+        ctx.request_context.request = request
     return ctx
+
+
+async def _check(
+    ctx,
+    *,
+    confirm,
+    resource_descriptor=RESOURCE,
+    resource_identity=IDENTITY,
+    tool_name=TOOL_NAME,
+    confirmation_token=None,
+    dependents_resolver=None,
+):
+    return await check_destructive_confirmation(
+        ctx,
+        confirm=confirm,
+        resource_descriptor=resource_descriptor,
+        resource_identity=resource_identity,
+        tool_name=tool_name,
+        confirmation_token=confirmation_token,
+        dependents_resolver=dependents_resolver,
+    )
 
 
 @pytest.mark.anyio
 class TestNoElicitation:
     async def test_no_confirm_returns_preview(self):
         ctx = _make_ctx(can_elicit=False)
-        payload = await check_destructive_confirmation(
-            ctx, confirm=False, resource_descriptor=RESOURCE
-        )
-        assert payload is not None
-        assert payload["success"] is False
-        assert payload["requires_confirmation"] is True
-        assert payload["resource"] == RESOURCE
-        assert "confirm=True" in payload["message"]
-        ctx.elicit.assert_not_called()
-
-    async def test_confirm_true_returns_none(self):
-        ctx = _make_ctx(can_elicit=False)
-        result = await check_destructive_confirmation(
-            ctx, confirm=True, resource_descriptor=RESOURCE
-        )
-        assert result is None
+        payload = await _check(ctx, confirm=False)
+        _assert_preview(payload)
         ctx.elicit.assert_not_called()
 
 
 @pytest.mark.anyio
 class TestClientAdvertisesElicitation:
-    """Even when the client supports elicitation, only ``confirm=True`` authorizes deletion."""
+    """Even when the client supports elicitation, only a valid token authorizes deletion."""
 
     async def test_confirm_false_returns_preview_and_never_elicits(self):
         ctx = _make_ctx(can_elicit=True)
-        payload = await check_destructive_confirmation(
-            ctx, confirm=False, resource_descriptor=RESOURCE
-        )
-        assert payload is not None
-        assert payload["success"] is False
-        assert payload["requires_confirmation"] is True
-        assert payload["resource"] == RESOURCE
-        assert "confirm=True" in payload["message"]
-        ctx.elicit.assert_not_called()
-
-    async def test_confirm_true_returns_none_without_elicit(self):
-        ctx = _make_ctx(can_elicit=True)
-        result = await check_destructive_confirmation(
-            ctx, confirm=True, resource_descriptor=RESOURCE
-        )
-        assert result is None
+        payload = await _check(ctx, confirm=False)
+        _assert_preview(payload)
         ctx.elicit.assert_not_called()
 
 
@@ -71,28 +101,16 @@ class TestMissingCapabilityMetadata:
         ctx = MagicMock()
         ctx.session = SimpleNamespace()
         ctx.elicit = AsyncMock()
-        payload = await check_destructive_confirmation(
-            ctx, confirm=False, resource_descriptor=RESOURCE
-        )
-        assert payload is not None
-        assert payload["success"] is False
-        assert payload["requires_confirmation"] is True
-        assert payload["resource"] == RESOURCE
-        assert "confirm=True" in payload["message"]
+        payload = await _check(ctx, confirm=False)
+        _assert_preview(payload)
         ctx.elicit.assert_not_called()
 
     async def test_client_params_without_capabilities_returns_preview(self):
         ctx = MagicMock()
         ctx.session = SimpleNamespace(client_params=SimpleNamespace())
         ctx.elicit = AsyncMock()
-        payload = await check_destructive_confirmation(
-            ctx, confirm=False, resource_descriptor=RESOURCE
-        )
-        assert payload is not None
-        assert payload["success"] is False
-        assert payload["requires_confirmation"] is True
-        assert payload["resource"] == RESOURCE
-        assert "confirm=True" in payload["message"]
+        payload = await _check(ctx, confirm=False)
+        _assert_preview(payload)
         ctx.elicit.assert_not_called()
 
     async def test_capabilities_without_elicitation_attr_returns_preview(self):
@@ -101,11 +119,161 @@ class TestMissingCapabilityMetadata:
             client_params=SimpleNamespace(capabilities=SimpleNamespace()),
         )
         ctx.elicit = AsyncMock()
-        payload = await check_destructive_confirmation(
-            ctx, confirm=False, resource_descriptor=RESOURCE
+        payload = await _check(ctx, confirm=False)
+        _assert_preview(payload)
+        ctx.elicit.assert_not_called()
+
+
+@pytest.mark.anyio
+class TestTokenAwareConfirmation:
+    async def test_confirm_false_with_valid_token_still_previews(self):
+        ctx = _make_ctx(can_elicit=False)
+        resolver = AsyncMock(return_value={"related": 1})
+        first = await _check(ctx, confirm=False, dependents_resolver=resolver)
+        token = _assert_preview(first)
+        resolver.assert_awaited()
+
+        resolver.reset_mock()
+        second = await _check(
+            ctx,
+            confirm=False,
+            confirmation_token=token,
+            dependents_resolver=resolver,
         )
+        second_token = _assert_preview(second)
+        assert second is not None
+        assert second_token.startswith("v1.")
+        resolver.assert_awaited()
+        ctx.elicit.assert_not_called()
+
+    async def test_confirm_true_without_token_previews(self):
+        ctx = _make_ctx(can_elicit=True)
+        resolver = AsyncMock(return_value={"related": 1})
+        payload = await _check(
+            ctx,
+            confirm=True,
+            confirmation_token=None,
+            dependents_resolver=resolver,
+        )
+        _assert_preview(payload)
+        _assert_token_required_wording(payload["message"])
+        resolver.assert_awaited()
+        ctx.elicit.assert_not_called()
+
+    async def test_confirm_true_with_valid_token_proceeds(self):
+        ctx = _make_ctx(can_elicit=False)
+        resolver = AsyncMock(return_value={"related": 1})
+        preview = await _check(ctx, confirm=False, dependents_resolver=resolver)
+        token = _assert_preview(preview)
+        resolver.assert_awaited()
+        resolver.reset_mock()
+
+        result = await _check(
+            ctx,
+            confirm=True,
+            confirmation_token=token,
+            dependents_resolver=resolver,
+        )
+        assert result is None
+        resolver.assert_not_called()
+        ctx.elicit.assert_not_called()
+
+    async def test_reworded_descriptor_does_not_invalidate_token(self):
+        ctx = _make_ctx(can_elicit=False)
+        field_identity = {"field_id": "1"}
+        preview = await _check(
+            ctx,
+            confirm=False,
+            resource_descriptor="phase field (ID: 1)",
+            resource_identity=field_identity,
+        )
+        token = _assert_preview(preview, resource="phase field (ID: 1)")
+
+        result = await _check(
+            ctx,
+            confirm=True,
+            resource_descriptor="field 'Priority' (ID: 1)",
+            resource_identity=field_identity,
+            confirmation_token=token,
+        )
+        assert result is None
+
+    async def test_wrong_token_previews_with_fresh_token(self):
+        ctx = _make_ctx(can_elicit=False)
+        payload = await _check(
+            ctx,
+            confirm=True,
+            confirmation_token="not-a-token",
+        )
+        token = _assert_preview(payload)
+        assert token != "not-a-token"
+        _assert_token_required_wording(payload["message"])
+
+    async def test_expired_token_previews_with_fresh_token(self, monkeypatch):
+        ctx = _make_ctx(can_elicit=False)
+        clock = [1_700_000_000]
+
+        def fake_time():
+            return clock[0]
+
+        monkeypatch.setattr(guard_mod.time, "time", fake_time)
+        preview = await _check(ctx, confirm=False)
+        token = _assert_preview(preview)
+
+        clock[0] += 301
+        payload = await _check(ctx, confirm=True, confirmation_token=token)
+        fresh = _assert_preview(payload)
         assert payload is not None
-        assert payload["success"] is False
-        assert payload["requires_confirmation"] is True
-        assert payload["resource"] == RESOURCE
+        assert fresh != token
+        _assert_token_required_wording(payload["message"])
+
+    async def test_dependents_invoked_on_failed_token_preview(self):
+        ctx = _make_ctx(can_elicit=False)
+        resolver = AsyncMock(return_value={"related": 1})
+        payload = await _check(
+            ctx,
+            confirm=True,
+            confirmation_token="not-a-token",
+            dependents_resolver=resolver,
+        )
+        _assert_preview(payload)
+        resolver.assert_awaited()
+
+
+@pytest.mark.anyio
+class TestHostedBearerDerivedKey:
+    async def test_different_bearer_cannot_reuse_token(self):
+        ctx_u1 = _make_ctx(
+            request=request_with_user(authenticated_user("bearer-u1")),
+        )
+        preview = await _check(ctx_u1, confirm=False)
+        token = _assert_preview(preview)
+
+        ctx_u2 = _make_ctx(
+            request=request_with_user(authenticated_user("bearer-u2")),
+        )
+        stolen = await _check(
+            ctx_u2,
+            confirm=True,
+            confirmation_token=token,
+        )
+        _assert_preview(stolen)
+        assert stolen is not None
+
+    async def test_same_bearer_preview_then_confirm_proceeds(self):
+        request = request_with_user(authenticated_user("bearer-u1"))
+        ctx = _make_ctx(request=request)
+        preview = await _check(ctx, confirm=False)
+        token = _assert_preview(preview)
+
+        result = await _check(ctx, confirm=True, confirmation_token=token)
+        assert result is None
+
+
+@pytest.mark.anyio
+class TestMissingBearer:
+    async def test_missing_bearer_does_not_raise(self):
+        ctx = _make_ctx(can_elicit=False)
+        payload = await _check(ctx, confirm=False)
+        _assert_preview(payload)
         ctx.elicit.assert_not_called()

--- a/packages/mcp/tests/tools/test_field_condition_tools.py
+++ b/packages/mcp/tests/tools/test_field_condition_tools.py
@@ -13,6 +13,7 @@ from pipefy_sdk import PipefyClient, PipefyGraphQLError
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.field_condition_tools import FieldConditionTools
 from tools.conftest import build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 _MINIMAL_CREATE_CONDITION = {
     "expressions": [
@@ -35,6 +36,7 @@ def mock_pipefy_client():
     client.get_field_condition = AsyncMock()
     client.create_field_condition = AsyncMock()
     client.update_field_condition = AsyncMock()
+    client.delete_field_condition = AsyncMock()
     client.get_phase_fields = AsyncMock(return_value={"fields": []})
     return client
 
@@ -821,3 +823,16 @@ class TestRequiredHiddenLint:
         assert payload["success"] is True
         mock_pipefy_client.update_field_condition.assert_awaited_once()
         mock_pipefy_client.get_phase_fields.assert_awaited_once_with(phase_id)
+
+
+@pytest.mark.anyio
+class TestDeleteFieldCondition:
+    async def test_success(self, client_session, mock_pipefy_client):
+        mock_pipefy_client.delete_field_condition.return_value = {"success": True}
+        async with client_session as session:
+            payload = await confirm_after_preview(
+                session, "delete_field_condition", {"condition_id": "cond-9"}
+            )
+        mock_pipefy_client.delete_field_condition.assert_awaited_once_with("cond-9")
+        assert payload["success"] is True
+        assert payload.get("message")

--- a/packages/mcp/tests/tools/test_field_conditions_tools_live.py
+++ b/packages/mcp/tests/tools/test_field_conditions_tools_live.py
@@ -31,6 +31,7 @@ from _shared.live_settings import pipefy_live_configured, require_live_creds
 
 from pipefy_mcp.server import build_pipefy_mcp_server
 from pipefy_mcp.settings import settings
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 # Building the app now resolves the Pipefy credential (the runtime wires its
 # client at construction), so this credential-dependent module skips itself
@@ -132,12 +133,11 @@ async def test_live_field_condition_tools_only_happy_path(extract_payload):
                 read_timeout_seconds=timedelta(seconds=120),
                 raise_exceptions=True,
             ) as session:
-                r_delete = await session.call_tool(
+                deleted = await confirm_after_preview(
+                    session,
                     "delete_field_condition",
                     {"condition_id": condition_id_created, "debug": True},
                 )
-        assert r_delete.is_error is False, r_delete
-        deleted = extract_payload(r_delete)
         assert deleted.get("success") is True, deleted
         deleted_successfully = True
     finally:
@@ -148,7 +148,8 @@ async def test_live_field_condition_tools_only_happy_path(extract_payload):
                     read_timeout_seconds=timedelta(seconds=120),
                     raise_exceptions=True,
                 ) as session:
-                    await session.call_tool(
+                    await confirm_after_preview(
+                        session,
                         "delete_field_condition",
                         {"condition_id": condition_id_created, "debug": True},
                     )

--- a/packages/mcp/tests/tools/test_knowledge_base_tools.py
+++ b/packages/mcp/tests/tools/test_knowledge_base_tools.py
@@ -16,6 +16,7 @@ from pipefy_sdk import (
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.knowledge_base_tools import KnowledgeBaseTools
 from tools.conftest import build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 PLAIN_TEXT_NODE = {
     "id": "kb-1",
@@ -243,22 +244,58 @@ async def test_delete_preview_without_confirm_does_not_delete(
 
 @pytest.mark.anyio
 async def test_delete_with_confirm_executes(
-    kb_session, mock_kb_client, unified_envelope, extract_payload
+    kb_session, mock_kb_client, unified_envelope
 ):
     mock_kb_client.delete_ai_knowledge_base_plain_text = AsyncMock(
         return_value={"success": True, "errors": []}
     )
     async with kb_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_ai_knowledge_base_plain_text",
             {"plain_text_id": "kb-1", "pipe_uuid": "pipe-uuid-1", "confirm": True},
         )
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is True
     mock_kb_client.delete_ai_knowledge_base_plain_text.assert_awaited_once_with(
         "kb-1", "pipe-uuid-1"
     )
+
+
+@pytest.mark.anyio
+async def test_delete_plain_text_rejects_token_when_pipe_uuid_differs(
+    kb_session, mock_kb_client, extract_payload
+):
+    mock_kb_client.delete_ai_knowledge_base_plain_text = AsyncMock(
+        return_value={"success": True, "errors": []}
+    )
+    async with kb_session as session:
+        preview = await session.call_tool(
+            "delete_ai_knowledge_base_plain_text",
+            {"plain_text_id": "kb-1", "pipe_uuid": "pipe-uuid-A"},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await session.call_tool(
+            "delete_ai_knowledge_base_plain_text",
+            {
+                "plain_text_id": "kb-1",
+                "pipe_uuid": "pipe-uuid-B",
+                "confirm": True,
+                "confirmation_token": token,
+            },
+        )
+        assert extract_payload(mismatch)["requires_confirmation"] is True
+        mock_kb_client.delete_ai_knowledge_base_plain_text.assert_not_awaited()
+
+        matched = await confirm_after_preview(
+            session,
+            "delete_ai_knowledge_base_plain_text",
+            {"plain_text_id": "kb-1", "pipe_uuid": "pipe-uuid-A"},
+        )
+
+    mock_kb_client.delete_ai_knowledge_base_plain_text.assert_awaited_once_with(
+        "kb-1", "pipe-uuid-A"
+    )
+    assert matched["success"] is True
 
 
 @pytest.mark.anyio
@@ -558,22 +595,58 @@ async def test_delete_document_preview_without_confirm(
 
 @pytest.mark.anyio
 async def test_delete_document_with_confirm_executes(
-    kb_session, mock_kb_client, unified_envelope, extract_payload
+    kb_session, mock_kb_client, unified_envelope
 ):
     mock_kb_client.delete_ai_knowledge_base_document = AsyncMock(
         return_value={"success": True, "errors": []}
     )
     async with kb_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_ai_knowledge_base_document",
             {"document_id": "kb-2", "pipe_uuid": "pipe-uuid-1", "confirm": True},
         )
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is True
     mock_kb_client.delete_ai_knowledge_base_document.assert_awaited_once_with(
         "kb-2", "pipe-uuid-1"
     )
+
+
+@pytest.mark.anyio
+async def test_delete_document_rejects_token_when_pipe_uuid_differs(
+    kb_session, mock_kb_client, extract_payload
+):
+    mock_kb_client.delete_ai_knowledge_base_document = AsyncMock(
+        return_value={"success": True, "errors": []}
+    )
+    async with kb_session as session:
+        preview = await session.call_tool(
+            "delete_ai_knowledge_base_document",
+            {"document_id": "kb-2", "pipe_uuid": "pipe-uuid-A"},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await session.call_tool(
+            "delete_ai_knowledge_base_document",
+            {
+                "document_id": "kb-2",
+                "pipe_uuid": "pipe-uuid-B",
+                "confirm": True,
+                "confirmation_token": token,
+            },
+        )
+        assert extract_payload(mismatch)["requires_confirmation"] is True
+        mock_kb_client.delete_ai_knowledge_base_document.assert_not_awaited()
+
+        matched = await confirm_after_preview(
+            session,
+            "delete_ai_knowledge_base_document",
+            {"document_id": "kb-2", "pipe_uuid": "pipe-uuid-A"},
+        )
+
+    mock_kb_client.delete_ai_knowledge_base_document.assert_awaited_once_with(
+        "kb-2", "pipe-uuid-A"
+    )
+    assert matched["success"] is True
 
 
 @pytest.mark.anyio
@@ -741,22 +814,58 @@ async def test_delete_data_lookup_preview_without_confirm(
 
 @pytest.mark.anyio
 async def test_delete_data_lookup_with_confirm_executes(
-    kb_session, mock_kb_client, unified_envelope, extract_payload
+    kb_session, mock_kb_client, unified_envelope
 ):
     mock_kb_client.delete_ai_knowledge_base_data_lookup = AsyncMock(
         return_value={"success": True, "errors": []}
     )
     async with kb_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_ai_knowledge_base_data_lookup",
             {"data_lookup_id": "kb-3", "pipe_uuid": "pipe-uuid-1", "confirm": True},
         )
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is True
     mock_kb_client.delete_ai_knowledge_base_data_lookup.assert_awaited_once_with(
         "kb-3", "pipe-uuid-1"
     )
+
+
+@pytest.mark.anyio
+async def test_delete_data_lookup_rejects_token_when_pipe_uuid_differs(
+    kb_session, mock_kb_client, extract_payload
+):
+    mock_kb_client.delete_ai_knowledge_base_data_lookup = AsyncMock(
+        return_value={"success": True, "errors": []}
+    )
+    async with kb_session as session:
+        preview = await session.call_tool(
+            "delete_ai_knowledge_base_data_lookup",
+            {"data_lookup_id": "kb-3", "pipe_uuid": "pipe-uuid-A"},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await session.call_tool(
+            "delete_ai_knowledge_base_data_lookup",
+            {
+                "data_lookup_id": "kb-3",
+                "pipe_uuid": "pipe-uuid-B",
+                "confirm": True,
+                "confirmation_token": token,
+            },
+        )
+        assert extract_payload(mismatch)["requires_confirmation"] is True
+        mock_kb_client.delete_ai_knowledge_base_data_lookup.assert_not_awaited()
+
+        matched = await confirm_after_preview(
+            session,
+            "delete_ai_knowledge_base_data_lookup",
+            {"data_lookup_id": "kb-3", "pipe_uuid": "pipe-uuid-A"},
+        )
+
+    mock_kb_client.delete_ai_knowledge_base_data_lookup.assert_awaited_once_with(
+        "kb-3", "pipe-uuid-A"
+    )
+    assert matched["success"] is True
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_llm_provider_tools.py
+++ b/packages/mcp/tests/tools/test_llm_provider_tools.py
@@ -12,6 +12,7 @@ from pipefy_sdk import PipefyClient, PipefyGraphQLError
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.llm_provider_tools import LlmProviderTools
 from tools.conftest import build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 BYOM_NODE = {
     "__typename": "LlmProvider",
@@ -513,37 +514,68 @@ async def test_delete_preview_without_confirm_does_not_delete(
 
 
 @pytest.mark.anyio
-async def test_delete_with_confirm_executes(
-    provider_session, mock_provider_client, extract_payload
-):
+async def test_delete_with_confirm_executes(provider_session, mock_provider_client):
     mock_provider_client.delete_llm_provider = AsyncMock(return_value={"success": True})
     async with provider_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_llm_provider",
             {"provider_id": "42", "organization_uuid": "org-uuid-1", "confirm": True},
         )
-    assert result.is_error is False
     mock_provider_client.delete_llm_provider.assert_awaited_once_with(
         "42", "org-uuid-1"
     )
-    assert extract_payload(result)["data"]["deleted_id"] == "42"
+    assert payload["data"]["deleted_id"] == "42"
 
 
 @pytest.mark.anyio
 async def test_delete_unconfirmed_by_api_is_tool_error(
-    provider_session, mock_provider_client, extract_payload
+    provider_session, mock_provider_client
 ):
     mock_provider_client.delete_llm_provider = AsyncMock(
         return_value={"success": False}
     )
     async with provider_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_llm_provider",
             {"provider_id": "42", "organization_uuid": "org-uuid-1", "confirm": True},
         )
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "did not confirm" in tool_error_message(payload)
+
+
+@pytest.mark.anyio
+async def test_delete_llm_provider_rejects_token_when_organization_uuid_differs(
+    provider_session, mock_provider_client, extract_payload
+):
+    mock_provider_client.delete_llm_provider = AsyncMock(return_value={"success": True})
+    async with provider_session as session:
+        preview = await session.call_tool(
+            "delete_llm_provider",
+            {"provider_id": "42", "organization_uuid": "org-A"},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await session.call_tool(
+            "delete_llm_provider",
+            {
+                "provider_id": "42",
+                "organization_uuid": "org-B",
+                "confirm": True,
+                "confirmation_token": token,
+            },
+        )
+        assert extract_payload(mismatch)["requires_confirmation"] is True
+        mock_provider_client.delete_llm_provider.assert_not_awaited()
+
+        matched = await confirm_after_preview(
+            session,
+            "delete_llm_provider",
+            {"provider_id": "42", "organization_uuid": "org-A"},
+        )
+
+    mock_provider_client.delete_llm_provider.assert_awaited_once_with("42", "org-A")
+    assert matched["success"] is True
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_member_tools.py
+++ b/packages/mcp/tests/tools/test_member_tools.py
@@ -12,6 +12,7 @@ from pipefy_sdk import PipefyClient, PipefyGraphQLError
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.member_tools import MemberTools
 from tools.conftest import build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 
 @pytest.fixture
@@ -378,28 +379,25 @@ async def test_invite_members_graphql_error(
 
 @pytest.mark.anyio
 async def test_remove_member_from_pipe_value_error_from_client(
-    member_session, mock_member_client, extract_payload
+    member_session, mock_member_client
 ):
     mock_member_client.remove_members_from_pipe.side_effect = ValueError(
         "pipe_id must be a numeric pipe ID or a pipe UUID, got 'bad'."
     )
 
     async with member_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "remove_member_from_pipe",
-            {"pipe_id": "bad", "user_ids": ["u1"], "confirm": True},
+            {"pipe_id": "bad", "user_ids": ["u1"]},
         )
 
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "pipe_id" in tool_error_message(payload)
 
 
 @pytest.mark.anyio
-async def test_remove_member_verified_all_removed(
-    member_session, mock_member_client, extract_payload
-):
+async def test_remove_member_verified_all_removed(member_session, mock_member_client):
     mock_member_client.remove_members_from_pipe.return_value = {
         "removeMembersFromPipe": {"success": True}
     }
@@ -420,24 +418,23 @@ async def test_remove_member_verified_all_removed(
     }
 
     async with member_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "remove_member_from_pipe",
-            {"pipe_id": "100", "user_ids": ["user-1", "user-2"], "confirm": True},
+            {"pipe_id": "100", "user_ids": ["user-1", "user-2"]},
         )
 
-    assert result.is_error is False
     mock_member_client.remove_members_from_pipe.assert_awaited_once_with(
         "100", ["user-1", "user-2"]
     )
     mock_member_client.get_pipe_members.assert_awaited_once_with("100")
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert "warning" not in payload
 
 
 @pytest.mark.anyio
 async def test_remove_member_warns_when_member_still_present(
-    member_session, mock_member_client, extract_payload
+    member_session, mock_member_client
 ):
     mock_member_client.remove_members_from_pipe.return_value = {
         "removeMembersFromPipe": {"success": True}
@@ -468,12 +465,12 @@ async def test_remove_member_warns_when_member_still_present(
     }
 
     async with member_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "remove_member_from_pipe",
-            {"pipe_id": "100", "user_ids": ["160654"], "confirm": True},
+            {"pipe_id": "100", "user_ids": ["160654"]},
         )
 
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert "warning" in payload
     assert "160654" in payload["warning"]
@@ -482,7 +479,7 @@ async def test_remove_member_warns_when_member_still_present(
 
 @pytest.mark.anyio
 async def test_remove_member_warns_when_uuid_still_present(
-    member_session, mock_member_client, extract_payload
+    member_session, mock_member_client
 ):
     """Verification matches user UUIDs too, not just numeric IDs."""
     mock_member_client.remove_members_from_pipe.return_value = {
@@ -505,12 +502,12 @@ async def test_remove_member_warns_when_uuid_still_present(
     }
 
     async with member_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "remove_member_from_pipe",
-            {"pipe_id": "100", "user_ids": ["abc-def-123"], "confirm": True},
+            {"pipe_id": "100", "user_ids": ["abc-def-123"]},
         )
 
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert "warning" in payload
     assert "abc-def-123" in payload["warning"]
@@ -518,27 +515,27 @@ async def test_remove_member_warns_when_uuid_still_present(
 
 @pytest.mark.anyio
 async def test_remove_member_skips_verification_for_non_numeric_pipe_id(
-    member_session, mock_member_client, extract_payload
+    member_session, mock_member_client
 ):
     mock_member_client.remove_members_from_pipe.return_value = {
         "removeMembersFromPipe": {"success": True}
     }
 
     async with member_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "remove_member_from_pipe",
-            {"pipe_id": "pipe-1", "user_ids": ["user-1"], "confirm": True},
+            {"pipe_id": "pipe-1", "user_ids": ["user-1"]},
         )
 
     mock_member_client.get_pipe_members.assert_not_awaited()
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert "warning" not in payload
 
 
 @pytest.mark.anyio
 async def test_remove_member_returns_success_when_verification_fails(
-    member_session, mock_member_client, extract_payload
+    member_session, mock_member_client
 ):
     """If get_pipe_members raises, don't fail the whole operation."""
     mock_member_client.remove_members_from_pipe.return_value = {
@@ -547,18 +544,18 @@ async def test_remove_member_returns_success_when_verification_fails(
     mock_member_client.get_pipe_members.side_effect = Exception("network error")
 
     async with member_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "remove_member_from_pipe",
-            {"pipe_id": "100", "user_ids": ["user-1"], "confirm": True},
+            {"pipe_id": "100", "user_ids": ["user-1"]},
         )
 
-    payload = extract_payload(result)
     assert payload["success"] is True
 
 
 @pytest.mark.anyio
 async def test_remove_member_coerces_int_user_ids_to_str(
-    member_session, mock_member_client, extract_payload
+    member_session, mock_member_client
 ):
     """Agent may re-serialize user_ids as ints on the confirm call."""
     mock_member_client.remove_members_from_pipe.return_value = {
@@ -567,12 +564,12 @@ async def test_remove_member_coerces_int_user_ids_to_str(
     mock_member_client.get_pipe_members.return_value = {"pipe": {"members": []}}
 
     async with member_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "remove_member_from_pipe",
-            {"pipe_id": "100", "user_ids": [307516938], "confirm": True},
+            {"pipe_id": "100", "user_ids": [307516938]},
         )
 
-    payload = extract_payload(result)
     assert payload["success"] is True
     mock_member_client.remove_members_from_pipe.assert_awaited_once_with(
         "100", ["307516938"]
@@ -581,20 +578,19 @@ async def test_remove_member_coerces_int_user_ids_to_str(
 
 @pytest.mark.anyio
 async def test_remove_member_from_pipe_graphql_error(
-    member_session, mock_member_client, extract_payload
+    member_session, mock_member_client
 ):
     mock_member_client.remove_members_from_pipe.side_effect = PipefyGraphQLError(
         [{"message": "forbidden"}]
     )
 
     async with member_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "remove_member_from_pipe",
-            {"pipe_id": "p1", "user_ids": ["u1"], "confirm": True},
+            {"pipe_id": "p1", "user_ids": ["u1"]},
         )
 
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "forbidden" in tool_error_message(payload)
 
@@ -670,6 +666,45 @@ async def test_remove_member_preview_does_not_call_mutation(
     assert payload.get("requires_confirmation") is True
     assert "1 member(s)" in payload["resource"]
     assert "pipe 100" in payload["resource"]
+
+
+@pytest.mark.anyio
+async def test_remove_member_rejects_token_when_user_ids_differ_same_length(
+    member_session, mock_member_client, extract_payload
+):
+    mock_member_client.remove_members_from_pipe.return_value = {
+        "removeMembersFromPipe": {"success": True}
+    }
+    mock_member_client.get_pipe_members.return_value = {"pipe": {"members": []}}
+
+    async with member_session as session:
+        preview = await session.call_tool(
+            "remove_member_from_pipe",
+            {"pipe_id": "100", "user_ids": ["1", "2"]},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await session.call_tool(
+            "remove_member_from_pipe",
+            {
+                "pipe_id": "100",
+                "user_ids": ["99", "100"],
+                "confirm": True,
+                "confirmation_token": token,
+            },
+        )
+        assert extract_payload(mismatch)["requires_confirmation"] is True
+        mock_member_client.remove_members_from_pipe.assert_not_awaited()
+
+        matched = await confirm_after_preview(
+            session,
+            "remove_member_from_pipe",
+            {"pipe_id": "100", "user_ids": ["1", "2"]},
+        )
+
+    mock_member_client.remove_members_from_pipe.assert_awaited_once_with(
+        "100", ["1", "2"]
+    )
+    assert matched["success"] is True
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -1107,6 +1107,38 @@ async def test_delete_phase_field_confirm_true_skips_enrichment(
 
 
 @pytest.mark.anyio
+async def test_delete_phase_field_confirm_omitting_advisory_phase_id_proceeds(
+    pipe_config_session, mock_pipe_config_client, extract_payload
+):
+    mock_pipe_config_client.delete_phase_field.return_value = {
+        "deletePhaseField": {"success": True},
+    }
+    mock_pipe_config_client.get_field_conditions.return_value = {
+        "phase": {"fieldConditions": []}
+    }
+
+    async with pipe_config_session as session:
+        preview = await session.call_tool(
+            "delete_phase_field",
+            {"field_id": 100, "phase_id": 50},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        result = await session.call_tool(
+            "delete_phase_field",
+            {
+                "field_id": 100,
+                "confirm": True,
+                "confirmation_token": token,
+            },
+        )
+
+    mock_pipe_config_client.delete_phase_field.assert_awaited_once_with(
+        "100", pipe_uuid=None
+    )
+    assert extract_payload(result)["success"] is True
+
+
+@pytest.mark.anyio
 async def test_delete_phase_field_success_with_string_slug(
     pipe_config_session, mock_pipe_config_client
 ):
@@ -1148,7 +1180,9 @@ async def test_delete_phase_field_rejects_token_when_pipe_uuid_differs(
                 "confirmation_token": token,
             },
         )
-        assert extract_payload(mismatch)["requires_confirmation"] is True
+        mismatch_payload = extract_payload(mismatch)
+        assert mismatch_payload["requires_confirmation"] is True
+        assert "expired" not in mismatch_payload["message"].lower()
         mock_pipe_config_client.delete_phase_field.assert_not_awaited()
 
         matched = await confirm_after_preview(

--- a/packages/mcp/tests/tools/test_pipe_config_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_config_tools.py
@@ -23,6 +23,7 @@ from pipefy_mcp.tools.pipe_config_tool_helpers import (
 )
 from pipefy_mcp.tools.pipe_config_tools import PipeConfigTools
 from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 
 @pytest.mark.unit
@@ -225,7 +226,7 @@ async def test_delete_pipe_preview_does_not_delete(
 
 @pytest.mark.anyio
 async def test_delete_pipe_confirm_calls_mutation(
-    pipe_config_session, mock_pipe_config_client, extract_payload
+    pipe_config_session, mock_pipe_config_client
 ):
     mock_pipe_config_client.get_pipe.return_value = {
         "pipe": {"id": "9", "name": "P1", "phases": []},
@@ -233,14 +234,9 @@ async def test_delete_pipe_confirm_calls_mutation(
     mock_pipe_config_client.delete_pipe.return_value = {"deletePipe": {"success": True}}
 
     async with pipe_config_session as session:
-        result = await session.call_tool(
-            "delete_pipe",
-            {"pipe_id": 9, "confirm": True},
-        )
+        payload = await confirm_after_preview(session, "delete_pipe", {"pipe_id": 9})
 
-    assert result.is_error is False
     mock_pipe_config_client.delete_pipe.assert_awaited_once_with("9")
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["pipe_id"] == "9"
 
@@ -401,20 +397,16 @@ async def test_update_phase_requires_at_least_one_attr(
 
 
 @pytest.mark.anyio
-async def test_delete_phase_success(
-    pipe_config_session, mock_pipe_config_client, extract_payload
-):
+async def test_delete_phase_success(pipe_config_session, mock_pipe_config_client):
     mock_pipe_config_client.delete_phase.return_value = {
         "deletePhase": {"success": True},
     }
 
     async with pipe_config_session as session:
-        result = await session.call_tool(
-            "delete_phase", {"phase_id": 55, "confirm": True}
-        )
+        payload = await confirm_after_preview(session, "delete_phase", {"phase_id": 55})
 
     mock_pipe_config_client.delete_phase.assert_awaited_once_with("55")
-    assert extract_payload(result)["success"] is True
+    assert payload["success"] is True
 
 
 @pytest.mark.anyio
@@ -459,9 +451,24 @@ async def test_delete_phase_confirm_true_skips_dependent_lookups(
         "deletePhase": {"success": True},
     }
     async with pipe_config_session as session:
+        preview = await session.call_tool(
+            "delete_phase",
+            {"phase_id": 55, "pipe_id": 1},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mock_pipe_config_client.get_field_conditions.reset_mock()
+        mock_pipe_config_client.get_automations.reset_mock()
+        mock_pipe_config_client.get_phase_cards_count.reset_mock()
+        mock_pipe_config_client.get_automation.reset_mock()
+        mock_pipe_config_client.get_phase_fields.reset_mock()
         result = await session.call_tool(
             "delete_phase",
-            {"phase_id": 55, "pipe_id": 1, "confirm": True},
+            {
+                "phase_id": 55,
+                "pipe_id": 1,
+                "confirm": True,
+                "confirmation_token": token,
+            },
         )
     assert extract_payload(result)["success"] is True
     mock_pipe_config_client.get_field_conditions.assert_not_called()
@@ -805,23 +812,20 @@ async def test_update_phase_field_rejects_blank_label(
 
 
 @pytest.mark.anyio
-async def test_delete_phase_field_success(
-    pipe_config_session, mock_pipe_config_client, extract_payload
-):
+async def test_delete_phase_field_success(pipe_config_session, mock_pipe_config_client):
     mock_pipe_config_client.delete_phase_field.return_value = {
         "deletePhaseField": {"success": True},
     }
 
     async with pipe_config_session as session:
-        result = await session.call_tool(
-            "delete_phase_field",
-            {"field_id": 100, "confirm": True},
+        payload = await confirm_after_preview(
+            session, "delete_phase_field", {"field_id": 100}
         )
 
     mock_pipe_config_client.delete_phase_field.assert_awaited_once_with(
         "100", pipe_uuid=None
     )
-    assert extract_payload(result)["success"] is True
+    assert payload["success"] is True
 
 
 @pytest.mark.anyio
@@ -1075,11 +1079,26 @@ async def test_delete_phase_field_confirm_true_skips_enrichment(
     mock_pipe_config_client.delete_phase_field.return_value = {
         "deletePhaseField": {"success": True},
     }
+    mock_pipe_config_client.get_field_conditions.return_value = {
+        "phase": {"fieldConditions": []}
+    }
 
     async with pipe_config_session as session:
+        preview = await session.call_tool(
+            "delete_phase_field",
+            {"field_id": 100, "phase_id": 50},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mock_pipe_config_client.get_field_conditions.reset_mock()
+        mock_pipe_config_client.get_phase_fields.reset_mock()
         result = await session.call_tool(
             "delete_phase_field",
-            {"field_id": 100, "phase_id": 50, "confirm": True},
+            {
+                "field_id": 100,
+                "phase_id": 50,
+                "confirm": True,
+                "confirmation_token": token,
+            },
         )
 
     mock_pipe_config_client.get_field_conditions.assert_not_called()
@@ -1089,6 +1108,25 @@ async def test_delete_phase_field_confirm_true_skips_enrichment(
 
 @pytest.mark.anyio
 async def test_delete_phase_field_success_with_string_slug(
+    pipe_config_session, mock_pipe_config_client
+):
+    mock_pipe_config_client.delete_phase_field.return_value = {
+        "deletePhaseField": {"success": True},
+    }
+
+    async with pipe_config_session as session:
+        payload = await confirm_after_preview(
+            session, "delete_phase_field", {"field_id": "detalhe_mcp"}
+        )
+
+    mock_pipe_config_client.delete_phase_field.assert_awaited_once_with(
+        "detalhe_mcp", pipe_uuid=None
+    )
+    assert payload["success"] is True
+
+
+@pytest.mark.anyio
+async def test_delete_phase_field_rejects_token_when_pipe_uuid_differs(
     pipe_config_session, mock_pipe_config_client, extract_payload
 ):
     mock_pipe_config_client.delete_phase_field.return_value = {
@@ -1096,15 +1134,33 @@ async def test_delete_phase_field_success_with_string_slug(
     }
 
     async with pipe_config_session as session:
-        result = await session.call_tool(
+        preview = await session.call_tool(
             "delete_phase_field",
-            {"field_id": "detalhe_mcp", "confirm": True},
+            {"field_id": "prioridade", "pipe_uuid": "A"},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await session.call_tool(
+            "delete_phase_field",
+            {
+                "field_id": "prioridade",
+                "pipe_uuid": "B",
+                "confirm": True,
+                "confirmation_token": token,
+            },
+        )
+        assert extract_payload(mismatch)["requires_confirmation"] is True
+        mock_pipe_config_client.delete_phase_field.assert_not_awaited()
+
+        matched = await confirm_after_preview(
+            session,
+            "delete_phase_field",
+            {"field_id": "prioridade", "pipe_uuid": "A"},
         )
 
     mock_pipe_config_client.delete_phase_field.assert_awaited_once_with(
-        "detalhe_mcp", pipe_uuid=None
+        "prioridade", pipe_uuid="A"
     )
-    assert extract_payload(result)["success"] is True
+    assert matched["success"] is True
 
 
 @pytest.mark.anyio
@@ -1202,20 +1258,16 @@ async def test_update_label_empty_color_returns_error(
 
 
 @pytest.mark.anyio
-async def test_delete_label_success(
-    pipe_config_session, mock_pipe_config_client, extract_payload
-):
+async def test_delete_label_success(pipe_config_session, mock_pipe_config_client):
     mock_pipe_config_client.delete_label.return_value = {
         "deleteLabel": {"success": True},
     }
 
     async with pipe_config_session as session:
-        result = await session.call_tool(
-            "delete_label", {"label_id": 40, "confirm": True}
-        )
+        payload = await confirm_after_preview(session, "delete_label", {"label_id": 40})
 
     mock_pipe_config_client.delete_label.assert_awaited_once_with("40")
-    assert extract_payload(result)["success"] is True
+    assert payload["success"] is True
 
 
 @pytest.mark.anyio
@@ -1346,11 +1398,25 @@ async def test_delete_label_confirm_true_skips_resolver(
     mock_pipe_config_client.delete_label.return_value = {
         "deleteLabel": {"success": True},
     }
+    mock_pipe_config_client.get_cards.return_value = {
+        "cards": {"edges": [], "pageInfo": {"hasNextPage": False}}
+    }
 
     async with pipe_config_session as session:
+        preview = await session.call_tool(
+            "delete_label",
+            {"label_id": 40, "pipe_id": 2},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mock_pipe_config_client.get_cards.reset_mock()
         result = await session.call_tool(
             "delete_label",
-            {"label_id": 40, "pipe_id": 2, "confirm": True},
+            {
+                "label_id": 40,
+                "pipe_id": 2,
+                "confirm": True,
+                "confirmation_token": token,
+            },
         )
 
     mock_pipe_config_client.get_cards.assert_not_called()
@@ -1475,16 +1541,13 @@ async def test_update_phase_get_phase_fields_error_returns_failure__no_integrati
 
 @pytest.mark.anyio
 async def test_delete_phase_graphql_error_returns_failure__no_integration(
-    pipe_config_session, mock_pipe_config_client, extract_payload
+    pipe_config_session, mock_pipe_config_client
 ):
     mock_pipe_config_client.delete_phase.side_effect = PipefyGraphQLError(
         [{"message": "Cannot delete"}]
     )
     async with pipe_config_session as session:
-        result = await session.call_tool(
-            "delete_phase", {"phase_id": 1, "confirm": True}
-        )
-    payload = extract_payload(result)
+        payload = await confirm_after_preview(session, "delete_phase", {"phase_id": 1})
     assert payload["success"] is False
     assert "Cannot delete" in tool_error_message(payload)
 
@@ -1525,24 +1588,22 @@ async def test_update_phase_field_graphql_error_returns_failure__no_integration(
 
 @pytest.mark.anyio
 async def test_delete_phase_field_graphql_error_returns_failure__no_integration(
-    pipe_config_session, mock_pipe_config_client, extract_payload
+    pipe_config_session, mock_pipe_config_client
 ):
     mock_pipe_config_client.delete_phase_field.side_effect = PipefyGraphQLError(
         [{"message": "Nope"}]
     )
     async with pipe_config_session as session:
-        result = await session.call_tool(
-            "delete_phase_field",
-            {"field_id": 100, "confirm": True},
+        payload = await confirm_after_preview(
+            session, "delete_phase_field", {"field_id": 100}
         )
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "Nope" in tool_error_message(payload)
 
 
 @pytest.mark.anyio
 async def test_delete_phase_field_cascade_diagnosis_with_pipe_id(
-    pipe_config_session, mock_pipe_config_client, extract_payload
+    pipe_config_session, mock_pipe_config_client
 ):
     """When the parent phase was deleted earlier in the session, Pipefy returns
     a generic ``INTERNAL_SERVER_ERROR``. With ``pipe_id`` supplied, the tool
@@ -1567,15 +1628,14 @@ async def test_delete_phase_field_cascade_diagnosis_with_pipe_id(
         ],
     }
     async with pipe_config_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_phase_field",
             {
                 "field_id": "gone_field",
-                "confirm": True,
                 "pipe_id": "77",
             },
         )
-    payload = extract_payload(result)
     assert payload["success"] is False
     msg = tool_error_message(payload)
     assert "no longer exists" in msg
@@ -1584,7 +1644,7 @@ async def test_delete_phase_field_cascade_diagnosis_with_pipe_id(
 
 @pytest.mark.anyio
 async def test_delete_phase_field_cascade_diagnosis_field_still_exists(
-    pipe_config_session, mock_pipe_config_client, extract_payload
+    pipe_config_session, mock_pipe_config_client
 ):
     """If the field is still present somewhere, the error is NOT a cascade —
     fall back to the generic upstream error instead of misleading the caller."""
@@ -1604,15 +1664,14 @@ async def test_delete_phase_field_cascade_diagnosis_field_still_exists(
         "fields": [{"id": "still_here", "uuid": "abc"}],
     }
     async with pipe_config_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_phase_field",
             {
                 "field_id": "still_here",
-                "confirm": True,
                 "pipe_id": "77",
             },
         )
-    payload = extract_payload(result)
     assert payload["success"] is False
     msg = tool_error_message(payload)
     assert "no longer exists" not in msg
@@ -1620,7 +1679,7 @@ async def test_delete_phase_field_cascade_diagnosis_field_still_exists(
 
 @pytest.mark.anyio
 async def test_delete_phase_field_cascade_diagnosis_skipped_without_pipe_id(
-    pipe_config_session, mock_pipe_config_client, extract_payload
+    pipe_config_session, mock_pipe_config_client
 ):
     """Without ``pipe_id`` the tool cannot diagnose; it preserves the raw error
     and does NOT perform the extra read-backs."""
@@ -1633,13 +1692,11 @@ async def test_delete_phase_field_cascade_diagnosis_skipped_without_pipe_id(
         ]
     )
     async with pipe_config_session as session:
-        result = await session.call_tool(
-            "delete_phase_field",
-            {"field_id": "any_field", "confirm": True},
+        payload = await confirm_after_preview(
+            session, "delete_phase_field", {"field_id": "any_field"}
         )
     mock_pipe_config_client.get_pipe.assert_not_called()
     mock_pipe_config_client.get_phase_fields.assert_not_called()
-    payload = extract_payload(result)
     assert payload["success"] is False
 
 
@@ -1679,16 +1736,13 @@ async def test_update_label_graphql_error_returns_failure__no_integration(
 
 @pytest.mark.anyio
 async def test_delete_label_graphql_error_returns_failure__no_integration(
-    pipe_config_session, mock_pipe_config_client, extract_payload
+    pipe_config_session, mock_pipe_config_client
 ):
     mock_pipe_config_client.delete_label.side_effect = PipefyGraphQLError(
         [{"message": "Still in use"}]
     )
     async with pipe_config_session as session:
-        result = await session.call_tool(
-            "delete_label", {"label_id": 40, "confirm": True}
-        )
-    payload = extract_payload(result)
+        payload = await confirm_after_preview(session, "delete_label", {"label_id": 40})
     assert payload["success"] is False
     assert "Still in use" in tool_error_message(payload)
 
@@ -2360,39 +2414,33 @@ async def test_update_field_condition_error(
 
 @pytest.mark.anyio
 async def test_delete_field_condition_success(
-    pipe_config_session, mock_pipe_config_client, extract_payload
+    pipe_config_session, mock_pipe_config_client
 ):
     mock_pipe_config_client.delete_field_condition.return_value = {"success": True}
 
     async with pipe_config_session as session:
-        result = await session.call_tool(
-            "delete_field_condition",
-            {"condition_id": "cond-9", "confirm": True},
+        payload = await confirm_after_preview(
+            session, "delete_field_condition", {"condition_id": "cond-9"}
         )
 
-    assert result.is_error is False
     mock_pipe_config_client.delete_field_condition.assert_awaited_once_with("cond-9")
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert payload.get("message")
 
 
 @pytest.mark.anyio
 async def test_delete_field_condition_error(
-    pipe_config_session, mock_pipe_config_client, extract_payload
+    pipe_config_session, mock_pipe_config_client
 ):
     mock_pipe_config_client.delete_field_condition.side_effect = PipefyGraphQLError(
         [{"message": "Forbidden"}]
     )
 
     async with pipe_config_session as session:
-        result = await session.call_tool(
-            "delete_field_condition",
-            {"condition_id": "cond-x", "confirm": True},
+        payload = await confirm_after_preview(
+            session, "delete_field_condition", {"condition_id": "cond-x"}
         )
 
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "Forbidden" in tool_error_message(payload)
 

--- a/packages/mcp/tests/tools/test_pipe_tools.py
+++ b/packages/mcp/tests/tools/test_pipe_tools.py
@@ -28,6 +28,21 @@ from pipefy_mcp.tools.pipe_tool_helpers import (
 )
 from pipefy_mcp.tools.pipe_tools import FIND_CARDS_RESPONSE_KEY, PipeTools
 from tools.conftest import build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
+
+
+def _assert_destructive_preview(payload, *, resource):
+    assert payload["success"] is False
+    assert payload["requires_confirmation"] is True
+    assert payload["resource"] == resource
+    message = payload["message"]
+    assert "confirm=True" in message
+    assert message.index("explicit approval") < message.index("confirm=True")
+    token = payload["confirmation_token"]
+    assert isinstance(token, str)
+    assert token.startswith("v1.")
+    assert token != "v1."
+
 
 # =============================================================================
 # Fixtures
@@ -1187,41 +1202,32 @@ class TestDirectToolCalls:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         """delete_comment with valid comment_id returns success payload."""
         async with client_session as session:
-            result = await session.call_tool(
-                "delete_comment",
-                {"comment_id": 456, "confirm": True},
+            payload = await confirm_after_preview(
+                session, "delete_comment", {"comment_id": 456}
             )
-        assert result.is_error is False
         mock_pipefy_client.delete_comment.assert_called_once_with("456")
-        payload = extract_payload(result)
         assert payload == {"success": True}
 
     async def test_delete_comment_zero_id_coerces_to_string_and_calls_api(
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         """delete_comment with comment_id=0 coerces to '0' via PipefyId and calls the API."""
         async with client_session as session:
-            result = await session.call_tool(
-                "delete_comment",
-                {"comment_id": 0, "confirm": True},
+            payload = await confirm_after_preview(
+                session, "delete_comment", {"comment_id": 0}
             )
-        assert result.is_error is False
         mock_pipefy_client.delete_comment.assert_called_once_with("0")
-        payload = extract_payload(result)
         assert payload == {"success": True}
 
     async def test_delete_comment_api_exception_returns_mapped_error_payload(
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         """When delete_comment API raises, tool returns error payload with friendly message."""
 
@@ -1234,13 +1240,10 @@ class TestDirectToolCalls:
             ]
         )
         async with client_session as session:
-            result = await session.call_tool(
-                "delete_comment",
-                {"comment_id": 12345, "confirm": True},
+            payload = await confirm_after_preview(
+                session, "delete_comment", {"comment_id": 12345}
             )
-        assert result.is_error is False
         mock_pipefy_client.delete_comment.assert_called_once_with("12345")
-        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
         assert "permission" in tool_error_message(payload).lower()
@@ -1249,7 +1252,6 @@ class TestDirectToolCalls:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ):
         """When delete_comment API returns not found, tool returns friendly error payload."""
 
@@ -1257,13 +1259,10 @@ class TestDirectToolCalls:
             [{"message": "Record not found", "extensions": {}}]
         )
         async with client_session as session:
-            result = await session.call_tool(
-                "delete_comment",
-                {"comment_id": 99999, "confirm": True},
+            payload = await confirm_after_preview(
+                session, "delete_comment", {"comment_id": 99999}
             )
-        assert result.is_error is False
         mock_pipefy_client.delete_comment.assert_called_once_with("99999")
-        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
         assert "comment" in tool_error_message(
@@ -1276,18 +1275,9 @@ class TestDirectToolCalls:
         mock_pipefy_client,
         extract_payload,
     ):
-        """Destructive guard: default returns preview; confirm=True runs delete (step 2)."""
+        """Destructive guard: default returns preview; confirm=True with token runs delete."""
         comment_id = 42
         resource = f"comment (ID: {comment_id})"
-        expected_preview = {
-            "success": False,
-            "requires_confirmation": True,
-            "resource": resource,
-            "message": (
-                f"⚠️ You are about to permanently delete {resource}. "
-                "This action is irreversible. Set 'confirm=True' to proceed."
-            ),
-        }
 
         async with client_session as session:
             preview = await session.call_tool(
@@ -1296,11 +1286,16 @@ class TestDirectToolCalls:
             )
             assert preview.is_error is False
             mock_pipefy_client.delete_comment.assert_not_called()
-            assert extract_payload(preview) == expected_preview
+            preview_payload = extract_payload(preview)
+            _assert_destructive_preview(preview_payload, resource=resource)
 
             result = await session.call_tool(
                 "delete_comment",
-                {"comment_id": comment_id, "confirm": True},
+                {
+                    "comment_id": comment_id,
+                    "confirm": True,
+                    "confirmation_token": preview_payload["confirmation_token"],
+                },
             )
         assert result.is_error is False
         mock_pipefy_client.delete_comment.assert_called_once_with(str(comment_id))
@@ -2098,22 +2093,15 @@ class TestDeleteCardTool:
             mock_pipefy_client.delete_card.assert_not_called()
 
             payload = extract_payload(result)
-            assert payload == {
-                "success": False,
-                "requires_confirmation": True,
-                "resource": "card 'Test Card' (ID: 12345) from pipe 'Test Pipe'",
-                "message": (
-                    "⚠️ You are about to permanently delete "
-                    "card 'Test Card' (ID: 12345) from pipe 'Test Pipe'. "
-                    "This action is irreversible. Set 'confirm=True' to proceed."
-                ),
-            }
+            _assert_destructive_preview(
+                payload,
+                resource="card 'Test Card' (ID: 12345) from pipe 'Test Pipe'",
+            )
 
     async def test_confirm_true_accepts_string_card_id(
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ) -> None:
         """String card_id is accepted (GraphQL IDs are strings)."""
         mock_pipefy_client.get_card.return_value = {
@@ -2122,15 +2110,11 @@ class TestDeleteCardTool:
         mock_pipefy_client.delete_card.return_value = {"deleteCard": {"success": True}}
 
         async with client_session as session:
-            result = await session.call_tool(
-                "delete_card",
-                {"card_id": "12345", "confirm": True},
+            payload = await confirm_after_preview(
+                session, "delete_card", {"card_id": "12345"}
             )
 
-        assert result.is_error is False
-        mock_pipefy_client.get_card.assert_called_once_with("12345")
         mock_pipefy_client.delete_card.assert_called_once_with("12345")
-        payload = extract_payload(result)
         assert payload["success"] is True
 
     @pytest.mark.parametrize(
@@ -2160,16 +2144,10 @@ class TestDeleteCardTool:
             mock_pipefy_client.delete_card.assert_not_called()
 
             payload = extract_payload(result)
-            assert payload == {
-                "success": False,
-                "requires_confirmation": True,
-                "resource": "card 'Test Card' (ID: 12345) from pipe 'Test Pipe'",
-                "message": (
-                    "⚠️ You are about to permanently delete "
-                    "card 'Test Card' (ID: 12345) from pipe 'Test Pipe'. "
-                    "This action is irreversible. Set 'confirm=True' to proceed."
-                ),
-            }
+            _assert_destructive_preview(
+                payload,
+                resource="card 'Test Card' (ID: 12345) from pipe 'Test Pipe'",
+            )
 
     async def test_invalid_card_id_returns_error(
         self,
@@ -2236,7 +2214,6 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ) -> None:
         """Test delete_card tool maps PERMISSION_DENIED GraphQL exception to friendly message."""
 
@@ -2259,15 +2236,12 @@ class TestDeleteCardTool:
         mock_pipefy_client.delete_card.side_effect = error
 
         async with client_session as session:
-            result = await session.call_tool(
-                "delete_card",
-                {"card_id": 12345, "confirm": True},
+            payload = await confirm_after_preview(
+                session, "delete_card", {"card_id": 12345}
             )
 
-            assert result.is_error is False
             mock_pipefy_client.delete_card.assert_called_once_with("12345")
 
-            payload = extract_payload(result)
             expected_payload = cast(
                 DeleteCardErrorPayload,
                 tool_error(
@@ -2280,7 +2254,6 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ) -> None:
         """Test delete_card tool handles API returning success=False."""
         mock_pipefy_client.get_card.return_value = {
@@ -2294,15 +2267,12 @@ class TestDeleteCardTool:
         mock_pipefy_client.delete_card.return_value = {"deleteCard": {"success": False}}
 
         async with client_session as session:
-            result = await session.call_tool(
-                "delete_card",
-                {"card_id": 12345, "confirm": True},
+            payload = await confirm_after_preview(
+                session, "delete_card", {"card_id": 12345}
             )
 
-            assert result.is_error is False
             mock_pipefy_client.delete_card.assert_called_once_with("12345")
 
-            payload = extract_payload(result)
             expected_payload = cast(
                 DeleteCardErrorPayload,
                 tool_error(
@@ -2320,23 +2290,19 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ) -> None:
-        """With confirm=True, delete runs without elicitation even if client supports it."""
+        """With confirm=True and a preview token, delete runs without elicitation."""
         mock_pipefy_client.get_card.return_value = {
             "card": {"id": "12345", "title": "Test Card", "pipe": {"name": "Test Pipe"}}
         }
         mock_pipefy_client.delete_card.return_value = {"deleteCard": {"success": True}}
 
         async with client_session as session:
-            result = await session.call_tool(
-                "delete_card",
-                {"card_id": 12345, "confirm": True},
+            payload = await confirm_after_preview(
+                session, "delete_card", {"card_id": 12345}
             )
 
-        assert result.is_error is False
         mock_pipefy_client.delete_card.assert_called_once_with("12345")
-        payload = extract_payload(result)
         assert payload["success"] is True
 
     @pytest.mark.parametrize(
@@ -2397,7 +2363,6 @@ class TestDeleteCardTool:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ) -> None:
         """When debug=True and client raises, error message includes codes and correlation_id."""
 
@@ -2414,11 +2379,9 @@ class TestDeleteCardTool:
         }
         mock_pipefy_client.delete_card.side_effect = error
         async with client_session as session:
-            result = await session.call_tool(
-                "delete_card", {"card_id": 12345, "confirm": True, "debug": True}
+            payload = await confirm_after_preview(
+                session, "delete_card", {"card_id": 12345, "debug": True}
             )
-        assert result.is_error is False
-        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
         assert "codes=" in tool_error_message(
@@ -2553,39 +2516,28 @@ class TestDeleteCardRelation:
     ) -> None:
         child_id, parent_id, source_id = 1, 2, 3
         resource = f"card relation (child: {child_id}, parent: {parent_id}, source: {source_id})"
-        expected_preview = {
-            "success": False,
-            "requires_confirmation": True,
-            "resource": resource,
-            "message": (
-                f"⚠️ You are about to permanently delete {resource}. "
-                "This action is irreversible. Set 'confirm=True' to proceed."
-            ),
+        relation_args = {
+            "child_id": child_id,
+            "parent_id": parent_id,
+            "source_id": source_id,
         }
         mock_pipefy_client.delete_card_relation.return_value = {
             "deleteCardRelation": {"success": True}
         }
 
         async with client_session as session:
-            preview = await session.call_tool(
-                "delete_card_relation",
-                {
-                    "child_id": child_id,
-                    "parent_id": parent_id,
-                    "source_id": source_id,
-                },
-            )
+            preview = await session.call_tool("delete_card_relation", relation_args)
             assert preview.is_error is False
             mock_pipefy_client.delete_card_relation.assert_not_called()
-            assert extract_payload(preview) == expected_preview
+            preview_payload = extract_payload(preview)
+            _assert_destructive_preview(preview_payload, resource=resource)
 
             result = await session.call_tool(
                 "delete_card_relation",
                 {
-                    "child_id": child_id,
-                    "parent_id": parent_id,
-                    "source_id": source_id,
+                    **relation_args,
                     "confirm": True,
+                    "confirmation_token": preview_payload["confirmation_token"],
                 },
             )
         assert result.is_error is False
@@ -2600,7 +2552,6 @@ class TestDeleteCardRelation:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ) -> None:
         mock_pipefy_client.delete_card_relation.side_effect = PipefyGraphQLError(
             [
@@ -2611,17 +2562,15 @@ class TestDeleteCardRelation:
             ]
         )
         async with client_session as session:
-            result = await session.call_tool(
+            payload = await confirm_after_preview(
+                session,
                 "delete_card_relation",
                 {
                     "child_id": 10,
                     "parent_id": 20,
                     "source_id": 30,
-                    "confirm": True,
                 },
             )
-        assert result.is_error is False
-        payload = extract_payload(result)
         assert payload["success"] is False
         assert "error" in payload
 
@@ -2629,23 +2578,20 @@ class TestDeleteCardRelation:
         self,
         client_session,
         mock_pipefy_client,
-        extract_payload,
     ) -> None:
         mock_pipefy_client.delete_card_relation = AsyncMock(
             return_value={"deleteCardRelation": {"success": False}}
         )
         async with client_session as session:
-            result = await session.call_tool(
+            payload = await confirm_after_preview(
+                session,
                 "delete_card_relation",
                 {
                     "child_id": "a",
                     "parent_id": "b",
                     "source_id": "c",
-                    "confirm": True,
                 },
             )
-        assert result.is_error is False
-        payload = extract_payload(result)
         assert payload["success"] is False
         assert "did not succeed" in tool_error_message(payload).lower()
 
@@ -3173,7 +3119,7 @@ class TestElicitationWithoutABackChannel:
     ],
 )
 async def test_comment_and_card_mutations_emit_unstructured_content(
-    client_session, mock_pipefy_client, tool_name, args, prep
+    client_session, mock_pipefy_client, tool_name, args, prep, extract_payload
 ):
     """Tools keep their TypedDict return hints for callers, but
     ``structured_output=False`` prevents the ``{"result": {...}}`` wrap that
@@ -3188,7 +3134,18 @@ async def test_comment_and_card_mutations_emit_unstructured_content(
         }
         mock_pipefy_client.delete_card.return_value = {"deleteCard": {"success": True}}
     async with client_session as session:
-        result = await session.call_tool(tool_name, args)
+        call_args = args
+        if args.get("confirm"):
+            preview_args = {
+                key: value for key, value in args.items() if key != "confirm"
+            }
+            preview = extract_payload(await session.call_tool(tool_name, preview_args))
+            call_args = {
+                **preview_args,
+                "confirm": True,
+                "confirmation_token": preview["confirmation_token"],
+            }
+        result = await session.call_tool(tool_name, call_args)
     assert result.is_error is False
     # The tool body returns a plain success dict; structured_output=False
     # means no structuredContent is emitted on the MCP protocol side.

--- a/packages/mcp/tests/tools/test_portal_tools.py
+++ b/packages/mcp/tests/tools/test_portal_tools.py
@@ -17,6 +17,7 @@ from pipefy_sdk.exceptions import PortalPermissionError
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.portal_tools import PortalTools
 from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 _PORTAL_LIST_NODE = {
     "id": "portal-uuid-1",
@@ -632,63 +633,58 @@ async def test_delete_portal_preview_does_not_delete(
 
 
 @pytest.mark.anyio
-async def test_delete_portal_success(
-    portal_session, mock_portal_client, extract_payload
-):
+async def test_delete_portal_success(portal_session, mock_portal_client):
     mock_portal_client.delete_portal = AsyncMock(
         return_value={"deleteInterface": {"success": True}}
     )
 
     async with portal_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_portal",
             {"portal_uuid": "portal-to-delete", "confirm": True},
         )
 
-    assert result.is_error is False
     mock_portal_client.delete_portal.assert_awaited_once_with("portal-to-delete")
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["data"]["deleteInterface"]["success"] is True
 
 
 @pytest.mark.anyio
 async def test_delete_portal_fails_when_success_false(
-    portal_session, mock_portal_client, extract_payload
+    portal_session, mock_portal_client
 ):
     mock_portal_client.delete_portal = AsyncMock(
         return_value={"deleteInterface": {"success": False}}
     )
 
     async with portal_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_portal",
             {"portal_uuid": "portal-to-delete", "confirm": True},
         )
 
-    assert result.is_error is False
     mock_portal_client.delete_portal.assert_awaited_once_with("portal-to-delete")
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "failed to delete portal" in tool_error_message(payload).lower()
 
 
 @pytest.mark.anyio
 async def test_delete_portal_permission_denied_returns_actionable_error(
-    portal_session, mock_portal_client, extract_payload
+    portal_session, mock_portal_client
 ):
     mock_portal_client.delete_portal = AsyncMock(
         side_effect=ValueError(_PORTAL_PERMISSION_DENIED_MSG)
     )
 
     async with portal_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_portal",
             {"portal_uuid": "portal-to-delete", "confirm": True},
         )
 
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is False
     message = tool_error_message(payload).lower()
     assert "create_portal" in message or "manage_portals" in message
@@ -904,15 +900,14 @@ async def test_delete_portal_page_preview_does_not_delete(
 
 
 @pytest.mark.anyio
-async def test_delete_portal_page_success(
-    portal_session, mock_portal_client, extract_payload
-):
+async def test_delete_portal_page_success(portal_session, mock_portal_client):
     mock_portal_client.delete_portal_page = AsyncMock(
         return_value={"deletePage": {"success": True}}
     )
 
     async with portal_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_portal_page",
             {
                 "portal_uuid": _PORTAL_UUID,
@@ -921,25 +916,24 @@ async def test_delete_portal_page_success(
             },
         )
 
-    assert result.is_error is False
     mock_portal_client.delete_portal_page.assert_awaited_once_with(
         _PORTAL_UUID, _PAGE_UUID
     )
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["data"]["deletePage"]["success"] is True
 
 
 @pytest.mark.anyio
 async def test_delete_portal_page_fails_when_success_false(
-    portal_session, mock_portal_client, extract_payload
+    portal_session, mock_portal_client
 ):
     mock_portal_client.delete_portal_page = AsyncMock(
         return_value={"deletePage": {"success": False}}
     )
 
     async with portal_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_portal_page",
             {
                 "portal_uuid": _PORTAL_UUID,
@@ -948,8 +942,6 @@ async def test_delete_portal_page_fails_when_success_false(
             },
         )
 
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "failed to delete" in tool_error_message(payload).lower()
 
@@ -1409,15 +1401,14 @@ async def test_delete_portal_element_preview_does_not_delete(
 
 
 @pytest.mark.anyio
-async def test_delete_portal_element_success(
-    portal_session, mock_portal_client, extract_payload
-):
+async def test_delete_portal_element_success(portal_session, mock_portal_client):
     mock_portal_client.delete_portal_element = AsyncMock(
         return_value={"deleteElement": {"success": True}}
     )
 
     async with portal_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_portal_element",
             {
                 "element_id": _ELEMENT_UUID,
@@ -1426,25 +1417,24 @@ async def test_delete_portal_element_success(
             },
         )
 
-    assert result.is_error is False
     mock_portal_client.delete_portal_element.assert_awaited_once_with(
         _ELEMENT_UUID, _PAGE_UUID
     )
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["data"]["deleteElement"]["success"] is True
 
 
 @pytest.mark.anyio
 async def test_delete_portal_element_fails_when_success_false(
-    portal_session, mock_portal_client, extract_payload
+    portal_session, mock_portal_client
 ):
     mock_portal_client.delete_portal_element = AsyncMock(
         return_value={"deleteElement": {"success": False}}
     )
 
     async with portal_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_portal_element",
             {
                 "element_id": _ELEMENT_UUID,
@@ -1453,8 +1443,6 @@ async def test_delete_portal_element_fails_when_success_false(
             },
         )
 
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "failed to delete" in tool_error_message(payload).lower()
 
@@ -1832,10 +1820,13 @@ async def test_sub_portal_internal_api_permission_denied_returns_actionable_erro
     )
 
     async with portal_session as session:
-        result = await session.call_tool(tool_name, tool_args)
+        if tool_args.get("confirm"):
+            payload = await confirm_after_preview(session, tool_name, tool_args)
+        else:
+            result = await session.call_tool(tool_name, tool_args)
+            assert result.is_error is False
+            payload = extract_payload(result)
 
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is False
     message = tool_error_message(payload).lower()
     assert "create_portal" in message or "manage_portals" in message
@@ -1932,15 +1923,14 @@ async def test_delete_sub_portal_element_preview_does_not_delete(
 
 
 @pytest.mark.anyio
-async def test_delete_sub_portal_element_success(
-    portal_session, mock_portal_client, extract_payload
-):
+async def test_delete_sub_portal_element_success(portal_session, mock_portal_client):
     mock_portal_client.delete_sub_portal_element = AsyncMock(
         return_value={"deleteSubPortalElement": {"success": True}}
     )
 
     async with portal_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_sub_portal_element",
             {
                 "portal_uuid": _MAIN_PORTAL_UUID,
@@ -1949,26 +1939,25 @@ async def test_delete_sub_portal_element_success(
             },
         )
 
-    assert result.is_error is False
     mock_portal_client.delete_sub_portal_element.assert_awaited_once_with(
         _MAIN_PORTAL_UUID,
         _FORMS_ELEMENT_ID,
     )
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["data"]["deleteSubPortalElement"]["success"] is True
 
 
 @pytest.mark.anyio
 async def test_delete_sub_portal_element_fails_when_success_false(
-    portal_session, mock_portal_client, extract_payload
+    portal_session, mock_portal_client
 ):
     mock_portal_client.delete_sub_portal_element = AsyncMock(
         return_value={"deleteSubPortalElement": {"success": False}}
     )
 
     async with portal_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_sub_portal_element",
             {
                 "portal_uuid": _MAIN_PORTAL_UUID,
@@ -1977,8 +1966,6 @@ async def test_delete_sub_portal_element_fails_when_success_false(
             },
         )
 
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "failed" in tool_error_message(payload).lower()
 
@@ -2015,42 +2002,38 @@ async def test_delete_sub_portal_preview_does_not_delete(
 
 
 @pytest.mark.anyio
-async def test_delete_sub_portal_success(
-    portal_session, mock_portal_client, extract_payload
-):
+async def test_delete_sub_portal_success(portal_session, mock_portal_client):
     mock_portal_client.delete_sub_portal = AsyncMock(
         return_value={"deleteSubPortalInterface": {"success": True}}
     )
 
     async with portal_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_sub_portal",
             {"sub_portal_uuid": _SUB_PORTAL_UUID, "confirm": True},
         )
 
-    assert result.is_error is False
     mock_portal_client.delete_sub_portal.assert_awaited_once_with(_SUB_PORTAL_UUID)
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["data"]["deleteSubPortalInterface"]["success"] is True
 
 
 @pytest.mark.anyio
 async def test_delete_sub_portal_fails_when_success_false(
-    portal_session, mock_portal_client, extract_payload
+    portal_session, mock_portal_client
 ):
     mock_portal_client.delete_sub_portal = AsyncMock(
         return_value={"deleteSubPortalInterface": {"success": False}}
     )
 
     async with portal_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_sub_portal",
             {"sub_portal_uuid": _SUB_PORTAL_UUID, "confirm": True},
         )
 
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "failed" in tool_error_message(payload).lower()
 

--- a/packages/mcp/tests/tools/test_relation_tools.py
+++ b/packages/mcp/tests/tools/test_relation_tools.py
@@ -12,6 +12,7 @@ from pipefy_sdk import PipefyClient, PipefyGraphQLError
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.relation_tools import RelationTools
 from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 
 @pytest.fixture
@@ -249,40 +250,39 @@ async def test_update_pipe_relation_graphql_error(
 
 
 @pytest.mark.anyio
-async def test_delete_pipe_relation_success(
-    relation_session, mock_relation_client, extract_payload
-):
+async def test_delete_pipe_relation_success(relation_session, mock_relation_client):
     mock_relation_client.delete_pipe_relation.return_value = {
         "deletePipeRelation": {"success": True},
     }
 
     async with relation_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_pipe_relation",
             {"relation_id": 100, "confirm": True},
         )
 
-    assert result.is_error is False
     mock_relation_client.delete_pipe_relation.assert_awaited_once_with("100")
-    assert extract_payload(result)["success"] is True
+    assert payload["success"] is True
 
 
 @pytest.mark.anyio
 async def test_delete_pipe_relation_graphql_error(
-    relation_session, mock_relation_client, extract_payload
+    relation_session, mock_relation_client
 ):
     mock_relation_client.delete_pipe_relation.side_effect = PipefyGraphQLError(
         [{"message": "denied"}]
     )
 
     async with relation_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_pipe_relation",
             {"relation_id": 1, "confirm": True},
         )
 
-    assert extract_payload(result)["success"] is False
-    assert "denied" in tool_error_message(extract_payload(result))
+    assert payload["success"] is False
+    assert "denied" in tool_error_message(payload)
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_report_tools.py
+++ b/packages/mcp/tests/tools/test_report_tools.py
@@ -13,6 +13,7 @@ from pipefy_sdk.report_filter_preflight import EXAMPLE_PHASE_FILTER
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.report_tools import ReportTools
 from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 GOLDEN_REPORT_PHASE_FILTER = {
     **EXAMPLE_PHASE_FILTER,
@@ -589,21 +590,17 @@ async def test_update_pipe_report_success(
 
 
 @pytest.mark.anyio
-async def test_delete_pipe_report_success(
-    report_session, mock_report_client, extract_payload
-):
+async def test_delete_pipe_report_success(report_session, mock_report_client):
     mock_report_client.delete_pipe_report.return_value = {
         "deletePipeReport": {"success": True}
     }
 
     async with report_session as session:
-        result = await session.call_tool(
-            "delete_pipe_report", {"report_id": "r10", "confirm": True}
+        payload = await confirm_after_preview(
+            session, "delete_pipe_report", {"report_id": "r10", "confirm": True}
         )
 
-    assert result.is_error is False
     mock_report_client.delete_pipe_report.assert_awaited_once_with("r10")
-    payload = extract_payload(result)
     assert payload["success"] is True
 
 
@@ -664,21 +661,17 @@ async def test_update_organization_report_success(
 
 
 @pytest.mark.anyio
-async def test_delete_organization_report_success(
-    report_session, mock_report_client, extract_payload
-):
+async def test_delete_organization_report_success(report_session, mock_report_client):
     mock_report_client.delete_organization_report.return_value = {
         "deleteOrganizationReport": {"success": True}
     }
 
     async with report_session as session:
-        result = await session.call_tool(
-            "delete_organization_report", {"report_id": "or5", "confirm": True}
+        payload = await confirm_after_preview(
+            session, "delete_organization_report", {"report_id": "or5", "confirm": True}
         )
 
-    assert result.is_error is False
     mock_report_client.delete_organization_report.assert_awaited_once_with("or5")
-    payload = extract_payload(result)
     assert payload["success"] is True
 
 
@@ -1545,19 +1538,16 @@ async def test_update_pipe_report_graphql_error(
 
 
 @pytest.mark.anyio
-async def test_delete_pipe_report_graphql_error(
-    report_session, mock_report_client, extract_payload
-):
+async def test_delete_pipe_report_graphql_error(report_session, mock_report_client):
     mock_report_client.delete_pipe_report.side_effect = PipefyGraphQLError(
         [{"message": "delete denied"}]
     )
 
     async with report_session as session:
-        result = await session.call_tool(
-            "delete_pipe_report", {"report_id": "r10", "confirm": True}
+        payload = await confirm_after_preview(
+            session, "delete_pipe_report", {"report_id": "r10", "confirm": True}
         )
 
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "delete denied" in tool_error_message(payload)
 
@@ -1601,18 +1591,17 @@ async def test_update_organization_report_graphql_error(
 
 @pytest.mark.anyio
 async def test_delete_organization_report_graphql_error(
-    report_session, mock_report_client, extract_payload
+    report_session, mock_report_client
 ):
     mock_report_client.delete_organization_report.side_effect = PipefyGraphQLError(
         [{"message": "org delete failed"}]
     )
 
     async with report_session as session:
-        result = await session.call_tool(
-            "delete_organization_report", {"report_id": "or5", "confirm": True}
+        payload = await confirm_after_preview(
+            session, "delete_organization_report", {"report_id": "or5", "confirm": True}
         )
 
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "org delete failed" in tool_error_message(payload)
 

--- a/packages/mcp/tests/tools/test_service_account_tools.py
+++ b/packages/mcp/tests/tools/test_service_account_tools.py
@@ -13,6 +13,7 @@ from pipefy_sdk import PipefyClient, PipefyGraphQLError
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.service_account_tools import ServiceAccountTools
 from tools.conftest import build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 ORG = "341c1327-261c-4766-bb96-7953e4c3970d"
 
@@ -426,14 +427,13 @@ async def test_delete_service_account_preview_does_not_call_mutation(
 
 
 @pytest.mark.anyio
-async def test_delete_service_account_confirmed(
-    sa_session, mock_sa_client, extract_payload
-):
+async def test_delete_service_account_confirmed(sa_session, mock_sa_client):
     mock_sa_client.delete_service_account.return_value = {
         "deleteServiceAccount": {"success": True}
     }
     async with sa_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_service_account",
             {
                 "organization_uuid": ORG,
@@ -441,11 +441,9 @@ async def test_delete_service_account_confirmed(
                 "confirm": True,
             },
         )
-    assert result.is_error is False
     mock_sa_client.delete_service_account.assert_awaited_once_with(
         organization_uuid=ORG, service_account_uuid="sa-uuid-1"
     )
-    payload = extract_payload(result)
     assert payload["success"] is True
 
 
@@ -459,11 +457,12 @@ async def test_delete_service_account_confirmed(
     ],
 )
 async def test_delete_service_account_soft_failure_is_not_reported_as_deleted(
-    sa_session, mock_sa_client, extract_payload, raw
+    sa_session, mock_sa_client, raw
 ):
     mock_sa_client.delete_service_account.return_value = raw
     async with sa_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_service_account",
             {
                 "organization_uuid": ORG,
@@ -471,10 +470,45 @@ async def test_delete_service_account_soft_failure_is_not_reported_as_deleted(
                 "confirm": True,
             },
         )
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "did not succeed" in tool_error_message(payload).lower()
+
+
+@pytest.mark.anyio
+async def test_delete_service_account_rejects_token_when_organization_uuid_differs(
+    sa_session, mock_sa_client, extract_payload
+):
+    mock_sa_client.delete_service_account.return_value = {
+        "deleteServiceAccount": {"success": True}
+    }
+    async with sa_session as session:
+        preview = await session.call_tool(
+            "delete_service_account",
+            {"organization_uuid": "org-A", "service_account_uuid": "sa-uuid-1"},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await session.call_tool(
+            "delete_service_account",
+            {
+                "organization_uuid": "org-B",
+                "service_account_uuid": "sa-uuid-1",
+                "confirm": True,
+                "confirmation_token": token,
+            },
+        )
+        assert extract_payload(mismatch)["requires_confirmation"] is True
+        mock_sa_client.delete_service_account.assert_not_awaited()
+
+        matched = await confirm_after_preview(
+            session,
+            "delete_service_account",
+            {"organization_uuid": "org-A", "service_account_uuid": "sa-uuid-1"},
+        )
+
+    mock_sa_client.delete_service_account.assert_awaited_once_with(
+        organization_uuid="org-A", service_account_uuid="sa-uuid-1"
+    )
+    assert matched["success"] is True
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_table_tools.py
+++ b/packages/mcp/tests/tools/test_table_tools.py
@@ -13,6 +13,20 @@ from pipefy_sdk import PipefyClient, PipefyGraphQLError
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.table_tools import TableTools
 from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
+
+
+def _assert_destructive_preview(payload, *, resource):
+    assert payload["success"] is False
+    assert payload["requires_confirmation"] is True
+    assert payload["resource"] == resource
+    message = payload["message"]
+    assert "confirm=True" in message
+    assert message.index("explicit approval") < message.index("confirm=True")
+    token = payload["confirmation_token"]
+    assert isinstance(token, str)
+    assert token.startswith("v1.")
+    assert token != "v1."
 
 
 @pytest.fixture
@@ -541,44 +555,32 @@ async def test_delete_table_preview(table_session, mock_table_client, extract_pa
 
     mock_table_client.delete_table.assert_not_called()
     payload = extract_payload(result)
-    assert payload["success"] is False
-    assert payload["requires_confirmation"] is True
-    assert payload["resource"] == "table 'Cat' (ID: 5)"
+    _assert_destructive_preview(payload, resource="table 'Cat' (ID: 5)")
 
 
 @pytest.mark.anyio
-async def test_delete_table_confirm_success(
-    table_session, mock_table_client, extract_payload
-):
+async def test_delete_table_confirm_success(table_session, mock_table_client):
     mock_table_client.get_table.return_value = {"table": {"id": "5", "name": "Cat"}}
     mock_table_client.delete_table.return_value = {"deleteTable": {"success": True}}
 
     async with table_session as session:
-        result = await session.call_tool(
-            "delete_table",
-            {"table_id": 5, "confirm": True},
-        )
+        payload = await confirm_after_preview(session, "delete_table", {"table_id": 5})
 
     mock_table_client.delete_table.assert_awaited_once_with("5")
-    assert extract_payload(result)["success"] is True
+    assert payload["success"] is True
 
 
 @pytest.mark.anyio
-async def test_delete_table_graphql_error_on_confirm(
-    table_session, mock_table_client, extract_payload
-):
+async def test_delete_table_graphql_error_on_confirm(table_session, mock_table_client):
     mock_table_client.get_table.return_value = {"table": {"id": "1", "name": "X"}}
     mock_table_client.delete_table.side_effect = PipefyGraphQLError(
         [{"message": "cannot"}]
     )
 
     async with table_session as session:
-        result = await session.call_tool(
-            "delete_table",
-            {"table_id": 1, "confirm": True},
-        )
+        payload = await confirm_after_preview(session, "delete_table", {"table_id": 1})
 
-    assert extract_payload(result)["success"] is False
+    assert payload["success"] is False
 
 
 @pytest.mark.anyio
@@ -655,37 +657,32 @@ async def test_update_table_record_graphql_error(
 
 
 @pytest.mark.anyio
-async def test_delete_table_record_success(
-    table_session, mock_table_client, extract_payload
-):
+async def test_delete_table_record_success(table_session, mock_table_client):
     mock_table_client.delete_table_record.return_value = {
         "deleteTableRecord": {"success": True},
     }
 
     async with table_session as session:
-        result = await session.call_tool(
-            "delete_table_record",
-            {"record_id": 99, "confirm": True},
+        payload = await confirm_after_preview(
+            session, "delete_table_record", {"record_id": 99}
         )
 
     mock_table_client.delete_table_record.assert_awaited_once_with("99")
-    assert extract_payload(result)["success"] is True
+    assert payload["success"] is True
 
 
 @pytest.mark.anyio
-async def test_delete_table_record_graphql_error(
-    table_session, mock_table_client, extract_payload
-):
+async def test_delete_table_record_graphql_error(table_session, mock_table_client):
     mock_table_client.delete_table_record.side_effect = PipefyGraphQLError(
         [{"message": "no"}]
     )
 
     async with table_session as session:
-        result = await session.call_tool(
-            "delete_table_record", {"record_id": 1, "confirm": True}
+        payload = await confirm_after_preview(
+            session, "delete_table_record", {"record_id": 1}
         )
 
-    assert extract_payload(result)["success"] is False
+    assert payload["success"] is False
 
 
 @pytest.mark.anyio
@@ -800,37 +797,36 @@ async def test_update_table_field_graphql_error(
 
 
 @pytest.mark.anyio
-async def test_delete_table_field_success(
-    table_session, mock_table_client, extract_payload
-):
+async def test_delete_table_field_success(table_session, mock_table_client):
     mock_table_client.delete_table_field.return_value = {
         "deleteTableField": {"success": True},
     }
 
     async with table_session as session:
-        result = await session.call_tool(
-            "delete_table_field", {"field_id": 88, "table_id": "tbl_1", "confirm": True}
+        payload = await confirm_after_preview(
+            session,
+            "delete_table_field",
+            {"field_id": 88, "table_id": "tbl_1"},
         )
 
     mock_table_client.delete_table_field.assert_awaited_once_with("88", "tbl_1")
-    assert extract_payload(result)["success"] is True
+    assert payload["success"] is True
 
 
 @pytest.mark.anyio
-async def test_delete_table_field_graphql_error(
-    table_session, mock_table_client, extract_payload
-):
+async def test_delete_table_field_graphql_error(table_session, mock_table_client):
     mock_table_client.delete_table_field.side_effect = PipefyGraphQLError(
         [{"message": "nope"}]
     )
 
     async with table_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_table_field",
-            {"field_id": "x", "table_id": "tbl_1", "confirm": True},
+            {"field_id": "x", "table_id": "tbl_1"},
         )
 
-    assert extract_payload(result)["success"] is False
+    assert payload["success"] is False
 
 
 @pytest.mark.anyio
@@ -1203,8 +1199,7 @@ async def test_delete_table_record_preview_without_confirm(
 
     mock_table_client.delete_table_record.assert_not_called()
     payload = extract_payload(result)
-    assert payload["success"] is False
-    assert payload.get("requires_confirmation") is True
+    _assert_destructive_preview(payload, resource="table record (ID: 99)")
 
 
 # ---------------------------------------------------------------------------
@@ -1365,8 +1360,43 @@ async def test_delete_table_field_preview_without_confirm(
 
     mock_table_client.delete_table_field.assert_not_called()
     payload = extract_payload(result)
-    assert payload["success"] is False
-    assert payload.get("requires_confirmation") is True
+    _assert_destructive_preview(payload, resource="table field (ID: slug-1)")
+
+
+@pytest.mark.anyio
+async def test_delete_table_field_rejects_token_when_table_id_differs(
+    table_session, mock_table_client, extract_payload
+):
+    mock_table_client.delete_table_field.return_value = {
+        "deleteTableField": {"success": True},
+    }
+
+    async with table_session as session:
+        preview = await session.call_tool(
+            "delete_table_field",
+            {"field_id": "prioridade", "table_id": "tbl_A"},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await session.call_tool(
+            "delete_table_field",
+            {
+                "field_id": "prioridade",
+                "table_id": "tbl_B",
+                "confirm": True,
+                "confirmation_token": token,
+            },
+        )
+        assert extract_payload(mismatch)["requires_confirmation"] is True
+        mock_table_client.delete_table_field.assert_not_awaited()
+
+        matched = await confirm_after_preview(
+            session,
+            "delete_table_field",
+            {"field_id": "prioridade", "table_id": "tbl_A"},
+        )
+
+    mock_table_client.delete_table_field.assert_awaited_once_with("prioridade", "tbl_A")
+    assert matched["success"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -1574,19 +1604,13 @@ async def test_delete_table_graphql_error_on_lookup(
 
 
 @pytest.mark.anyio
-async def test_delete_table_confirm_returns_false(
-    table_session, mock_table_client, extract_payload
-):
+async def test_delete_table_confirm_returns_false(table_session, mock_table_client):
     mock_table_client.get_table.return_value = {"table": {"id": "5", "name": "T"}}
     mock_table_client.delete_table.return_value = {"deleteTable": {"success": False}}
 
     async with table_session as session:
-        result = await session.call_tool(
-            "delete_table",
-            {"table_id": 5, "confirm": True},
-        )
+        payload = await confirm_after_preview(session, "delete_table", {"table_id": 5})
 
-    payload = extract_payload(result)
     assert payload["success"] is False
 
 

--- a/packages/mcp/tests/tools/test_validation_helpers.py
+++ b/packages/mcp/tests/tools/test_validation_helpers.py
@@ -4,21 +4,11 @@ import pytest
 
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.validation_helpers import (
-    format_json_preview,
     mutation_error_if_not_optional_dict,
     valid_repo_id,
     validate_optional_tool_id,
     validate_tool_id,
 )
-
-
-@pytest.mark.unit
-def test_format_json_preview_pretty_and_utf8():
-    s = format_json_preview({"a": 1, "ç": "β"})
-    assert '"a": 1' in s
-    assert "ç" in s
-    assert "β" in s
-    assert "\n" in s
 
 
 @pytest.mark.unit

--- a/packages/mcp/tests/tools/test_webhook_tools.py
+++ b/packages/mcp/tests/tools/test_webhook_tools.py
@@ -13,6 +13,7 @@ from pipefy_sdk import PipefyClient, PipefyGraphQLError
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.webhook_tools import WebhookTools
 from tools.conftest import assert_invalid_arguments_envelope, build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 
 @pytest.fixture
@@ -496,42 +497,36 @@ async def test_delete_webhook_preview_does_not_delete(
 
 
 @pytest.mark.anyio
-async def test_delete_webhook_success(
-    webhook_session, mock_webhook_client, extract_payload
-):
+async def test_delete_webhook_success(webhook_session, mock_webhook_client):
     mock_webhook_client.delete_webhook.return_value = {
         "deleteWebhook": {"success": True}
     }
 
     async with webhook_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_webhook",
             {"webhook_id": "webhook-1", "confirm": True},
         )
 
-    assert result.is_error is False
     mock_webhook_client.delete_webhook.assert_awaited_once_with("webhook-1")
-    payload = extract_payload(result)
     assert payload["success"] is True
     assert payload["result"]["deleteWebhook"]["success"] is True
 
 
 @pytest.mark.anyio
-async def test_delete_webhook_graphql_error(
-    webhook_session, mock_webhook_client, extract_payload
-):
+async def test_delete_webhook_graphql_error(webhook_session, mock_webhook_client):
     mock_webhook_client.delete_webhook.side_effect = PipefyGraphQLError(
         [{"message": "webhook not found"}]
     )
 
     async with webhook_session as session:
-        result = await session.call_tool(
+        payload = await confirm_after_preview(
+            session,
             "delete_webhook",
             {"webhook_id": "w1", "confirm": True},
         )
 
-    assert result.is_error is False
-    payload = extract_payload(result)
     assert payload["success"] is False
     assert "webhook not found" in tool_error_message(payload).lower()
 


### PR DESCRIPTION
## Summary

- Dedicated destructive MCP tools no longer execute on one `confirm=true`. Call 1 returns a preview with an HMAC `confirmation_token` and mutates nothing; call 2 runs only when `confirm=true` echoes a token valid for the same tool, resource identity, caller key, token version and 300s TTL.
- 29 tools gain optional `confirmation_token` (28 `delete_*` + `remove_member_from_pipe`). Preview wording puts "get their explicit approval" before the mechanics.
- Token failures are told apart: missing / invalid-or-expired / identity mismatch. A changed `pipe_uuid` between preview and confirm no longer reads as "expired".
- Version signed inside the MAC; non-canonical base64url rejected; identity canonicalised on both mint and verify (a stringified value used to mint a token that could never verify, so the caller previewed forever).
- 829 deletions are consolidation: `build_delete_pipe_preview_payload`, `build_delete_table_preview_payload` and `format_json_preview` gone, every tool through one guard.

**Part 1 of 3.** Merge #629 → #630 → #631. Retarget #630 to `dev` once this lands.

## Accepted limits (ADR-001, decisions not oversights)

| Limit | Why it stands |
| --- | --- |
| Hosted caller can mint its own token (key = `sha256(bearer)`) | Token orders the protocol; authorization stays the API permission |
| Replay inside the 300s TTL | Stateless by design, no ticket store |
| Auto-approving client can preview + confirm back to back | Guarantee is that the preview reached the transcript |
| `unpublish_sub_portal` ungated | Reversible |
| CLI keeps `--yes`, no tokens | TTL 300s and the six needles are frozen |

## Test plan

- [x] `uv run pytest -m "not integration"` (4618 passed)
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run lint-imports` from `packages/mcp`
- [x] Live smoke: preview without token does not delete; confirm with token does. Disposable resources only.
- [x] CI green here (DCO, shell scripts, install/uninstall, lint, test). Only PR in the stack based on `dev`, so it is the stack's CI anchor.

## Docs / skills

- [x] No docs/skills in this PR. `docs/parity.md`, skills and the CHANGELOG entry land in #631.

## Legal / contributions

- [x] Commits include DCO sign-off (`git commit -s`)
