### PR TITLE
feat: gate GraphQL and iPaaS destructive calls behind confirmation token

### DIFF
--- a/packages/cli/src/pipefy_cli/commands/graphql.py
+++ b/packages/cli/src/pipefy_cli/commands/graphql.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import typer
 from pipefy_sdk import PipefyClient
-from pipefy_sdk.graphql_document import document_contains_mutation
+from pipefy_sdk.graphql_document import inspect_graphql_document
 
 from pipefy_cli.commands._common import run_pipefy_client_coroutine
 from pipefy_cli.output import render_json, render_rich
@@ -72,11 +72,25 @@ def graphql_exec(
 
     Pass variables as JSON with ``--vars '{"key":"value"}'`` (not ``--variables``).
 
-    Mutations are rejected unless ``--yes`` is set (exit code 2). Pair with
-    ``pipefy introspect`` to discover operation shapes (see docs/cli/self-healing.md).
+    Mutations are rejected unless ``--yes`` is set (exit code 2). A document too
+    deeply nested to parse is rejected outright, because its operation type
+    cannot be determined. Pair with ``pipefy introspect`` to discover operation
+    shapes (see docs/cli/self-healing.md).
     """
     variables = _parse_vars_json(vars_json)
-    if document_contains_mutation(query) and not yes:
+    inspection = inspect_graphql_document(query)
+    # Nesting deep enough to exhaust the parser leaves the operation type
+    # unknown, so --yes cannot stand in for a mutation acknowledgement here.
+    # Refusing matches execute_graphql, which errors on the same document.
+    if inspection.too_nested:
+        typer.echo(
+            "This document is too deeply nested to parse, so it cannot be "
+            "classified as a query or a mutation; nothing was sent. Reduce the "
+            "nesting and re-run.",
+            err=True,
+        )
+        raise typer.Exit(2)
+    if inspection.contains_mutation and not yes:
         typer.echo(
             "This document includes a mutation; re-run with --yes to confirm, "
             "or use read-only operations.",

--- a/packages/cli/src/pipefy_cli/commands/graphql.py
+++ b/packages/cli/src/pipefy_cli/commands/graphql.py
@@ -7,9 +7,8 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 import typer
-from graphql import GraphQLSyntaxError, parse
-from graphql.language.ast import OperationDefinitionNode, OperationType
 from pipefy_sdk import PipefyClient
+from pipefy_sdk.graphql_document import document_contains_mutation
 
 from pipefy_cli.commands._common import run_pipefy_client_coroutine
 from pipefy_cli.output import render_json, render_rich
@@ -18,21 +17,6 @@ graphql_app = typer.Typer(
     help="Execute arbitrary GraphQL (mutations require --yes). See docs/cli/self-healing.md.",
     no_args_is_help=True,
 )
-
-
-def _document_contains_mutation(document: str) -> bool:
-    """Return True when the document defines at least one mutation operation."""
-    try:
-        doc = parse(document)
-    except GraphQLSyntaxError:
-        return False
-    for defn in doc.definitions:
-        if (
-            isinstance(defn, OperationDefinitionNode)
-            and defn.operation == OperationType.MUTATION
-        ):
-            return True
-    return False
 
 
 def _parse_vars_json(raw: str | None) -> dict[str, Any]:
@@ -92,7 +76,7 @@ def graphql_exec(
     ``pipefy introspect`` to discover operation shapes (see docs/cli/self-healing.md).
     """
     variables = _parse_vars_json(vars_json)
-    if _document_contains_mutation(query) and not yes:
+    if document_contains_mutation(query) and not yes:
         typer.echo(
             "This document includes a mutation; re-run with --yes to confirm, "
             "or use read-only operations.",

--- a/packages/cli/tests/fixtures/cli_help_golden.txt
+++ b/packages/cli/tests/fixtures/cli_help_golden.txt
@@ -1785,9 +1785,10 @@ Usage: pipefy graphql exec [OPTIONS]
 
  Pass variables as JSON with ``--vars '{"key":"value"}'`` (not
  ``--variables``).
- Mutations are rejected unless ``--yes`` is set (exit code 2). Pair with
- ``pipefy introspect`` to discover operation shapes (see
- docs/cli/self-healing.md).
+ Mutations are rejected unless ``--yes`` is set (exit code 2). A document too
+ deeply nested to parse is rejected outright, because its operation type cannot
+ be determined. Pair with ``pipefy introspect`` to discover operation shapes
+ (see docs/cli/self-healing.md).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --query  -q      TEXT  GraphQL document string (query or mutation).       │

--- a/packages/cli/tests/test_v8_v9_cli_commands.py
+++ b/packages/cli/tests/test_v8_v9_cli_commands.py
@@ -369,6 +369,32 @@ def test_graphql_exec_mutation_with_yes_calls_sdk(
     mock_client.execute_graphql.assert_awaited_once()
 
 
+def test_graphql_exec_too_nested_document_exit_2(
+    runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
+):
+    """A document the parser cannot classify is refused, ``--yes`` included.
+
+    The parser reports neither query nor mutation for it, so ``--yes`` has no
+    mutation to acknowledge. ``execute_graphql`` answers the same document with
+    an error envelope and never calls the API; the CLI must not send it either.
+    """
+    oauth_env("gql_nested")
+    nested = "mutation M { " + "a { " * 400 + "x " + "} " * 401
+    mock_client = MagicMock()
+    mock_client.execute_graphql = AsyncMock(return_value={"ok": True})
+    with patch(
+        "pipefy_cli.commands._common.get_authenticated_client",
+        return_value=mock_client,
+    ):
+        for argv in (
+            ["graphql", "exec", "--query", nested, "--json"],
+            ["graphql", "exec", "--query", nested, "--yes", "--json"],
+        ):
+            result = runner.invoke(app, argv)
+            assert result.exit_code == 2, argv
+    mock_client.execute_graphql.assert_not_called()
+
+
 def test_graphql_exec_invalid_vars_exit_2(
     runner: CliRunner, clean_pipefy_env, saved_cwd, oauth_env
 ):

--- a/packages/mcp/src/pipefy_mcp/core/ipaas_gateway.py
+++ b/packages/mcp/src/pipefy_mcp/core/ipaas_gateway.py
@@ -26,6 +26,7 @@ gateway itself reads no settings.
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any
@@ -77,7 +78,23 @@ def _step_field(step: str, body: dict[str, Any], key: str) -> Any:
         raise IpaasGatewayError(f"{step} returned a body without '{key}'.") from exc
 
 
-class _IpaasMcpSession:
+def _tools_from_list_result(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """The ``tools`` list from a ``tools/list`` result, or a step-named error."""
+    tools = _step_field("iPaaS tools/list", result, "tools")
+    if not isinstance(tools, list):
+        raise IpaasGatewayError(
+            "iPaaS tools/list returned a body whose 'tools' field is not a list."
+        )
+    for index, entry in enumerate(tools):
+        if not isinstance(entry, dict):
+            raise IpaasGatewayError(
+                "iPaaS tools/list returned a catalog entry that is not an "
+                f"object (index {index})."
+            )
+    return tools
+
+
+class IpaasMcpSession:
     """MCP list/call on one already-minted access token."""
 
     def __init__(
@@ -94,7 +111,7 @@ class _IpaasMcpSession:
         result = await self._gateway._mcp_request(
             self._http, self._access_token, "tools/list", {}
         )
-        return result["tools"]
+        return _tools_from_list_result(result)
 
     async def call_tool(
         self, tool_name: str, arguments: dict[str, Any] | None = None
@@ -136,43 +153,12 @@ class IpaasGateway:
         result = await self._authed_mcp_request(
             advanced_automations_token, "tools/list", params={}
         )
-        return result["tools"]
-
-    async def call_tool(
-        self,
-        advanced_automations_token: str,
-        tool_name: str,
-        arguments: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """Invoke one tool in the pipe's iPaaS workspace and return its raw result.
-
-        The return value is the wire-format ``tools/call`` result
-        (``content`` list plus ``isError``); interpreting or reshaping it is
-        the caller's concern. Like :meth:`list_tools`, each call runs the full
-        stateless auth chain; only the invocation hop itself gets the longer
-        :data:`CALL_TIMEOUT_SECONDS` budget, since a called tool may execute a
-        real flow.
-
-        Args:
-            advanced_automations_token: Pipe-scoped token from
-                ``PipefyClient.get_advanced_automations_token``.
-            tool_name: Exact catalog name (see :meth:`list_tools`).
-            arguments: Tool arguments, forwarded verbatim; the iPaaS host
-                validates them against its own input schema.
-
-        Raises:
-            IpaasGatewayError: When any step of the chain is refused by the
-                iPaaS host; the message names the step.
-        """
-        return await self._authed_mcp_request(
-            advanced_automations_token,
-            "tools/call",
-            params={"name": tool_name, "arguments": arguments or {}},
-            timeout_seconds=CALL_TIMEOUT_SECONDS,
-        )
+        return _tools_from_list_result(result)
 
     @asynccontextmanager
-    async def mcp_session(self, advanced_automations_token: str):
+    async def mcp_session(
+        self, advanced_automations_token: str
+    ) -> AsyncIterator[IpaasMcpSession]:
         """One OAuth handshake; list and call reuse that access token.
 
         The token lives only on the yielded session and is dropped on exit.
@@ -182,7 +168,7 @@ class IpaasGateway:
             timeout=httpx.Timeout(REQUEST_TIMEOUT_SECONDS)
         ) as http:
             access_token = await self._access_token(http, advanced_automations_token)
-            yield _IpaasMcpSession(self, http, access_token)
+            yield IpaasMcpSession(self, http, access_token)
 
     async def connection_auth_url(
         self, advanced_automations_token: str, piece_name: str
@@ -578,4 +564,9 @@ def _parse_mcp_response(response: httpx.Response) -> dict[str, Any]:
     )
 
 
-__all__ = ["IpaasGateway", "IpaasGatewayError", "oauth_connection_value"]
+__all__ = [
+    "IpaasGateway",
+    "IpaasGatewayError",
+    "IpaasMcpSession",
+    "oauth_connection_value",
+]

--- a/packages/mcp/src/pipefy_mcp/core/ipaas_gateway.py
+++ b/packages/mcp/src/pipefy_mcp/core/ipaas_gateway.py
@@ -26,6 +26,7 @@ gateway itself reads no settings.
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -74,6 +75,37 @@ def _step_field(step: str, body: dict[str, Any], key: str) -> Any:
         return body[key]
     except KeyError as exc:
         raise IpaasGatewayError(f"{step} returned a body without '{key}'.") from exc
+
+
+class _IpaasMcpSession:
+    """MCP list/call on one already-minted access token."""
+
+    def __init__(
+        self,
+        gateway: IpaasGateway,
+        http: httpx.AsyncClient,
+        access_token: str,
+    ) -> None:
+        self._gateway = gateway
+        self._http = http
+        self._access_token = access_token
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        result = await self._gateway._mcp_request(
+            self._http, self._access_token, "tools/list", {}
+        )
+        return result["tools"]
+
+    async def call_tool(
+        self, tool_name: str, arguments: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return await self._gateway._mcp_request(
+            self._http,
+            self._access_token,
+            "tools/call",
+            {"name": tool_name, "arguments": arguments or {}},
+            CALL_TIMEOUT_SECONDS,
+        )
 
 
 @dataclass(frozen=True)
@@ -138,6 +170,19 @@ class IpaasGateway:
             params={"name": tool_name, "arguments": arguments or {}},
             timeout_seconds=CALL_TIMEOUT_SECONDS,
         )
+
+    @asynccontextmanager
+    async def mcp_session(self, advanced_automations_token: str):
+        """One OAuth handshake; list and call reuse that access token.
+
+        The token lives only on the yielded session and is dropped on exit.
+        The gateway itself stays stateless.
+        """
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(REQUEST_TIMEOUT_SECONDS)
+        ) as http:
+            access_token = await self._access_token(http, advanced_automations_token)
+            yield _IpaasMcpSession(self, http, access_token)
 
     async def connection_auth_url(
         self, advanced_automations_token: str, piece_name: str

--- a/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -65,6 +65,7 @@ async def check_destructive_confirmation(
     tool_name: str,
     confirmation_token: str | None = None,
     dependents_resolver: DependentsResolver | None = None,
+    irreversible_sentence: str | None = None,
 ) -> DestructivePreviewPayload | None:
     """Gate a destructive operation behind ``confirm=True`` and a verified token.
 
@@ -85,6 +86,9 @@ async def check_destructive_confirmation(
             empty dict to skip enrichment. Invoked on every preview path;
             never invoked when proceeding. Exceptions are swallowed so the
             base preview is still returned.
+        irreversible_sentence: Optional first preview sentence. Defaults to
+            ``Deleting {resource_descriptor} is permanent...``. Pass a custom
+            sentence when the operation is not a deletion of that descriptor.
 
     Returns:
         ``None`` when ``confirm=True`` and the token verifies. The caller
@@ -121,6 +125,7 @@ async def check_destructive_confirmation(
         resource_descriptor,
         confirmation_token=minted,
         token_status=token_status,
+        irreversible_sentence=irreversible_sentence,
     )
     if dependents_resolver is not None:
         try:
@@ -137,9 +142,11 @@ def _build_preview_payload(
     *,
     confirmation_token: str,
     token_status: ConfirmationTokenFailure | None = None,
+    irreversible_sentence: str | None = None,
 ) -> DestructivePreviewPayload:
     sentences = [
-        f"⚠️ Deleting {resource_descriptor} is permanent and cannot be undone.",
+        irreversible_sentence
+        or f"⚠️ Deleting {resource_descriptor} is permanent and cannot be undone.",
     ]
     if token_status == "missing":
         sentences.append("The confirmation token is missing.")

--- a/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
@@ -210,6 +210,10 @@ class IntrospectionTools:
                     ctx,
                     confirm=confirm,
                     resource_descriptor="GraphQL mutation",
+                    irreversible_sentence=(
+                        "⚠️ This GraphQL mutation's effects are permanent "
+                        "and cannot be undone."
+                    ),
                     resource_identity={
                         "document": hashlib.sha256(query.encode("utf-8")).hexdigest(),
                         "variables": hashlib.sha256(

--- a/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
@@ -190,7 +190,7 @@ class IntrospectionTools:
             Mutations need a preview token: call once to receive ``confirmation_token``,
             then echo that token with ``confirm=True`` on step 2. A token is replayable
             within its TTL, so a non-idempotent mutation can run twice if the caller
-            resends it. Prefer dedicated tools.
+            resends it.
 
             On ambiguous write failure (``success: false`` with empty or unclear message),
             re-read counts/ids before retrying; do not blind-retry creates.

--- a/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Any
 
 from mcp.server.mcpserver import Context, MCPServer
 from mcp.types import ToolAnnotations
+from pipefy_sdk.graphql_document import document_contains_mutation
 
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import ensure_non_empty_error_message
 from pipefy_mcp.tools.introspection_tool_helpers import (
     build_error_payload,
@@ -175,11 +179,19 @@ class IntrospectionTools:
             ctx: Context,
             variables: dict[str, Any] | None = None,
             include_parsed: bool = False,
+            confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict:
             """Run arbitrary GraphQL against Pipefy (queries or mutations).
 
             Prefer dedicated tools when available. Use this as a fallback when no specific
             tool exists. Always introspect the mutation's input shape before executing.
+
+            Mutations need a preview token: call once to receive ``confirmation_token``,
+            then echo that token with ``confirm=True`` on step 2. A token is replayable
+            within its TTL, so a non-idempotent mutation can run twice if the caller
+            resends it. Prefer dedicated tools.
+
             On ambiguous write failure (``success: false`` with empty or unclear message),
             re-read counts/ids before retrying; do not blind-retry creates.
             Returns ``result`` (pretty-printed JSON string).  Set ``include_parsed=True``
@@ -189,8 +201,30 @@ class IntrospectionTools:
                 query: Full GraphQL document (query or mutation).
                 variables: Optional variable map for the operation.
                 include_parsed: When True, include ``data`` dict alongside ``result``.
+                confirm: Set to True with the preview token to execute a mutation (step 2).
+                confirmation_token: Token from the preview response; echo it on step 2.
             """
             client = get_pipefy_client(ctx)
+            if document_contains_mutation(query):
+                guard = await check_destructive_confirmation(
+                    ctx,
+                    confirm=confirm,
+                    resource_descriptor="GraphQL mutation",
+                    resource_identity={
+                        "document": hashlib.sha256(query.encode("utf-8")).hexdigest(),
+                        "variables": hashlib.sha256(
+                            json.dumps(
+                                variables or {},
+                                sort_keys=True,
+                                separators=(",", ":"),
+                            ).encode("utf-8")
+                        ).hexdigest(),
+                    },
+                    tool_name="execute_graphql",
+                    confirmation_token=confirmation_token,
+                )
+                if guard is not None:
+                    return guard
             try:
                 result = await client.execute_graphql(query, variables)
             except Exception as exc:  # noqa: BLE001

--- a/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
@@ -210,7 +210,9 @@ class IntrospectionTools:
             inspection = inspect_graphql_document(query)
             if inspection.too_nested:
                 return build_error_payload(
-                    "GraphQL document is too deeply nested to parse."
+                    "This document is too deeply nested to parse, so it cannot "
+                    "be classified as a query or a mutation; nothing was sent. "
+                    "Reduce the nesting and retry."
                 )
             if inspection.contains_mutation:
                 guard = await check_destructive_confirmation(
@@ -218,8 +220,8 @@ class IntrospectionTools:
                     confirm=confirm,
                     resource_descriptor=inspection.mutation_descriptor,
                     irreversible_sentence=(
-                        "⚠️ This GraphQL mutation's effects are permanent "
-                        "and cannot be undone."
+                        f"⚠️ Executing {inspection.mutation_descriptor} is "
+                        "permanent and cannot be undone."
                     ),
                     resource_identity={
                         "document": hashlib.sha256(query.encode("utf-8")).hexdigest(),

--- a/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
@@ -220,8 +220,9 @@ class IntrospectionTools:
                     confirm=confirm,
                     resource_descriptor=inspection.mutation_descriptor,
                     irreversible_sentence=(
-                        f"⚠️ Executing {inspection.mutation_descriptor} is "
-                        "permanent and cannot be undone."
+                        f"Executing {inspection.mutation_descriptor} needs "
+                        "approval because this server cannot tell what the "
+                        "mutation changes."
                     ),
                     resource_identity={
                         "document": hashlib.sha256(query.encode("utf-8")).hexdigest(),

--- a/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/introspection_tools.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from mcp.server.mcpserver import Context, MCPServer
 from mcp.types import ToolAnnotations
-from pipefy_sdk.graphql_document import document_contains_mutation
+from pipefy_sdk.graphql_document import inspect_graphql_document
 
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import ensure_non_empty_error_message
@@ -194,8 +194,10 @@ class IntrospectionTools:
 
             On ambiguous write failure (``success: false`` with empty or unclear message),
             re-read counts/ids before retrying; do not blind-retry creates.
-            Returns ``result`` (pretty-printed JSON string).  Set ``include_parsed=True``
-            to also get a ``data`` dict for programmatic access.
+            Queries and step-2 executions return ``result`` (pretty-printed JSON
+            string). The step-1 mutation preview has no ``result`` key; it
+            returns ``confirmation_token``. Set ``include_parsed=True`` to also
+            get a ``data`` dict on executed responses.
 
             Args:
                 query: Full GraphQL document (query or mutation).
@@ -205,11 +207,16 @@ class IntrospectionTools:
                 confirmation_token: Token from the preview response; echo it on step 2.
             """
             client = get_pipefy_client(ctx)
-            if document_contains_mutation(query):
+            inspection = inspect_graphql_document(query)
+            if inspection.too_nested:
+                return build_error_payload(
+                    "GraphQL document is too deeply nested to parse."
+                )
+            if inspection.contains_mutation:
                 guard = await check_destructive_confirmation(
                     ctx,
                     confirm=confirm,
-                    resource_descriptor="GraphQL mutation",
+                    resource_descriptor=inspection.mutation_descriptor,
                     irreversible_sentence=(
                         "⚠️ This GraphQL mutation's effects are permanent "
                         "and cannot be undone."

--- a/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
@@ -61,10 +61,11 @@ def ipaas_call_is_destructive(
 ) -> bool:
     """Whether a catalog call must take the two-step confirmation ticket.
 
-    Order (do not reorder): annotation true; ``operation`` needle-equality;
-    annotation false stops; else ``tool_name`` substring needles. ``entry`` is
-    the raw ``list_tools`` wire object; a missing catalog name is passed as
-    ``{"name": tool_name}`` (treated as no boolean).
+    Order (do not reorder): annotation true; ``operation`` needle-equality
+    after strip and casefold; annotation false stops; else ``tool_name``
+    substring needles. ``entry`` is a found ``list_tools`` wire object. A
+    catalog miss is unclassifiable: the call site gates it instead of
+    passing ``{"name": tool_name}`` here.
     """
     hint = _catalog_destructive_hint(entry)
     if hint is True:
@@ -91,19 +92,23 @@ def _catalog_tool_name(entry: dict[str, Any]) -> str:
     return name if isinstance(name, str) else ""
 
 
+def _normalized_operation(value: str) -> str:
+    return value.strip().casefold()
+
+
 def _operation_equals_destructive_needle(arguments: dict[str, Any] | None) -> bool:
     if arguments is None or "operation" not in arguments:
         return False
     value = arguments["operation"]
     if not isinstance(value, str):
         return False
-    return value.casefold() in IPAAS_DESTRUCTIVE_NEEDLES
+    return _normalized_operation(value) in IPAAS_DESTRUCTIVE_NEEDLES
 
 
 def _arguments_digest(arguments: dict[str, Any] | None) -> str:
     canonical: dict[str, Any] = dict(arguments or {})
     if "operation" in canonical and isinstance(canonical["operation"], str):
-        canonical["operation"] = canonical["operation"].casefold()
+        canonical["operation"] = _normalized_operation(canonical["operation"])
     return hashlib.sha256(
         json.dumps(
             canonical, sort_keys=True, separators=(",", ":"), default=str
@@ -120,7 +125,7 @@ def _ipaas_call_resource_identity(
         "arguments": _arguments_digest(arguments),
     }
     if arguments is not None and "operation" in arguments:
-        identity["operation"] = str(arguments["operation"]).casefold()
+        identity["operation"] = _normalized_operation(str(arguments["operation"]))
     return identity
 
 
@@ -261,11 +266,13 @@ class IpaasTools:
 
             Destructive catalog calls need a preview token: annotation
             ``true``, or ``arguments.operation`` equal to a delete-like needle
-            (case-insensitive equality), else a delete-like substring in the
-            catalog name. Call once to receive ``confirmation_token``, then
-            echo that token with ``confirm=True`` on step 2. Mixed manage
-            ADD/UPDATE stay one-shot unless a confirmation token is supplied.
-            A token is replayable within its TTL.
+            (strip then case-insensitive equality), else a delete-like
+            substring in the catalog name. A catalog miss is unclassifiable
+            and takes the two-step as well. Call once to receive
+            ``confirmation_token``, then echo that token with ``confirm=True``
+            on step 2. Mixed manage ADD/UPDATE stay one-shot unless a
+            confirmation token is supplied. A token is replayable within
+            its TTL.
 
             Prefer the read and validate tools while iterating, and for
             long-running executions (flow tests, retries) inspect progress
@@ -290,8 +297,12 @@ class IpaasTools:
                 async with gateway.mcp_session(token) as ipaas_session:
                     catalog = await ipaas_session.list_tools()
                     entry = _catalog_entry_named(catalog, tool_name)
-                    judged = {"name": tool_name} if entry is None else entry
-                    destructive = ipaas_call_is_destructive(judged, arguments)
+                    if entry is None:
+                        catalog_miss = True
+                        destructive = True
+                    else:
+                        catalog_miss = False
+                        destructive = ipaas_call_is_destructive(entry, arguments)
                     # A leftover DELETE token must not authorize mixed ADD
                     # (identity includes operation). ADD without a token stays
                     # one-shot.
@@ -299,7 +310,13 @@ class IpaasTools:
                         descriptor = _ipaas_call_resource_descriptor(
                             pipe_id, tool_name, arguments
                         )
-                        if destructive:
+                        if catalog_miss:
+                            irreversible = (
+                                f"Running {descriptor} could not be classified "
+                                "because it was not in the catalog page this "
+                                "server read, so it needs approval."
+                            )
+                        elif destructive:
                             irreversible = (
                                 f"⚠️ Running {descriptor} is permanent "
                                 "and cannot be undone."

--- a/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
@@ -14,6 +14,7 @@ from mcp.types import ToolAnnotations
 from pipefy_sdk import PipefyId
 
 from pipefy_mcp.core.ipaas_gateway import IpaasGateway, oauth_connection_value
+from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
 from pipefy_mcp.tools.graphql_error_helpers import ensure_non_empty_error_message
 from pipefy_mcp.tools.introspection_tool_helpers import (
     build_error_payload,
@@ -42,6 +43,88 @@ _IPAAS_REQUEST_FAILED = (
 _ENV_REF_PREFIX = "PIPEFY_IPAAS_CONNECTION_"
 
 _SECRET_CONNECTION_TYPES = ("SECRET_TEXT", "BASIC_AUTH", "CUSTOM_AUTH")
+
+IPAAS_DESTRUCTIVE_NEEDLES = (
+    "delete",
+    "remove",
+    "destroy",
+    "drop",
+    "uninstall",
+    "revoke",
+)
+
+
+def ipaas_call_is_destructive(entry: dict | None, arguments: dict | None) -> bool:
+    """Whether a catalog call must take the two-step confirmation ticket.
+
+    Order (do not reorder): annotation true; ``operation`` needle-equality;
+    annotation false stops; else ``tool_name`` substring needles. ``entry`` is
+    the raw ``list_tools`` wire object, or ``None`` when the name is missing
+    (treated as no boolean).
+    """
+    hint = _catalog_destructive_hint(entry)
+    if hint is True:
+        return True
+    if _operation_equals_destructive_needle(arguments):
+        return True
+    if hint is False:
+        return False
+    name = _catalog_tool_name(entry)
+    folded = name.casefold()
+    return any(needle in folded for needle in IPAAS_DESTRUCTIVE_NEEDLES)
+
+
+def _catalog_destructive_hint(entry: dict | None) -> bool | None:
+    if entry is None:
+        return None
+    annotations = entry.get("annotations")
+    if not isinstance(annotations, dict):
+        return None
+    hint = annotations.get("destructiveHint")
+    return hint if isinstance(hint, bool) else None
+
+
+def _catalog_tool_name(entry: dict | None) -> str:
+    if entry is None:
+        return ""
+    name = entry.get("name")
+    return name if isinstance(name, str) else ""
+
+
+def _operation_equals_destructive_needle(arguments: dict | None) -> bool:
+    if arguments is None or "operation" not in arguments:
+        return False
+    value = arguments["operation"]
+    if not isinstance(value, str):
+        return False
+    return value.casefold() in IPAAS_DESTRUCTIVE_NEEDLES
+
+
+def _ipaas_call_resource_identity(
+    pipe_id: PipefyId, tool_name: str, arguments: dict[str, Any] | None
+) -> dict[str, Any]:
+    identity: dict[str, Any] = {"pipe_id": str(pipe_id), "tool_name": tool_name}
+    if arguments is not None and "operation" in arguments:
+        identity["operation"] = str(arguments["operation"]).casefold()
+    return identity
+
+
+def _ipaas_call_resource_descriptor(
+    pipe_id: PipefyId, tool_name: str, arguments: dict[str, Any] | None
+) -> str:
+    descriptor = f"iPaaS catalog tool '{tool_name}' on pipe {pipe_id}"
+    if arguments is None or "operation" not in arguments:
+        return descriptor
+    return f"{descriptor} (operation {arguments['operation']})"
+
+
+def _catalog_entry_named(
+    tools: list[dict[str, Any]], tool_name: str
+) -> dict[str, Any] | None:
+    for tool in tools:
+        if tool.get("name") == tool_name:
+            return tool
+    return None
 
 
 def _first_line(text: str | None) -> str:
@@ -149,6 +232,8 @@ class IpaasTools:
             tool_name: str,
             ctx: Context,
             arguments: dict[str, Any] | None = None,
+            confirm: bool = False,
+            confirmation_token: str | None = None,
         ) -> dict:
             """Invoke one iPaaS (Advanced Automations) tool in a pipe's workspace.
 
@@ -158,8 +243,13 @@ class IpaasTools:
             from its input schema — the iPaaS host validates them and its
             error messages are returned here verbatim.
 
-            The catalog includes destructive operations (deleting flows,
-            tables, or records): only call those on explicit user intent.
+            Destructive catalog calls need a preview token: annotation
+            ``true``, or ``arguments.operation`` equal to a delete-like needle
+            (case-insensitive equality), else a delete-like substring in the
+            catalog name. Call once to receive ``confirmation_token``, then
+            echo that token with ``confirm=True`` on step 2. Mixed manage
+            ADD/UPDATE stay one-shot. A token is replayable within its TTL.
+
             Prefer the read and validate tools while iterating, and for
             long-running executions (flow tests, retries) inspect progress
             with the run-listing tools rather than re-invoking.
@@ -173,10 +263,39 @@ class IpaasTools:
                     catalog.
                 arguments: Arguments matching the tool's input schema. Omit
                     for tools that take none.
+                confirm: Set to True with the preview token to run a
+                    destructive catalog call (step 2).
+                confirmation_token: Token from the preview response; echo it
+                    on step 2.
             """
 
             async def work(gateway: IpaasGateway, token: str) -> dict:
-                result = await gateway.call_tool(token, tool_name, arguments)
+                async with gateway.mcp_session(token) as mcp:
+                    catalog = await mcp.list_tools()
+                    entry = _catalog_entry_named(catalog, tool_name)
+                    judged = {"name": tool_name} if entry is None else entry
+                    # A leftover DELETE token must not authorize mixed ADD
+                    # (identity includes operation). ADD without a token stays
+                    # one-shot.
+                    if (
+                        ipaas_call_is_destructive(judged, arguments)
+                        or confirmation_token
+                    ):
+                        guard = await check_destructive_confirmation(
+                            ctx,
+                            confirm=confirm,
+                            resource_descriptor=_ipaas_call_resource_descriptor(
+                                pipe_id, tool_name, arguments
+                            ),
+                            resource_identity=_ipaas_call_resource_identity(
+                                pipe_id, tool_name, arguments
+                            ),
+                            tool_name="call_ipaas_tool",
+                            confirmation_token=confirmation_token,
+                        )
+                        if guard is not None:
+                            return guard
+                    result = await mcp.call_tool(tool_name, arguments)
                 return _call_result_payload(pipe_id, tool_name, result)
 
             return await _run_ipaas_tool(ctx, pipe_id, work)

--- a/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
@@ -281,11 +281,16 @@ class IpaasTools:
                         ipaas_call_is_destructive(judged, arguments)
                         or confirmation_token
                     ):
+                        descriptor = _ipaas_call_resource_descriptor(
+                            pipe_id, tool_name, arguments
+                        )
                         guard = await check_destructive_confirmation(
                             ctx,
                             confirm=confirm,
-                            resource_descriptor=_ipaas_call_resource_descriptor(
-                                pipe_id, tool_name, arguments
+                            resource_descriptor=descriptor,
+                            irreversible_sentence=(
+                                f"⚠️ Running {descriptor} is permanent "
+                                "and cannot be undone."
                             ),
                             resource_identity=_ipaas_call_resource_identity(
                                 pipe_id, tool_name, arguments

--- a/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
@@ -305,9 +305,12 @@ class IpaasTools:
                                 "and cannot be undone."
                             )
                         else:
+                            # The classifier cleared this call, so no warning
+                            # glyph: the token is what pulled it into the guard.
                             irreversible = (
-                                f"⚠️ Running {descriptor} is being "
-                                "re-checked against its confirmation token."
+                                f"Running {descriptor} is not classified as "
+                                "destructive, and the confirmation token "
+                                "supplied with it is being re-checked."
                             )
                         guard = await check_destructive_confirmation(
                             ctx,

--- a/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import re
 import uuid
@@ -54,13 +56,15 @@ IPAAS_DESTRUCTIVE_NEEDLES = (
 )
 
 
-def ipaas_call_is_destructive(entry: dict | None, arguments: dict | None) -> bool:
+def ipaas_call_is_destructive(
+    entry: dict[str, Any], arguments: dict[str, Any] | None
+) -> bool:
     """Whether a catalog call must take the two-step confirmation ticket.
 
     Order (do not reorder): annotation true; ``operation`` needle-equality;
     annotation false stops; else ``tool_name`` substring needles. ``entry`` is
-    the raw ``list_tools`` wire object, or ``None`` when the name is missing
-    (treated as no boolean).
+    the raw ``list_tools`` wire object; a missing catalog name is passed as
+    ``{"name": tool_name}`` (treated as no boolean).
     """
     hint = _catalog_destructive_hint(entry)
     if hint is True:
@@ -74,9 +78,7 @@ def ipaas_call_is_destructive(entry: dict | None, arguments: dict | None) -> boo
     return any(needle in folded for needle in IPAAS_DESTRUCTIVE_NEEDLES)
 
 
-def _catalog_destructive_hint(entry: dict | None) -> bool | None:
-    if entry is None:
-        return None
+def _catalog_destructive_hint(entry: dict[str, Any]) -> bool | None:
     annotations = entry.get("annotations")
     if not isinstance(annotations, dict):
         return None
@@ -84,14 +86,12 @@ def _catalog_destructive_hint(entry: dict | None) -> bool | None:
     return hint if isinstance(hint, bool) else None
 
 
-def _catalog_tool_name(entry: dict | None) -> str:
-    if entry is None:
-        return ""
+def _catalog_tool_name(entry: dict[str, Any]) -> str:
     name = entry.get("name")
     return name if isinstance(name, str) else ""
 
 
-def _operation_equals_destructive_needle(arguments: dict | None) -> bool:
+def _operation_equals_destructive_needle(arguments: dict[str, Any] | None) -> bool:
     if arguments is None or "operation" not in arguments:
         return False
     value = arguments["operation"]
@@ -100,10 +100,25 @@ def _operation_equals_destructive_needle(arguments: dict | None) -> bool:
     return value.casefold() in IPAAS_DESTRUCTIVE_NEEDLES
 
 
+def _arguments_digest(arguments: dict[str, Any] | None) -> str:
+    canonical: dict[str, Any] = dict(arguments or {})
+    if "operation" in canonical and isinstance(canonical["operation"], str):
+        canonical["operation"] = canonical["operation"].casefold()
+    return hashlib.sha256(
+        json.dumps(
+            canonical, sort_keys=True, separators=(",", ":"), default=str
+        ).encode("utf-8")
+    ).hexdigest()
+
+
 def _ipaas_call_resource_identity(
     pipe_id: PipefyId, tool_name: str, arguments: dict[str, Any] | None
 ) -> dict[str, Any]:
-    identity: dict[str, Any] = {"pipe_id": str(pipe_id), "tool_name": tool_name}
+    identity: dict[str, Any] = {
+        "pipe_id": str(pipe_id),
+        "tool_name": tool_name,
+        "arguments": _arguments_digest(arguments),
+    }
     if arguments is not None and "operation" in arguments:
         identity["operation"] = str(arguments["operation"]).casefold()
     return identity
@@ -113,9 +128,10 @@ def _ipaas_call_resource_descriptor(
     pipe_id: PipefyId, tool_name: str, arguments: dict[str, Any] | None
 ) -> str:
     descriptor = f"iPaaS catalog tool '{tool_name}' on pipe {pipe_id}"
-    if arguments is None or "operation" not in arguments:
+    if not arguments:
         return descriptor
-    return f"{descriptor} (operation {arguments['operation']})"
+    rendered = json.dumps(arguments, sort_keys=True, separators=(",", ":"), default=str)
+    return f"{descriptor} ({rendered})"
 
 
 def _catalog_entry_named(
@@ -248,7 +264,8 @@ class IpaasTools:
             (case-insensitive equality), else a delete-like substring in the
             catalog name. Call once to receive ``confirmation_token``, then
             echo that token with ``confirm=True`` on step 2. Mixed manage
-            ADD/UPDATE stay one-shot. A token is replayable within its TTL.
+            ADD/UPDATE stay one-shot unless a confirmation token is supplied.
+            A token is replayable within its TTL.
 
             Prefer the read and validate tools while iterating, and for
             long-running executions (flow tests, retries) inspect progress
@@ -270,28 +287,33 @@ class IpaasTools:
             """
 
             async def work(gateway: IpaasGateway, token: str) -> dict:
-                async with gateway.mcp_session(token) as mcp:
-                    catalog = await mcp.list_tools()
+                async with gateway.mcp_session(token) as ipaas_session:
+                    catalog = await ipaas_session.list_tools()
                     entry = _catalog_entry_named(catalog, tool_name)
                     judged = {"name": tool_name} if entry is None else entry
+                    destructive = ipaas_call_is_destructive(judged, arguments)
                     # A leftover DELETE token must not authorize mixed ADD
                     # (identity includes operation). ADD without a token stays
                     # one-shot.
-                    if (
-                        ipaas_call_is_destructive(judged, arguments)
-                        or confirmation_token
-                    ):
+                    if destructive or confirmation_token:
                         descriptor = _ipaas_call_resource_descriptor(
                             pipe_id, tool_name, arguments
                         )
+                        if destructive:
+                            irreversible = (
+                                f"⚠️ Running {descriptor} is permanent "
+                                "and cannot be undone."
+                            )
+                        else:
+                            irreversible = (
+                                f"⚠️ Running {descriptor} is being "
+                                "re-checked against its confirmation token."
+                            )
                         guard = await check_destructive_confirmation(
                             ctx,
                             confirm=confirm,
                             resource_descriptor=descriptor,
-                            irreversible_sentence=(
-                                f"⚠️ Running {descriptor} is permanent "
-                                "and cannot be undone."
-                            ),
+                            irreversible_sentence=irreversible,
                             resource_identity=_ipaas_call_resource_identity(
                                 pipe_id, tool_name, arguments
                             ),
@@ -300,7 +322,7 @@ class IpaasTools:
                         )
                         if guard is not None:
                             return guard
-                    result = await mcp.call_tool(tool_name, arguments)
+                    result = await ipaas_session.call_tool(tool_name, arguments)
                 return _call_result_payload(pipe_id, tool_name, result)
 
             return await _run_ipaas_tool(ctx, pipe_id, work)

--- a/packages/mcp/tests/core/test_ipaas_gateway.py
+++ b/packages/mcp/tests/core/test_ipaas_gateway.py
@@ -306,6 +306,50 @@ async def test_jsonrpc_error_from_tools_call_names_the_method(respx_mock, gatewa
 
 @pytest.mark.anyio
 @respx.mock
+async def test_mcp_session_list_then_call_posts_token_once(respx_mock, gateway):
+    """list_tools then call_tool inside one session run the OAuth handshake once."""
+    _mock_auth_chain(respx_mock)
+
+    def mcp_responder(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        method = body["method"]
+        if method == "initialize":
+            return httpx.Response(
+                200, json={"jsonrpc": "2.0", "id": body["id"], "result": {}}
+            )
+        if method == "tools/list":
+            return httpx.Response(
+                200,
+                json={"jsonrpc": "2.0", "id": body["id"], "result": {"tools": TOOLS}},
+            )
+        if method == "tools/call":
+            return httpx.Response(
+                200,
+                json={"jsonrpc": "2.0", "id": body["id"], "result": CALL_RESULT},
+            )
+        return httpx.Response(500)
+
+    respx_mock.post(f"{IPAAS_URL}/mcp").mock(side_effect=mcp_responder)
+
+    async with gateway.mcp_session("embed-jwt") as mcp:
+        tools = await mcp.list_tools()
+        result = await mcp.call_tool("demo_create_flow", {"name": "My flow"})
+
+    assert tools == TOOLS
+    assert result == CALL_RESULT
+    token_posts = [
+        call
+        for call in respx_mock.calls
+        if urlparse(str(call.request.url)).path == "/token"
+    ]
+    assert len(token_posts) == 1
+    assert not any(
+        key in vars(gateway) for key in ("access_token", "_cached_access_token")
+    )
+
+
+@pytest.mark.anyio
+@respx.mock
 async def test_call_tool_timeout_names_the_method_and_points_at_runs(
     respx_mock, gateway
 ):

--- a/packages/mcp/tests/core/test_ipaas_gateway.py
+++ b/packages/mcp/tests/core/test_ipaas_gateway.py
@@ -213,10 +213,52 @@ async def test_jsonrpc_error_from_tools_list_raises(respx_mock, gateway):
         await gateway.list_tools("embed-jwt")
 
 
+@pytest.mark.anyio
+@respx.mock
+async def test_list_tools_missing_tools_key_names_the_step(respx_mock, gateway):
+    _mock_happy_chain(respx_mock, rpc_result={})
+
+    with pytest.raises(IpaasGatewayError, match="tools/list.*without 'tools'"):
+        await gateway.list_tools("embed-jwt")
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_list_tools_non_list_tools_field_names_the_step(respx_mock, gateway):
+    _mock_happy_chain(respx_mock, rpc_result={"tools": "nope"})
+
+    with pytest.raises(IpaasGatewayError, match="tools/list.*not a list"):
+        await gateway.list_tools("embed-jwt")
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_list_tools_non_object_catalog_entry_names_the_step(respx_mock, gateway):
+    _mock_happy_chain(respx_mock, rpc_result={"tools": ["not-an-object"]})
+
+    with pytest.raises(IpaasGatewayError, match="tools/list.*not an object"):
+        await gateway.list_tools("embed-jwt")
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_session_list_tools_missing_tools_key_names_the_step(respx_mock, gateway):
+    _mock_happy_chain(respx_mock, rpc_result={})
+
+    with pytest.raises(IpaasGatewayError, match="tools/list.*without 'tools'"):
+        async with gateway.mcp_session("embed-jwt") as session:
+            await session.list_tools()
+
+
 CALL_RESULT = {
     "content": [{"type": "text", "text": "flow created: flow-1"}],
     "isError": False,
 }
+
+
+async def _session_call_tool(gateway, token, name, arguments=None):
+    async with gateway.mcp_session(token) as session:
+        return await session.call_tool(name, arguments)
 
 
 @pytest.mark.anyio
@@ -224,8 +266,8 @@ CALL_RESULT = {
 async def test_call_tool_posts_tools_call_with_arguments(respx_mock, gateway):
     mcp_route = _mock_happy_chain(respx_mock, rpc_result=CALL_RESULT)
 
-    result = await gateway.call_tool(
-        "embed-jwt", "demo_create_flow", {"name": "My flow"}
+    result = await _session_call_tool(
+        gateway, "embed-jwt", "demo_create_flow", {"name": "My flow"}
     )
 
     assert result == CALL_RESULT
@@ -245,7 +287,7 @@ async def test_call_tool_posts_tools_call_with_arguments(respx_mock, gateway):
 async def test_call_tool_defaults_arguments_to_empty_object(respx_mock, gateway):
     mcp_route = _mock_happy_chain(respx_mock, rpc_result=CALL_RESULT)
 
-    await gateway.call_tool("embed-jwt", "demo_list_flows")
+    await _session_call_tool(gateway, "embed-jwt", "demo_list_flows")
 
     body = json.loads(mcp_route.calls.last.request.content)
     assert body["params"] == {"name": "demo_list_flows", "arguments": {}}
@@ -259,7 +301,9 @@ async def test_call_tool_gives_only_the_invocation_hop_the_long_timeout(
     """A called tool may run a real flow; the handshake hops keep 30s."""
     mcp_route = _mock_happy_chain(respx_mock, rpc_result=CALL_RESULT)
 
-    await gateway.call_tool("embed-jwt", "demo_test_flow", {"flowId": "flow-1"})
+    await _session_call_tool(
+        gateway, "embed-jwt", "demo_test_flow", {"flowId": "flow-1"}
+    )
 
     initialize, invocation = mcp_route.calls[-2].request, mcp_route.calls[-1].request
     assert initialize.extensions["timeout"]["read"] == REQUEST_TIMEOUT_SECONDS
@@ -276,7 +320,9 @@ async def test_call_tool_relays_host_error_results_without_raising(respx_mock, g
     }
     _mock_happy_chain(respx_mock, rpc_result=error_result)
 
-    result = await gateway.call_tool("embed-jwt", "demo_delete_flow", {"id": "nope"})
+    result = await _session_call_tool(
+        gateway, "embed-jwt", "demo_delete_flow", {"id": "nope"}
+    )
 
     assert result == error_result
 
@@ -286,7 +332,9 @@ async def test_call_tool_relays_host_error_results_without_raising(respx_mock, g
 async def test_call_tool_parses_sse_encoded_response(respx_mock, gateway):
     _mock_happy_chain(respx_mock, sse_tools_list=True, rpc_result=CALL_RESULT)
 
-    result = await gateway.call_tool("embed-jwt", "demo_create_flow", {"name": "x"})
+    result = await _session_call_tool(
+        gateway, "embed-jwt", "demo_create_flow", {"name": "x"}
+    )
 
     assert result == CALL_RESULT
 
@@ -301,7 +349,7 @@ async def test_jsonrpc_error_from_tools_call_names_the_method(respx_mock, gatewa
     )
 
     with pytest.raises(IpaasGatewayError, match="tools/call returned an error"):
-        await gateway.call_tool("embed-jwt", "demo_create_flow", {})
+        await _session_call_tool(gateway, "embed-jwt", "demo_create_flow", {})
 
 
 @pytest.mark.anyio
@@ -366,7 +414,9 @@ async def test_call_tool_timeout_names_the_method_and_points_at_runs(
     with pytest.raises(
         IpaasGatewayError, match="tools/call timed out after 120s.*run-listing"
     ):
-        await gateway.call_tool("embed-jwt", "demo_test_flow", {"flowId": "flow-1"})
+        await _session_call_tool(
+            gateway, "embed-jwt", "demo_test_flow", {"flowId": "flow-1"}
+        )
 
 
 @pytest.mark.anyio
@@ -381,7 +431,9 @@ async def test_handshake_timeout_reports_retry_safe(respx_mock, gateway):
     respx_mock.post(f"{IPAAS_URL}/mcp").mock(side_effect=responder)
 
     with pytest.raises(IpaasGatewayError, match="handshake timed out.*safe to retry"):
-        await gateway.call_tool("embed-jwt", "demo_test_flow", {"flowId": "flow-1"})
+        await _session_call_tool(
+            gateway, "embed-jwt", "demo_test_flow", {"flowId": "flow-1"}
+        )
 
 
 @pytest.mark.anyio
@@ -391,7 +443,7 @@ async def test_response_without_result_names_the_method(respx_mock, gateway):
     respx_mock.post(f"{IPAAS_URL}/mcp").respond(200, json={"jsonrpc": "2.0", "id": 2})
 
     with pytest.raises(IpaasGatewayError, match="tools/call.*no result"):
-        await gateway.call_tool("embed-jwt", "demo_list_flows")
+        await _session_call_tool(gateway, "embed-jwt", "demo_list_flows")
 
 
 PIECE_NAME = "@example/piece-demo"
@@ -608,7 +660,9 @@ async def test_sse_notification_frames_before_the_response_are_skipped(
 
     respx_mock.post(f"{IPAAS_URL}/mcp").mock(side_effect=responder)
 
-    result = await gateway.call_tool("embed-jwt", "demo_create_flow", {"name": "x"})
+    result = await _session_call_tool(
+        gateway, "embed-jwt", "demo_create_flow", {"name": "x"}
+    )
 
     assert result == CALL_RESULT
 
@@ -623,7 +677,7 @@ async def test_null_result_is_a_protocol_error(respx_mock, gateway):
     )
 
     with pytest.raises(IpaasGatewayError, match="tools/call.*non-object result"):
-        await gateway.call_tool("embed-jwt", "demo_list_flows")
+        await _session_call_tool(gateway, "embed-jwt", "demo_list_flows")
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_destructive_tool_guard.py
+++ b/packages/mcp/tests/tools/test_destructive_tool_guard.py
@@ -1,5 +1,6 @@
 """Tests for the reusable destructive tool confirmation guard."""
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -333,3 +334,35 @@ class TestMissingBearer:
         payload = await _check(ctx, confirm=False)
         _assert_preview(payload)
         ctx.elicit.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_signing_key_is_absent_from_preview_and_token_error_envelopes(
+    monkeypatch,
+):
+    canary = b"leak-canary-signing-key-bytes!!"
+    monkeypatch.setattr(guard_mod, "signing_key_for", lambda _ctx: canary)
+    ctx = _make_ctx(can_elicit=False)
+
+    def assert_key_absent(payload):
+        blob = json.dumps(payload, default=str)
+        assert canary.decode() not in blob
+        assert canary.hex() not in blob
+        assert str(canary) not in blob
+
+    preview = await _check(ctx, confirm=False)
+    assert_key_absent(preview)
+
+    missing = await _check(ctx, confirm=True, confirmation_token=None)
+    assert_key_absent(missing)
+
+    invalid = await _check(ctx, confirm=True, confirmation_token="not-a-token")
+    assert_key_absent(invalid)
+
+    mismatch = await _check(
+        ctx,
+        confirm=True,
+        confirmation_token=preview["confirmation_token"],
+        resource_identity={"phase_id": "other"},
+    )
+    assert_key_absent(mismatch)

--- a/packages/mcp/tests/tools/test_destructive_tool_guard.py
+++ b/packages/mcp/tests/tools/test_destructive_tool_guard.py
@@ -86,6 +86,7 @@ async def _check(
     tool_name=TOOL_NAME,
     confirmation_token=None,
     dependents_resolver=None,
+    irreversible_sentence=None,
 ):
     return await check_destructive_confirmation(
         ctx,
@@ -95,6 +96,7 @@ async def _check(
         tool_name=tool_name,
         confirmation_token=confirmation_token,
         dependents_resolver=dependents_resolver,
+        irreversible_sentence=irreversible_sentence,
     )
 
 
@@ -104,6 +106,18 @@ class TestNoElicitation:
         ctx = _make_ctx(can_elicit=False)
         payload = await _check(ctx, confirm=False)
         _assert_preview(payload)
+        assert payload["message"].startswith(f"⚠️ Deleting {RESOURCE}")
+        ctx.elicit.assert_not_called()
+
+    async def test_custom_irreversible_sentence_is_first_preview_sentence(self):
+        ctx = _make_ctx(can_elicit=False)
+        sentence = (
+            "⚠️ This GraphQL mutation's effects are permanent and cannot be undone."
+        )
+        payload = await _check(ctx, confirm=False, irreversible_sentence=sentence)
+        _assert_preview(payload)
+        assert payload["message"].startswith(sentence)
+        assert not payload["message"].startswith("⚠️ Deleting")
         ctx.elicit.assert_not_called()
 
 

--- a/packages/mcp/tests/tools/test_destructive_tool_guard.py
+++ b/packages/mcp/tests/tools/test_destructive_tool_guard.py
@@ -111,13 +111,10 @@ class TestNoElicitation:
 
     async def test_custom_irreversible_sentence_is_first_preview_sentence(self):
         ctx = _make_ctx(can_elicit=False)
-        sentence = (
-            "⚠️ This GraphQL mutation's effects are permanent and cannot be undone."
-        )
+        sentence = "⚠️ Running this catalog call is permanent and cannot be undone."
         payload = await _check(ctx, confirm=False, irreversible_sentence=sentence)
         _assert_preview(payload)
         assert payload["message"].startswith(sentence)
-        assert not payload["message"].startswith("⚠️ Deleting")
         ctx.elicit.assert_not_called()
 
 

--- a/packages/mcp/tests/tools/test_introspection_scenarios.py
+++ b/packages/mcp/tests/tools/test_introspection_scenarios.py
@@ -12,6 +12,7 @@ from pipefy_sdk import PipefyClient
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.introspection_tools import IntrospectionTools
 from tools.conftest import build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 
 @pytest.fixture
@@ -103,21 +104,23 @@ async def test_scenario_discover_input_shape_then_execute_mutation_path(
         t1 = await session.call_tool(
             "introspect_type", {"type_name": "CreateLabelInput"}
         )
-        ex = await session.call_tool(
+        p3 = await confirm_after_preview(
+            session,
             "execute_graphql",
             {
-                "query": "mutation M($input: CreateLabelInput!) { createLabel(input: $input) { label { id } } }",
+                "query": (
+                    "mutation M($input: CreateLabelInput!) { "
+                    "createLabel(input: $input) { label { id } } }"
+                ),
                 "variables": {"input": {"pipe_id": "1", "name": "From agent"}},
             },
         )
 
     assert m1.is_error is False
     assert t1.is_error is False
-    assert ex.is_error is False
 
     p1 = extract_payload(m1)
     p2 = extract_payload(t1)
-    p3 = extract_payload(ex)
     assert p1["success"] and "createLabel" in p1["result"]
     assert p2["success"] and "CreateLabelInput" in p2["result"]
     assert p3["success"] and "lbl_1" in p3["result"]

--- a/packages/mcp/tests/tools/test_introspection_tools.py
+++ b/packages/mcp/tests/tools/test_introspection_tools.py
@@ -347,7 +347,6 @@ async def test_execute_graphql_mutation_without_token_returns_preview(
     token = payload["confirmation_token"]
     assert token
     assert token.startswith("v1.")
-    assert "Deleting GraphQL mutation" not in payload["message"]
     assert payload["message"].startswith(
         "⚠️ This GraphQL mutation's effects are permanent and cannot be undone."
     )

--- a/packages/mcp/tests/tools/test_introspection_tools.py
+++ b/packages/mcp/tests/tools/test_introspection_tools.py
@@ -12,6 +12,7 @@ from pipefy_sdk import PipefyClient, PipefyGraphQLError
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.tools.introspection_tools import IntrospectionTools
 from tools.conftest import build_tool_test_server
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 
 @pytest.fixture
@@ -325,7 +326,111 @@ async def test_execute_graphql_success(
     )
     payload = extract_payload(result)
     assert payload["success"] is True
+    assert payload.get("requires_confirmation") is not True
     assert "Query" in payload["result"]
+
+
+@pytest.mark.anyio
+async def test_execute_graphql_mutation_without_token_returns_preview(
+    introspection_session, mock_introspection_client, extract_payload
+):
+    async with introspection_session as session:
+        result = await session.call_tool(
+            "execute_graphql",
+            {"query": "mutation { __typename }"},
+        )
+    assert result.is_error is False
+    mock_introspection_client.execute_graphql.assert_not_awaited()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["requires_confirmation"] is True
+    token = payload["confirmation_token"]
+    assert token
+    assert token.startswith("v1.")
+
+
+@pytest.mark.anyio
+async def test_execute_graphql_mutation_identity_hashes_are_hex(
+    introspection_session, mock_introspection_client, monkeypatch
+):
+    captured = {}
+
+    async def capture_guard(_ctx, **kwargs):
+        captured["resource_identity"] = kwargs["resource_identity"]
+        return {
+            "success": False,
+            "requires_confirmation": True,
+            "confirmation_token": "v1.preview",
+        }
+
+    monkeypatch.setattr(
+        "pipefy_mcp.tools.introspection_tools.check_destructive_confirmation",
+        capture_guard,
+    )
+    async with introspection_session as session:
+        await session.call_tool(
+            "execute_graphql",
+            {"query": "mutation { __typename }", "variables": {"n": 1}},
+        )
+    mock_introspection_client.execute_graphql.assert_not_awaited()
+    identity = captured["resource_identity"]
+    for value in (identity["document"], identity["variables"]):
+        assert isinstance(value, str)
+        assert len(value) == 64
+        assert all(c in "0123456789abcdef" for c in value)
+
+
+@pytest.mark.anyio
+async def test_execute_graphql_mutation_with_matching_token_executes(
+    introspection_session, mock_introspection_client
+):
+    mock_introspection_client.execute_graphql = AsyncMock(
+        return_value={"__typename": "Mutation"}
+    )
+    async with introspection_session as session:
+        payload = await confirm_after_preview(
+            session,
+            "execute_graphql",
+            {"query": "mutation { __typename }", "confirm": True},
+        )
+    mock_introspection_client.execute_graphql.assert_awaited_once_with(
+        "mutation { __typename }", None
+    )
+    assert payload["success"] is True
+    assert "Mutation" in payload["result"]
+
+
+@pytest.mark.anyio
+async def test_execute_graphql_token_from_mutation_a_does_not_execute_mutation_b(
+    introspection_session, mock_introspection_client, extract_payload
+):
+    async with introspection_session as session:
+        preview = await session.call_tool(
+            "execute_graphql",
+            {"query": "mutation A { __typename }"},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await session.call_tool(
+            "execute_graphql",
+            {
+                "query": "mutation B { __typename }",
+                "confirm": True,
+                "confirmation_token": token,
+            },
+        )
+    mock_introspection_client.execute_graphql.assert_not_awaited()
+    payload = extract_payload(mismatch)
+    assert payload["requires_confirmation"] is True
+
+
+@pytest.mark.anyio
+async def test_execute_graphql_does_not_set_destructive_hint(introspection_session):
+    async with introspection_session as session:
+        listed = await session.list_tools()
+    tool = next(t for t in listed.tools if t.name == "execute_graphql")
+    assert tool.annotations is not None
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is not True
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_introspection_tools.py
+++ b/packages/mcp/tests/tools/test_introspection_tools.py
@@ -424,6 +424,32 @@ async def test_execute_graphql_token_from_mutation_a_does_not_execute_mutation_b
 
 
 @pytest.mark.anyio
+async def test_execute_graphql_token_from_variables_a_does_not_execute_variables_b(
+    introspection_session, mock_introspection_client, extract_payload
+):
+    mutation = "mutation M($i: ID!) { __typename }"
+    async with introspection_session as session:
+        preview = await session.call_tool(
+            "execute_graphql",
+            {"query": mutation, "variables": {"i": "1"}},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await session.call_tool(
+            "execute_graphql",
+            {
+                "query": mutation,
+                "variables": {"i": "2"},
+                "confirm": True,
+                "confirmation_token": token,
+            },
+        )
+    mock_introspection_client.execute_graphql.assert_not_awaited()
+    payload = extract_payload(mismatch)
+    assert payload["requires_confirmation"] is True
+    assert payload["confirmation_token"] != token
+
+
+@pytest.mark.anyio
 async def test_execute_graphql_does_not_set_destructive_hint(introspection_session):
     async with introspection_session as session:
         listed = await session.list_tools()

--- a/packages/mcp/tests/tools/test_introspection_tools.py
+++ b/packages/mcp/tests/tools/test_introspection_tools.py
@@ -349,8 +349,30 @@ async def test_execute_graphql_mutation_without_token_returns_preview(
     assert token
     assert token.startswith("v1.")
     assert payload["message"].startswith(
-        "⚠️ This GraphQL mutation's effects are permanent and cannot be undone."
+        "⚠️ Executing GraphQL mutation __typename is permanent and cannot be undone."
     )
+
+
+@pytest.mark.anyio
+async def test_execute_graphql_previews_name_the_mutation_they_would_run(
+    introspection_session, mock_introspection_client, extract_payload
+):
+    """Two pending mutations must not render the same approval text."""
+    async with introspection_session as session:
+        first = await session.call_tool(
+            "execute_graphql",
+            {"query": "mutation DeleteThing { deleteCard { id } }"},
+        )
+        second = await session.call_tool(
+            "execute_graphql",
+            {"query": "mutation CreateThing { createCard { id } }"},
+        )
+    mock_introspection_client.execute_graphql.assert_not_awaited()
+    first_message = extract_payload(first)["message"]
+    second_message = extract_payload(second)["message"]
+    assert "DeleteThing" in first_message
+    assert "CreateThing" in second_message
+    assert first_message != second_message
 
 
 @pytest.mark.anyio
@@ -519,7 +541,9 @@ async def test_execute_graphql_too_nested_document_is_error_envelope(
     payload = extract_payload(result)
     assert payload["success"] is False
     assert payload.get("requires_confirmation") is not True
-    assert "nested" in tool_error_message(payload).lower()
+    message = tool_error_message(payload).lower()
+    assert "nested" in message
+    assert "nothing was sent" in message
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_introspection_tools.py
+++ b/packages/mcp/tests/tools/test_introspection_tools.py
@@ -347,6 +347,10 @@ async def test_execute_graphql_mutation_without_token_returns_preview(
     token = payload["confirmation_token"]
     assert token
     assert token.startswith("v1.")
+    assert "Deleting GraphQL mutation" not in payload["message"]
+    assert payload["message"].startswith(
+        "⚠️ This GraphQL mutation's effects are permanent and cannot be undone."
+    )
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_introspection_tools.py
+++ b/packages/mcp/tests/tools/test_introspection_tools.py
@@ -349,8 +349,11 @@ async def test_execute_graphql_mutation_without_token_returns_preview(
     assert token
     assert token.startswith("v1.")
     assert payload["message"].startswith(
-        "⚠️ Executing GraphQL mutation __typename is permanent and cannot be undone."
+        "Executing GraphQL mutation __typename needs approval because "
+        "this server cannot tell what the mutation changes."
     )
+    assert "permanent" not in payload["message"]
+    assert "cannot be undone" not in payload["message"]
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_introspection_tools.py
+++ b/packages/mcp/tests/tools/test_introspection_tools.py
@@ -1,5 +1,6 @@
 """Tests for GraphQL introspection MCP tools (mocked PipefyClient)."""
 
+import json
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
@@ -450,6 +451,75 @@ async def test_execute_graphql_token_from_variables_a_does_not_execute_variables
     payload = extract_payload(mismatch)
     assert payload["requires_confirmation"] is True
     assert payload["confirmation_token"] != token
+
+
+@pytest.mark.anyio
+async def test_execute_graphql_mutation_previews_name_the_operation(
+    introspection_session, mock_introspection_client, extract_payload
+):
+    async with introspection_session as session:
+        preview_a = await session.call_tool(
+            "execute_graphql",
+            {"query": "mutation DeletePipe { deletePipe(id: 999) { id } }"},
+        )
+        preview_b = await session.call_tool(
+            "execute_graphql",
+            {"query": "mutation DeleteCard { deleteCard(id: 111) { id } }"},
+        )
+    mock_introspection_client.execute_graphql.assert_not_awaited()
+    payload_a = extract_payload(preview_a)
+    payload_b = extract_payload(preview_b)
+    assert payload_a["resource"] != payload_b["resource"]
+    assert "DeletePipe" in payload_a["resource"]
+    assert "DeleteCard" in payload_b["resource"]
+
+
+@pytest.mark.anyio
+async def test_execute_graphql_preview_does_not_leak_signing_key(
+    introspection_session, mock_introspection_client, extract_payload, monkeypatch
+):
+    canary = b"leak-canary-signing-key-bytes!!"
+    monkeypatch.setattr(
+        "pipefy_mcp.tools.destructive_tool_guard.signing_key_for",
+        lambda _ctx: canary,
+    )
+    async with introspection_session as session:
+        preview = await session.call_tool(
+            "execute_graphql",
+            {"query": "mutation { __typename }"},
+        )
+        invalid = await session.call_tool(
+            "execute_graphql",
+            {
+                "query": "mutation { __typename }",
+                "confirm": True,
+                "confirmation_token": "not-a-token",
+            },
+        )
+    mock_introspection_client.execute_graphql.assert_not_awaited()
+    for result in (preview, invalid):
+        blob = json.dumps(extract_payload(result), default=str)
+        assert canary.decode() not in blob
+        assert canary.hex() not in blob
+        assert str(canary) not in blob
+
+
+_TOO_NESTED_QUERY = "{a" * 400 + "}" * 400
+_TOO_NESTED_MUTATION = "mutation { " + "a { " * 400 + "x " + "} " * 401
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("query", [_TOO_NESTED_QUERY, _TOO_NESTED_MUTATION])
+async def test_execute_graphql_too_nested_document_is_error_envelope(
+    introspection_session, mock_introspection_client, extract_payload, query
+):
+    async with introspection_session as session:
+        result = await session.call_tool("execute_graphql", {"query": query})
+    mock_introspection_client.execute_graphql.assert_not_awaited()
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload.get("requires_confirmation") is not True
+    assert "nested" in tool_error_message(payload).lower()
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_ipaas_tools.py
+++ b/packages/mcp/tests/tools/test_ipaas_tools.py
@@ -94,30 +94,26 @@ def _wire_entry(name, *, destructive_hint=None, extra_annotations=None):
     return entry
 
 
-_MIXED_WIDGETS = _wire_entry("manage_widgets", destructive_hint=False)
+_MIXED_WIDGETS = _wire_entry("demo_manage_widgets", destructive_hint=False)
 
 
 @pytest.fixture
 def mock_gateway():
     gateway = MagicMock(IpaasGateway)
     gateway.list_tools = AsyncMock(return_value=TOOLS)
-    gateway.call_tool = AsyncMock(return_value=_CALL_OK)
+    opened_session = MagicMock()
+    opened_session.call_tool = AsyncMock(return_value=_CALL_OK)
 
     @asynccontextmanager
     async def mcp_session(token):
-        session = MagicMock()
-
         async def list_tools():
             return await gateway.list_tools(token)
 
-        async def call_tool(name, arguments=None):
-            return await gateway.call_tool(token, name, arguments)
-
-        session.list_tools = list_tools
-        session.call_tool = call_tool
-        yield session
+        opened_session.list_tools = list_tools
+        yield opened_session
 
     gateway.mcp_session = mcp_session
+    gateway.opened_session = opened_session
     return gateway
 
 
@@ -139,7 +135,7 @@ def test_ipaas_destructive_needles_are_the_frozen_six():
 
 
 def test_ipaas_call_is_destructive_annotation_true_wins_over_benign_name():
-    entry = _wire_entry("archive_everything", destructive_hint=True)
+    entry = _wire_entry("demo_archive_everything", destructive_hint=True)
     assert ipaas_call_is_destructive(entry, None) is True
     assert ipaas_call_is_destructive(entry, {"operation": "ADD"}) is True
 
@@ -156,29 +152,34 @@ def test_ipaas_call_is_destructive_operation_equality_gates_even_when_annotated_
 
 
 def test_ipaas_call_is_destructive_annotation_false_does_not_fall_through_to_name():
-    entry = _wire_entry("delete_flow", destructive_hint=False)
+    entry = _wire_entry("demo_delete_flow", destructive_hint=False)
     assert ipaas_call_is_destructive(entry, None) is False
 
 
 def test_ipaas_call_is_destructive_no_boolean_uses_name_substring():
-    named = {"name": "delete_flow"}
+    named = {"name": "demo_delete_flow"}
     assert ipaas_call_is_destructive(named, None) is True
     assert (
         ipaas_call_is_destructive(
-            _wire_entry("list_flows", extra_annotations={"readOnlyHint": True}),
+            _wire_entry("demo_list_flows", extra_annotations={"readOnlyHint": True}),
             None,
         )
         is False
     )
-    assert ipaas_call_is_destructive({"name": "list_flows"}, None) is False
+    assert ipaas_call_is_destructive({"name": "demo_list_flows"}, None) is False
 
 
-def test_ipaas_call_is_destructive_missing_entry_is_no_boolean():
-    assert ipaas_call_is_destructive(None, None) is False
-    assert ipaas_call_is_destructive(None, {"operation": "DELETE"}) is True
-    assert ipaas_call_is_destructive(None, {"operation": "UNDELETE"}) is False
-    assert ipaas_call_is_destructive({"name": "delete_flow"}, None) is True
-    assert ipaas_call_is_destructive({"name": "list_widgets"}, None) is False
+def test_ipaas_call_is_destructive_catalog_miss_falls_back_to_operation():
+    # A catalog miss reaches the classifier as {"name": tool_name}, so there is
+    # no annotation to short-circuit on and the operation needle decides. The
+    # name-substring half of that fallback is covered by the test above.
+    assert (
+        ipaas_call_is_destructive({"name": "unknown"}, {"operation": "DELETE"}) is True
+    )
+    assert (
+        ipaas_call_is_destructive({"name": "unknown"}, {"operation": "UNDELETE"})
+        is False
+    )
 
 
 @pytest.mark.anyio
@@ -337,7 +338,7 @@ async def test_int_pipe_id_is_coerced_to_string(
 async def test_call_tool_forwards_arguments_and_relays_output(
     mock_client, mock_gateway, extract_payload
 ):
-    mock_gateway.call_tool = AsyncMock(
+    mock_gateway.opened_session.call_tool = AsyncMock(
         return_value={
             "content": [
                 {"type": "text", "text": "flow created"},
@@ -362,8 +363,8 @@ async def test_call_tool_forwards_arguments_and_relays_output(
     assert payload["success"] is True
     mock_client.get_advanced_automations_token.assert_awaited_once_with("303088927")
     mock_gateway.list_tools.assert_awaited_once_with("embed-jwt")
-    mock_gateway.call_tool.assert_awaited_once_with(
-        "embed-jwt", "demo_create_flow", {"name": "My flow"}
+    mock_gateway.opened_session.call_tool.assert_awaited_once_with(
+        "demo_create_flow", {"name": "My flow"}
     )
     # Text segments are joined and relayed in full.
     assert "flow created" in payload["result"]
@@ -375,7 +376,7 @@ async def test_call_tool_forwards_arguments_and_relays_output(
 async def test_call_tool_arguments_default_to_none(
     mock_client, mock_gateway, extract_payload
 ):
-    mock_gateway.call_tool = AsyncMock(
+    mock_gateway.opened_session.call_tool = AsyncMock(
         return_value={"content": [{"type": "text", "text": "[]"}], "isError": False}
     )
     server = build_ipaas_test_server(mock_client, mock_gateway)
@@ -387,8 +388,8 @@ async def test_call_tool_arguments_default_to_none(
 
     payload = extract_payload(result)
     assert payload["success"] is True
-    mock_gateway.call_tool.assert_awaited_once_with(
-        "embed-jwt", "demo_list_flows", None
+    mock_gateway.opened_session.call_tool.assert_awaited_once_with(
+        "demo_list_flows", None
     )
 
 
@@ -396,7 +397,7 @@ async def test_call_tool_arguments_default_to_none(
 async def test_call_tool_maps_host_iserror_to_error_payload(
     mock_client, mock_gateway, extract_payload
 ):
-    mock_gateway.call_tool = AsyncMock(
+    mock_gateway.opened_session.call_tool = AsyncMock(
         return_value={
             "content": [{"type": "text", "text": "flow not found"}],
             "isError": True,
@@ -420,7 +421,7 @@ async def test_call_tool_null_result_becomes_error_payload_not_attribute_error(
 ):
     """A host `result: null` surfaces (via the gateway guard) as the standard
     envelope, never a bare `AttributeError` on a None result."""
-    mock_gateway.call_tool = AsyncMock(
+    mock_gateway.opened_session.call_tool = AsyncMock(
         side_effect=IpaasGatewayError("iPaaS tools/call returned a non-object result.")
     )
     server = build_ipaas_test_server(mock_client, mock_gateway)
@@ -439,7 +440,7 @@ async def test_call_tool_null_result_becomes_error_payload_not_attribute_error(
 async def test_call_tool_passes_non_text_content_through(
     mock_client, mock_gateway, extract_payload
 ):
-    mock_gateway.call_tool = AsyncMock(
+    mock_gateway.opened_session.call_tool = AsyncMock(
         return_value={
             "content": [
                 {"type": "text", "text": "done"},
@@ -465,7 +466,7 @@ async def test_call_tool_passes_non_text_content_through(
 async def test_call_tool_gateway_error_becomes_error_payload(
     mock_client, mock_gateway, extract_payload
 ):
-    mock_gateway.call_tool = AsyncMock(
+    mock_gateway.opened_session.call_tool = AsyncMock(
         side_effect=IpaasGatewayError("iPaaS tools/call failed (HTTP 500): boom")
     )
     server = build_ipaas_test_server(mock_client, mock_gateway)
@@ -513,17 +514,19 @@ async def test_read_like_annotated_false_calls_tool_without_preview(
     mock_client, mock_gateway, extract_payload
 ):
     mock_gateway.list_tools = AsyncMock(
-        return_value=[_wire_entry("list_flows", destructive_hint=False)]
+        return_value=[_wire_entry("demo_list_flows", destructive_hint=False)]
     )
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
-        result = await _call_ipaas(session, "list_flows")
+        result = await _call_ipaas(session, "demo_list_flows")
 
     payload = extract_payload(result)
     assert payload["success"] is True
     assert payload.get("requires_confirmation") is not True
     mock_gateway.list_tools.assert_awaited_once_with("embed-jwt")
-    mock_gateway.call_tool.assert_awaited_once_with("embed-jwt", "list_flows", None)
+    mock_gateway.opened_session.call_tool.assert_awaited_once_with(
+        "demo_list_flows", None
+    )
 
 
 @pytest.mark.anyio
@@ -531,19 +534,19 @@ async def test_annotated_true_benign_name_previews_without_calling(
     mock_client, mock_gateway, extract_payload
 ):
     mock_gateway.list_tools = AsyncMock(
-        return_value=[_wire_entry("archive_everything", destructive_hint=True)]
+        return_value=[_wire_entry("demo_archive_everything", destructive_hint=True)]
     )
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
-        result = await _call_ipaas(session, "archive_everything")
+        result = await _call_ipaas(session, "demo_archive_everything")
 
     payload = extract_payload(result)
     assert payload["success"] is False
     assert payload["requires_confirmation"] is True
     assert payload["confirmation_token"]
-    assert "archive_everything" in payload["resource"]
+    assert "demo_archive_everything" in payload["resource"]
     assert PIPE_ID in payload["resource"]
-    mock_gateway.call_tool.assert_not_awaited()
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -552,16 +555,16 @@ async def test_no_boolean_delete_flow_name_previews(
 ):
     mock_gateway.list_tools = AsyncMock(
         return_value=[
-            _wire_entry("delete_flow", extra_annotations={"readOnlyHint": False})
+            _wire_entry("demo_delete_flow", extra_annotations={"readOnlyHint": False})
         ]
     )
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
-        result = await _call_ipaas(session, "delete_flow")
+        result = await _call_ipaas(session, "demo_delete_flow")
 
     payload = extract_payload(result)
     assert payload["requires_confirmation"] is True
-    mock_gateway.call_tool.assert_not_awaited()
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -571,12 +574,12 @@ async def test_mixed_operation_add_calls_tool(
     mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
-        result = await _call_ipaas(session, "manage_widgets", {"operation": "ADD"})
+        result = await _call_ipaas(session, "demo_manage_widgets", {"operation": "ADD"})
 
     payload = extract_payload(result)
     assert payload["success"] is True
-    mock_gateway.call_tool.assert_awaited_once_with(
-        "embed-jwt", "manage_widgets", {"operation": "ADD"}
+    mock_gateway.opened_session.call_tool.assert_awaited_once_with(
+        "demo_manage_widgets", {"operation": "ADD"}
     )
 
 
@@ -606,20 +609,25 @@ async def test_mixed_operation_delete_previews_with_operation_identity(
     )
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
-        result = await _call_ipaas(session, "manage_widgets", {"operation": operation})
+        result = await _call_ipaas(
+            session, "demo_manage_widgets", {"operation": operation}
+        )
 
     payload = extract_payload(result)
     assert payload["requires_confirmation"] is True
-    mock_gateway.call_tool.assert_not_awaited()
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
     assert captured["tool_name"] == "call_ipaas_tool"
-    assert captured["resource_identity"] == {
-        "pipe_id": PIPE_ID,
-        "tool_name": "manage_widgets",
-        "operation": "delete",
-    }
+    identity = captured["resource_identity"]
+    assert identity["pipe_id"] == PIPE_ID
+    assert identity["tool_name"] == "demo_manage_widgets"
+    assert identity["operation"] == "delete"
+    digest = identity["arguments"]
+    assert isinstance(digest, str)
+    assert len(digest) == 64
+    assert all(c in "0123456789abcdef" for c in digest)
     descriptor = captured["resource_descriptor"]
     assert PIPE_ID in descriptor
-    assert "manage_widgets" in descriptor
+    assert "demo_manage_widgets" in descriptor
     assert operation in descriptor
 
 
@@ -628,17 +636,17 @@ async def test_delete_token_does_not_confirm_add_arguments(
     mock_client, mock_gateway, extract_payload
 ):
     mock_gateway.list_tools = AsyncMock(
-        return_value=[_wire_entry("archive_everything", destructive_hint=True)]
+        return_value=[_wire_entry("demo_archive_everything", destructive_hint=True)]
     )
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
         preview = await _call_ipaas(
-            session, "archive_everything", {"operation": "DELETE"}
+            session, "demo_archive_everything", {"operation": "DELETE"}
         )
         token = extract_payload(preview)["confirmation_token"]
         mismatch = await _call_ipaas(
             session,
-            "archive_everything",
+            "demo_archive_everything",
             {"operation": "ADD"},
             confirm=True,
             confirmation_token=token,
@@ -648,7 +656,7 @@ async def test_delete_token_does_not_confirm_add_arguments(
     assert payload["requires_confirmation"] is True
     assert payload["confirmation_token"] != token
     assert payload["message"].startswith("⚠️ Running ")
-    mock_gateway.call_tool.assert_not_awaited()
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -658,11 +666,13 @@ async def test_mixed_delete_token_does_not_confirm_add_arguments(
     mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
-        preview = await _call_ipaas(session, "manage_widgets", {"operation": "DELETE"})
+        preview = await _call_ipaas(
+            session, "demo_manage_widgets", {"operation": "DELETE"}
+        )
         token = extract_payload(preview)["confirmation_token"]
         mismatch = await _call_ipaas(
             session,
-            "manage_widgets",
+            "demo_manage_widgets",
             {"operation": "ADD"},
             confirm=True,
             confirmation_token=token,
@@ -672,7 +682,150 @@ async def test_mixed_delete_token_does_not_confirm_add_arguments(
     assert payload["requires_confirmation"] is True
     assert payload["confirmation_token"] != token
     assert payload["message"].startswith("⚠️ Running ")
-    mock_gateway.call_tool.assert_not_awaited()
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_delete_token_does_not_confirm_swapped_arguments(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(
+        return_value=[_wire_entry("demo_delete_flow", destructive_hint=True)]
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        preview_a = await _call_ipaas(session, "demo_delete_flow", {"id": "resource-a"})
+        preview_b = await _call_ipaas(session, "demo_delete_flow", {"id": "resource-b"})
+        token = extract_payload(preview_a)["confirmation_token"]
+        swapped = await _call_ipaas(
+            session,
+            "demo_delete_flow",
+            {"id": "resource-b"},
+            confirm=True,
+            confirmation_token=token,
+        )
+
+    payload_a = extract_payload(preview_a)
+    payload_b = extract_payload(preview_b)
+    assert payload_a["resource"] != payload_b["resource"]
+    payload = extract_payload(swapped)
+    assert payload["requires_confirmation"] is True
+    assert payload["confirmation_token"] != token
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_delete_token_confirms_reordered_arguments(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(
+        return_value=[_wire_entry("demo_delete_flow", destructive_hint=True)]
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        preview = await _call_ipaas(
+            session, "demo_delete_flow", {"z": "1", "id": "resource-a"}
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        confirmed = await _call_ipaas(
+            session,
+            "demo_delete_flow",
+            {"id": "resource-a", "z": "1"},
+            confirm=True,
+            confirmation_token=token,
+        )
+
+    payload = extract_payload(confirmed)
+    assert payload["success"] is True
+    mock_gateway.opened_session.call_tool.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_delete_token_confirms_case_variant_operation(
+    mock_client, mock_gateway, extract_payload
+):
+    """The case of ``operation`` is not part of what the caller approved.
+
+    The classifier casefolds it and the identity carries it casefolded, so the
+    arguments digest has to casefold it too. Without that, the same call
+    written ``delete`` would fail to confirm a token minted for ``DELETE``.
+    """
+    mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        preview = await _call_ipaas(
+            session,
+            "demo_manage_widgets",
+            {"operation": "DELETE", "id": "resource-a"},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        confirmed = await _call_ipaas(
+            session,
+            "demo_manage_widgets",
+            {"operation": "delete", "id": "resource-a"},
+            confirm=True,
+            confirmation_token=token,
+        )
+
+    payload = extract_payload(confirmed)
+    assert payload["success"] is True
+    mock_gateway.opened_session.call_tool.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_read_like_call_with_token_does_not_claim_permanent(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(
+        return_value=[_wire_entry("demo_list_flows", destructive_hint=False)]
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(
+            session,
+            "demo_list_flows",
+            confirmation_token="v1.stale-or-stray",
+        )
+
+    payload = extract_payload(result)
+    assert payload["requires_confirmation"] is True
+    assert "permanent" not in payload["message"]
+    assert "cannot be undone" not in payload["message"]
+    assert "confirmation token" in payload["message"]
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("needle", IPAAS_DESTRUCTIVE_NEEDLES)
+async def test_name_needle_gates_call_without_host(
+    mock_client, mock_gateway, extract_payload, needle
+):
+    name = f"demo_{needle}_item"
+    mock_gateway.list_tools = AsyncMock(return_value=[_wire_entry(name)])
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(session, name)
+
+    payload = extract_payload(result)
+    assert payload["requires_confirmation"] is True
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("needle", IPAAS_DESTRUCTIVE_NEEDLES)
+async def test_operation_needle_gates_mixed_call_without_host(
+    mock_client, mock_gateway, extract_payload, needle
+):
+    mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(
+            session, "demo_manage_widgets", {"operation": needle}
+        )
+
+    payload = extract_payload(result)
+    assert payload["requires_confirmation"] is True
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -687,15 +840,15 @@ async def test_delete_token_confirms_matching_delete_arguments(
             "call_ipaas_tool",
             {
                 "pipe_id": PIPE_ID,
-                "tool_name": "manage_widgets",
+                "tool_name": "demo_manage_widgets",
                 "arguments": {"operation": "DELETE"},
                 "confirm": True,
             },
         )
 
     assert payload["success"] is True
-    mock_gateway.call_tool.assert_awaited_once_with(
-        "embed-jwt", "manage_widgets", {"operation": "DELETE"}
+    mock_gateway.opened_session.call_tool.assert_awaited_once_with(
+        "demo_manage_widgets", {"operation": "DELETE"}
     )
 
 
@@ -706,11 +859,13 @@ async def test_mixed_undelete_operation_is_ungated(
     mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
-        result = await _call_ipaas(session, "manage_widgets", {"operation": "UNDELETE"})
+        result = await _call_ipaas(
+            session, "demo_manage_widgets", {"operation": "UNDELETE"}
+        )
 
     payload = extract_payload(result)
     assert payload["success"] is True
-    mock_gateway.call_tool.assert_awaited_once()
+    mock_gateway.opened_session.call_tool.assert_awaited_once()
 
 
 @pytest.mark.anyio
@@ -722,13 +877,13 @@ async def test_list_tools_failure_is_error_envelope_and_does_not_call(
     )
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
-        result = await _call_ipaas(session, "delete_flow")
+        result = await _call_ipaas(session, "demo_delete_flow")
 
     payload = extract_payload(result)
     assert payload["success"] is False
     assert payload.get("requires_confirmation") is not True
     assert "tools/list" in tool_error_message(payload)
-    mock_gateway.call_tool.assert_not_awaited()
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -738,11 +893,13 @@ async def test_missing_catalog_benign_name_still_calls(
     mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
-        result = await _call_ipaas(session, "list_widgets")
+        result = await _call_ipaas(session, "demo_list_widgets")
 
     payload = extract_payload(result)
     assert payload["success"] is True
-    mock_gateway.call_tool.assert_awaited_once_with("embed-jwt", "list_widgets", None)
+    mock_gateway.opened_session.call_tool.assert_awaited_once_with(
+        "demo_list_widgets", None
+    )
 
 
 @pytest.mark.anyio
@@ -752,11 +909,11 @@ async def test_missing_catalog_delete_flow_is_gated(
     mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
     server = build_ipaas_test_server(mock_client, mock_gateway)
     async with _session(server) as session:
-        result = await _call_ipaas(session, "delete_flow")
+        result = await _call_ipaas(session, "demo_delete_flow")
 
     payload = extract_payload(result)
     assert payload["requires_confirmation"] is True
-    mock_gateway.call_tool.assert_not_awaited()
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_ipaas_tools.py
+++ b/packages/mcp/tests/tools/test_ipaas_tools.py
@@ -647,6 +647,8 @@ async def test_delete_token_does_not_confirm_add_arguments(
     payload = extract_payload(mismatch)
     assert payload["requires_confirmation"] is True
     assert payload["confirmation_token"] != token
+    assert payload["message"].startswith("⚠️ Running ")
+    assert "Deleting iPaaS catalog tool" not in payload["message"]
     mock_gateway.call_tool.assert_not_awaited()
 
 
@@ -670,6 +672,8 @@ async def test_mixed_delete_token_does_not_confirm_add_arguments(
     payload = extract_payload(mismatch)
     assert payload["requires_confirmation"] is True
     assert payload["confirmation_token"] != token
+    assert payload["message"].startswith("⚠️ Running ")
+    assert "Deleting iPaaS catalog tool" not in payload["message"]
     mock_gateway.call_tool.assert_not_awaited()
 
 

--- a/packages/mcp/tests/tools/test_ipaas_tools.py
+++ b/packages/mcp/tests/tools/test_ipaas_tools.py
@@ -648,7 +648,6 @@ async def test_delete_token_does_not_confirm_add_arguments(
     assert payload["requires_confirmation"] is True
     assert payload["confirmation_token"] != token
     assert payload["message"].startswith("⚠️ Running ")
-    assert "Deleting iPaaS catalog tool" not in payload["message"]
     mock_gateway.call_tool.assert_not_awaited()
 
 
@@ -673,7 +672,6 @@ async def test_mixed_delete_token_does_not_confirm_add_arguments(
     assert payload["requires_confirmation"] is True
     assert payload["confirmation_token"] != token
     assert payload["message"].startswith("⚠️ Running ")
-    assert "Deleting iPaaS catalog tool" not in payload["message"]
     mock_gateway.call_tool.assert_not_awaited()
 
 

--- a/packages/mcp/tests/tools/test_ipaas_tools.py
+++ b/packages/mcp/tests/tools/test_ipaas_tools.py
@@ -681,7 +681,10 @@ async def test_mixed_delete_token_does_not_confirm_add_arguments(
     payload = extract_payload(mismatch)
     assert payload["requires_confirmation"] is True
     assert payload["confirmation_token"] != token
-    assert payload["message"].startswith("⚠️ Running ")
+    # The classifier clears ADD, so the re-check must not claim it destroys.
+    assert payload["message"].startswith("Running ")
+    assert "is not classified as destructive" in payload["message"]
+    assert "cannot be undone" not in payload["message"]
     mock_gateway.opened_session.call_tool.assert_not_awaited()
 
 

--- a/packages/mcp/tests/tools/test_ipaas_tools.py
+++ b/packages/mcp/tests/tools/test_ipaas_tools.py
@@ -144,6 +144,8 @@ def test_ipaas_call_is_destructive_operation_equality_gates_even_when_annotated_
     entry = _MIXED_WIDGETS
     assert ipaas_call_is_destructive(entry, {"operation": "DELETE"}) is True
     assert ipaas_call_is_destructive(entry, {"operation": "delete"}) is True
+    assert ipaas_call_is_destructive(entry, {"operation": "DELETE "}) is True
+    assert ipaas_call_is_destructive(entry, {"operation": " delete"}) is True
     assert ipaas_call_is_destructive(entry, {"operation": "ADD"}) is False
     assert ipaas_call_is_destructive(entry, {"operation": "UNDELETE"}) is False
     assert ipaas_call_is_destructive(entry, {"operation": 1}) is False
@@ -169,10 +171,9 @@ def test_ipaas_call_is_destructive_no_boolean_uses_name_substring():
     assert ipaas_call_is_destructive({"name": "demo_list_flows"}, None) is False
 
 
-def test_ipaas_call_is_destructive_catalog_miss_falls_back_to_operation():
-    # A catalog miss reaches the classifier as {"name": tool_name}, so there is
-    # no annotation to short-circuit on and the operation needle decides. The
-    # name-substring half of that fallback is covered by the test above.
+def test_ipaas_call_is_destructive_catalog_miss_is_not_classified_here():
+    # A catalog miss is gated at the call site, not by inventing a name-only
+    # entry for this classifier. Name-only objects still mean "no annotation".
     assert (
         ipaas_call_is_destructive({"name": "unknown"}, {"operation": "DELETE"}) is True
     )
@@ -453,7 +454,7 @@ async def test_call_tool_passes_non_text_content_through(
     async with _session(server) as session:
         result = await session.call_tool(
             "call_ipaas_tool",
-            {"pipe_id": "303088927", "tool_name": "demo_get_run"},
+            {"pipe_id": "303088927", "tool_name": "demo_list_flows"},
         )
 
     payload = extract_payload(result)
@@ -776,6 +777,78 @@ async def test_delete_token_confirms_case_variant_operation(
 
 
 @pytest.mark.anyio
+async def test_delete_token_confirms_whitespace_variant_operation(
+    mock_client, mock_gateway, extract_payload
+):
+    """Trailing space on ``operation`` is not part of what the caller approved.
+
+    The classifier strips then casefolds, and the identity carries the
+    normalized value, so a token minted for ``DELETE `` must confirm ``DELETE``.
+    """
+    mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        preview = await _call_ipaas(
+            session,
+            "demo_manage_widgets",
+            {"operation": "DELETE ", "id": "resource-a"},
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        confirmed = await _call_ipaas(
+            session,
+            "demo_manage_widgets",
+            {"operation": "DELETE", "id": "resource-a"},
+            confirm=True,
+            confirmation_token=token,
+        )
+
+    payload = extract_payload(confirmed)
+    assert payload["success"] is True
+    mock_gateway.opened_session.call_tool.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_trailing_space_operation_previews_without_calling(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(
+            session, "demo_manage_widgets", {"operation": "DELETE "}
+        )
+
+    payload = extract_payload(result)
+    assert payload["requires_confirmation"] is True
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_catalog_miss_is_unclassifiable_and_previews(
+    mock_client, mock_gateway, extract_payload
+):
+    """A name with no needle, missing from the catalog page, must not one-shot.
+
+    ``demo_archive_everything`` carries no destructive needle. If the
+    classifier saw only that name it would return False. A catalog miss
+    (pagination, or a tool the first page omitted) therefore has to fail
+    closed at the call site.
+    """
+    mock_gateway.list_tools = AsyncMock(
+        return_value=[_wire_entry("demo_list_flows", destructive_hint=False)]
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(session, "demo_archive_everything")
+
+    payload = extract_payload(result)
+    assert payload["requires_confirmation"] is True
+    assert "could not be classified" in payload["message"]
+    assert "permanent" not in payload["message"]
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_read_like_call_with_token_does_not_claim_permanent(
     mock_client, mock_gateway, extract_payload
 ):
@@ -890,7 +963,7 @@ async def test_list_tools_failure_is_error_envelope_and_does_not_call(
 
 
 @pytest.mark.anyio
-async def test_missing_catalog_benign_name_still_calls(
+async def test_missing_catalog_benign_name_previews(
     mock_client, mock_gateway, extract_payload
 ):
     mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
@@ -899,10 +972,9 @@ async def test_missing_catalog_benign_name_still_calls(
         result = await _call_ipaas(session, "demo_list_widgets")
 
     payload = extract_payload(result)
-    assert payload["success"] is True
-    mock_gateway.opened_session.call_tool.assert_awaited_once_with(
-        "demo_list_widgets", None
-    )
+    assert payload["requires_confirmation"] is True
+    assert "could not be classified" in payload["message"]
+    mock_gateway.opened_session.call_tool.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/packages/mcp/tests/tools/test_ipaas_tools.py
+++ b/packages/mcp/tests/tools/test_ipaas_tools.py
@@ -16,7 +16,12 @@ from pipefy_mcp.core.ipaas_gateway import IpaasGateway, IpaasGatewayError
 from pipefy_mcp.core.runtime import McpRuntime
 from pipefy_mcp.core.tool_error_envelope import tool_error_message
 from pipefy_mcp.settings import settings
-from pipefy_mcp.tools.ipaas_tools import IpaasTools
+from pipefy_mcp.tools.ipaas_tools import (
+    IPAAS_DESTRUCTIVE_NEEDLES,
+    IpaasTools,
+    ipaas_call_is_destructive,
+)
+from tools.destructive_confirm_test_support import confirm_after_preview
 
 TOOLS = [
     {
@@ -66,10 +71,53 @@ def mock_client():
     return client
 
 
+_CALL_OK = {
+    "content": [{"type": "text", "text": "ok"}],
+    "isError": False,
+}
+
+PIPE_ID = "303088927"
+
+
+def _wire_entry(name, *, destructive_hint=None, extra_annotations=None):
+    """Live-shaped list_tools wire object. Omit destructive_hint for no boolean."""
+    entry = {
+        "name": name,
+        "description": f"{name} catalog entry",
+        "inputSchema": {"type": "object"},
+    }
+    annotations = dict(extra_annotations or {})
+    if destructive_hint is not None:
+        annotations["destructiveHint"] = destructive_hint
+    if annotations:
+        entry["annotations"] = annotations
+    return entry
+
+
+_MIXED_WIDGETS = _wire_entry("manage_widgets", destructive_hint=False)
+
+
 @pytest.fixture
 def mock_gateway():
     gateway = MagicMock(IpaasGateway)
     gateway.list_tools = AsyncMock(return_value=TOOLS)
+    gateway.call_tool = AsyncMock(return_value=_CALL_OK)
+
+    @asynccontextmanager
+    async def mcp_session(token):
+        session = MagicMock()
+
+        async def list_tools():
+            return await gateway.list_tools(token)
+
+        async def call_tool(name, arguments=None):
+            return await gateway.call_tool(token, name, arguments)
+
+        session.list_tools = list_tools
+        session.call_tool = call_tool
+        yield session
+
+    gateway.mcp_session = mcp_session
     return gateway
 
 
@@ -77,6 +125,60 @@ def _session(server):
     return create_client_session(
         server, read_timeout_seconds=timedelta(seconds=10), raise_exceptions=True
     )
+
+
+def test_ipaas_destructive_needles_are_the_frozen_six():
+    assert IPAAS_DESTRUCTIVE_NEEDLES == (
+        "delete",
+        "remove",
+        "destroy",
+        "drop",
+        "uninstall",
+        "revoke",
+    )
+
+
+def test_ipaas_call_is_destructive_annotation_true_wins_over_benign_name():
+    entry = _wire_entry("archive_everything", destructive_hint=True)
+    assert ipaas_call_is_destructive(entry, None) is True
+    assert ipaas_call_is_destructive(entry, {"operation": "ADD"}) is True
+
+
+def test_ipaas_call_is_destructive_operation_equality_gates_even_when_annotated_false():
+    entry = _MIXED_WIDGETS
+    assert ipaas_call_is_destructive(entry, {"operation": "DELETE"}) is True
+    assert ipaas_call_is_destructive(entry, {"operation": "delete"}) is True
+    assert ipaas_call_is_destructive(entry, {"operation": "ADD"}) is False
+    assert ipaas_call_is_destructive(entry, {"operation": "UNDELETE"}) is False
+    assert ipaas_call_is_destructive(entry, {"operation": 1}) is False
+    assert ipaas_call_is_destructive(entry, {}) is False
+    assert ipaas_call_is_destructive(entry, None) is False
+
+
+def test_ipaas_call_is_destructive_annotation_false_does_not_fall_through_to_name():
+    entry = _wire_entry("delete_flow", destructive_hint=False)
+    assert ipaas_call_is_destructive(entry, None) is False
+
+
+def test_ipaas_call_is_destructive_no_boolean_uses_name_substring():
+    named = {"name": "delete_flow"}
+    assert ipaas_call_is_destructive(named, None) is True
+    assert (
+        ipaas_call_is_destructive(
+            _wire_entry("list_flows", extra_annotations={"readOnlyHint": True}),
+            None,
+        )
+        is False
+    )
+    assert ipaas_call_is_destructive({"name": "list_flows"}, None) is False
+
+
+def test_ipaas_call_is_destructive_missing_entry_is_no_boolean():
+    assert ipaas_call_is_destructive(None, None) is False
+    assert ipaas_call_is_destructive(None, {"operation": "DELETE"}) is True
+    assert ipaas_call_is_destructive(None, {"operation": "UNDELETE"}) is False
+    assert ipaas_call_is_destructive({"name": "delete_flow"}, None) is True
+    assert ipaas_call_is_destructive({"name": "list_widgets"}, None) is False
 
 
 @pytest.mark.anyio
@@ -259,6 +361,7 @@ async def test_call_tool_forwards_arguments_and_relays_output(
     payload = extract_payload(result)
     assert payload["success"] is True
     mock_client.get_advanced_automations_token.assert_awaited_once_with("303088927")
+    mock_gateway.list_tools.assert_awaited_once_with("embed-jwt")
     mock_gateway.call_tool.assert_awaited_once_with(
         "embed-jwt", "demo_create_flow", {"name": "My flow"}
     )
@@ -303,7 +406,7 @@ async def test_call_tool_maps_host_iserror_to_error_payload(
     async with _session(server) as session:
         result = await session.call_tool(
             "call_ipaas_tool",
-            {"pipe_id": "303088927", "tool_name": "demo_delete_flow"},
+            {"pipe_id": "303088927", "tool_name": "demo_create_flow"},
         )
 
     payload = extract_payload(result)
@@ -392,6 +495,277 @@ async def test_call_tool_unconfigured_gateway_reports_clearly(
     assert payload["success"] is False
     assert "disabled" in tool_error_message(payload)
     mock_client.get_advanced_automations_token.assert_not_awaited()
+
+
+async def _call_ipaas(session, tool_name, arguments=None, **extra):
+    payload = {
+        "pipe_id": PIPE_ID,
+        "tool_name": tool_name,
+        **extra,
+    }
+    if arguments is not None:
+        payload["arguments"] = arguments
+    return await session.call_tool("call_ipaas_tool", payload)
+
+
+@pytest.mark.anyio
+async def test_read_like_annotated_false_calls_tool_without_preview(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(
+        return_value=[_wire_entry("list_flows", destructive_hint=False)]
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(session, "list_flows")
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    assert payload.get("requires_confirmation") is not True
+    mock_gateway.list_tools.assert_awaited_once_with("embed-jwt")
+    mock_gateway.call_tool.assert_awaited_once_with("embed-jwt", "list_flows", None)
+
+
+@pytest.mark.anyio
+async def test_annotated_true_benign_name_previews_without_calling(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(
+        return_value=[_wire_entry("archive_everything", destructive_hint=True)]
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(session, "archive_everything")
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload["requires_confirmation"] is True
+    assert payload["confirmation_token"]
+    assert "archive_everything" in payload["resource"]
+    assert PIPE_ID in payload["resource"]
+    mock_gateway.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_no_boolean_delete_flow_name_previews(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(
+        return_value=[
+            _wire_entry("delete_flow", extra_annotations={"readOnlyHint": False})
+        ]
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(session, "delete_flow")
+
+    payload = extract_payload(result)
+    assert payload["requires_confirmation"] is True
+    mock_gateway.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_mixed_operation_add_calls_tool(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(session, "manage_widgets", {"operation": "ADD"})
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    mock_gateway.call_tool.assert_awaited_once_with(
+        "embed-jwt", "manage_widgets", {"operation": "ADD"}
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("operation", ["DELETE", "delete"])
+async def test_mixed_operation_delete_previews_with_operation_identity(
+    mock_client, mock_gateway, extract_payload, monkeypatch, operation
+):
+    mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
+    captured = {}
+
+    async def capture_guard(_ctx, **kwargs):
+        captured["resource_identity"] = kwargs["resource_identity"]
+        captured["resource_descriptor"] = kwargs["resource_descriptor"]
+        captured["tool_name"] = kwargs["tool_name"]
+        return {
+            "success": False,
+            "requires_confirmation": True,
+            "confirmation_token": "v1.preview",
+            "resource": kwargs["resource_descriptor"],
+            "message": "preview",
+        }
+
+    monkeypatch.setattr(
+        "pipefy_mcp.tools.ipaas_tools.check_destructive_confirmation",
+        capture_guard,
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(session, "manage_widgets", {"operation": operation})
+
+    payload = extract_payload(result)
+    assert payload["requires_confirmation"] is True
+    mock_gateway.call_tool.assert_not_awaited()
+    assert captured["tool_name"] == "call_ipaas_tool"
+    assert captured["resource_identity"] == {
+        "pipe_id": PIPE_ID,
+        "tool_name": "manage_widgets",
+        "operation": "delete",
+    }
+    descriptor = captured["resource_descriptor"]
+    assert PIPE_ID in descriptor
+    assert "manage_widgets" in descriptor
+    assert operation in descriptor
+
+
+@pytest.mark.anyio
+async def test_delete_token_does_not_confirm_add_arguments(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(
+        return_value=[_wire_entry("archive_everything", destructive_hint=True)]
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        preview = await _call_ipaas(
+            session, "archive_everything", {"operation": "DELETE"}
+        )
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await _call_ipaas(
+            session,
+            "archive_everything",
+            {"operation": "ADD"},
+            confirm=True,
+            confirmation_token=token,
+        )
+
+    payload = extract_payload(mismatch)
+    assert payload["requires_confirmation"] is True
+    assert payload["confirmation_token"] != token
+    mock_gateway.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_mixed_delete_token_does_not_confirm_add_arguments(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        preview = await _call_ipaas(session, "manage_widgets", {"operation": "DELETE"})
+        token = extract_payload(preview)["confirmation_token"]
+        mismatch = await _call_ipaas(
+            session,
+            "manage_widgets",
+            {"operation": "ADD"},
+            confirm=True,
+            confirmation_token=token,
+        )
+
+    payload = extract_payload(mismatch)
+    assert payload["requires_confirmation"] is True
+    assert payload["confirmation_token"] != token
+    mock_gateway.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_delete_token_confirms_matching_delete_arguments(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        payload = await confirm_after_preview(
+            session,
+            "call_ipaas_tool",
+            {
+                "pipe_id": PIPE_ID,
+                "tool_name": "manage_widgets",
+                "arguments": {"operation": "DELETE"},
+                "confirm": True,
+            },
+        )
+
+    assert payload["success"] is True
+    mock_gateway.call_tool.assert_awaited_once_with(
+        "embed-jwt", "manage_widgets", {"operation": "DELETE"}
+    )
+
+
+@pytest.mark.anyio
+async def test_mixed_undelete_operation_is_ungated(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(session, "manage_widgets", {"operation": "UNDELETE"})
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    mock_gateway.call_tool.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_list_tools_failure_is_error_envelope_and_does_not_call(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(
+        side_effect=IpaasGatewayError("iPaaS tools/list failed (HTTP 500): boom")
+    )
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(session, "delete_flow")
+
+    payload = extract_payload(result)
+    assert payload["success"] is False
+    assert payload.get("requires_confirmation") is not True
+    assert "tools/list" in tool_error_message(payload)
+    mock_gateway.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_missing_catalog_benign_name_still_calls(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(session, "list_widgets")
+
+    payload = extract_payload(result)
+    assert payload["success"] is True
+    mock_gateway.call_tool.assert_awaited_once_with("embed-jwt", "list_widgets", None)
+
+
+@pytest.mark.anyio
+async def test_missing_catalog_delete_flow_is_gated(
+    mock_client, mock_gateway, extract_payload
+):
+    mock_gateway.list_tools = AsyncMock(return_value=[_MIXED_WIDGETS])
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        result = await _call_ipaas(session, "delete_flow")
+
+    payload = extract_payload(result)
+    assert payload["requires_confirmation"] is True
+    mock_gateway.call_tool.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_call_ipaas_tool_keeps_destructive_hint(mock_client, mock_gateway):
+    server = build_ipaas_test_server(mock_client, mock_gateway)
+    async with _session(server) as session:
+        listed = await session.list_tools()
+
+    tool = next(t for t in listed.tools if t.name == "call_ipaas_tool")
+    assert tool.annotations is not None
+    assert tool.annotations.destructive_hint is True
 
 
 PIECE_NAME = "@example/piece-demo"

--- a/packages/mcp/tests/tools/test_meta_tools.py
+++ b/packages/mcp/tests/tools/test_meta_tools.py
@@ -126,7 +126,7 @@ async def test_execute_tool_passes_destructive_two_step_through(extract_payload)
         for tool in server._tool_manager.list_tools()
         if tool.name == "delete_webhook"
     }
-    assert catalog, "delete_webhook not registered"
+    assert catalog
     register_meta_tools(server, catalog)
 
     async with create_client_session(
@@ -158,5 +158,5 @@ async def test_execute_tool_passes_destructive_two_step_through(extract_payload)
             },
         )
         confirmed = extract_payload(confirm_result)
-        assert confirmed.get("success") is True, confirmed
+        assert confirmed["success"] is True
         client.delete_webhook.assert_awaited_once_with("wh-1")

--- a/packages/mcp/tests/tools/test_meta_tools.py
+++ b/packages/mcp/tests/tools/test_meta_tools.py
@@ -6,12 +6,22 @@ validation-error and not-found paths never reach a Pipefy client, so no runtime 
 needed.
 """
 
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from _mcp_compat import (
+    create_connected_server_and_client_session as create_client_session,
+)
 from mcp.server.mcpserver import MCPServer
+from pipefy_sdk import PipefyClient
 
 from pipefy_mcp.tools.meta_tools import register_meta_tools
 from pipefy_mcp.tools.registry import ToolRegistry
 from pipefy_mcp.tools.toolsets import DOMAINS, POWER_GRAPHQL_TOOLS
 from pipefy_mcp.tools.validation_envelope import install_pipefy_validation_envelope
+from pipefy_mcp.tools.webhook_tools import WebhookTools
+from tools.conftest import build_tool_test_server
 
 _META_TOOLS = ("get_tool_categories", "search_tools", "describe_tool", "execute_tool")
 
@@ -103,3 +113,50 @@ class TestExecuteTool:
         result = await fns["execute_tool"]("create_llm_provider", None, {})
         assert result["success"] is False
         assert result["error"]["code"] == "TOOL_NOT_FOUND"
+
+
+@pytest.mark.anyio
+async def test_execute_tool_passes_destructive_two_step_through(extract_payload):
+    """Power-profile deletes are reachable only via execute_tool; arguments pass through."""
+    client = MagicMock(PipefyClient)
+    client.delete_webhook = AsyncMock(return_value={"deleteWebhook": {"success": True}})
+    server = build_tool_test_server("power-passthrough", WebhookTools.register, client)
+    catalog = {
+        tool.name: tool
+        for tool in server._tool_manager.list_tools()
+        if tool.name == "delete_webhook"
+    }
+    assert catalog, "delete_webhook not registered"
+    register_meta_tools(server, catalog)
+
+    async with create_client_session(
+        server,
+        read_timeout_seconds=timedelta(seconds=10),
+        raise_exceptions=True,
+    ) as session:
+        preview_result = await session.call_tool(
+            "execute_tool",
+            {"name": "delete_webhook", "arguments": {"webhook_id": "wh-1"}},
+        )
+        preview = extract_payload(preview_result)
+        assert preview["success"] is False
+        assert preview["requires_confirmation"] is True
+        token = preview["confirmation_token"]
+        assert isinstance(token, str) and token.startswith("v1.")
+        assert token in preview["message"]
+        client.delete_webhook.assert_not_called()
+
+        confirm_result = await session.call_tool(
+            "execute_tool",
+            {
+                "name": "delete_webhook",
+                "arguments": {
+                    "webhook_id": "wh-1",
+                    "confirm": True,
+                    "confirmation_token": token,
+                },
+            },
+        )
+        confirmed = extract_payload(confirm_result)
+        assert confirmed.get("success") is True, confirmed
+        client.delete_webhook.assert_awaited_once_with("wh-1")

--- a/packages/sdk/src/pipefy_sdk/graphql_document.py
+++ b/packages/sdk/src/pipefy_sdk/graphql_document.py
@@ -23,7 +23,23 @@ class GraphqlDocumentInspection:
 
 
 def inspect_graphql_document(document: str) -> GraphqlDocumentInspection:
-    """Parse ``document`` once for mutation detection and preview naming."""
+    """Parse ``document`` once for mutation detection and preview naming.
+
+    Two unparseable documents are reported differently, on purpose. A syntax
+    error is invalid everywhere, so the API rejects it too and callers may send
+    it: it cannot turn out to be a mutation that runs unconfirmed. A document
+    that exhausts the parser's recursion is only unparseable *here*, and the
+    API may well accept it, so it comes back with ``too_nested`` set and callers
+    refuse it rather than send a document they could not classify.
+
+    The recursion ceiling is whatever stack headroom is left when this runs, not
+    a fixed nesting depth. Measurements put it near 246 levels called directly
+    and near 232 through the MCP tool path, dropping by roughly one level per
+    four frames already on the stack. So the same document can classify one way
+    from the CLI and another from a server with deeper middleware, and neither
+    result is wrong. Callers must treat ``too_nested`` as a refusal to judge,
+    never as a property of the document.
+    """
     try:
         doc = parse(document)
     except GraphQLSyntaxError:

--- a/packages/sdk/src/pipefy_sdk/graphql_document.py
+++ b/packages/sdk/src/pipefy_sdk/graphql_document.py
@@ -2,20 +2,58 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from graphql import GraphQLSyntaxError, parse
-from graphql.language.ast import OperationDefinitionNode, OperationType
+from graphql.language.ast import (
+    DocumentNode,
+    FieldNode,
+    OperationDefinitionNode,
+    OperationType,
+)
+
+_FALLBACK_MUTATION_DESCRIPTOR = "GraphQL mutation"
+
+
+@dataclass(frozen=True)
+class GraphqlDocumentInspection:
+    contains_mutation: bool
+    mutation_descriptor: str
+    too_nested: bool = False
+
+
+def inspect_graphql_document(document: str) -> GraphqlDocumentInspection:
+    """Parse ``document`` once for mutation detection and preview naming."""
+    try:
+        doc = parse(document)
+    except GraphQLSyntaxError:
+        return GraphqlDocumentInspection(
+            contains_mutation=False,
+            mutation_descriptor=_FALLBACK_MUTATION_DESCRIPTOR,
+        )
+    except RecursionError:
+        return GraphqlDocumentInspection(
+            contains_mutation=False,
+            mutation_descriptor=_FALLBACK_MUTATION_DESCRIPTOR,
+            too_nested=True,
+        )
+    return GraphqlDocumentInspection(
+        contains_mutation=_document_defines_mutation(doc),
+        mutation_descriptor=_mutation_descriptor(doc),
+    )
 
 
 def document_contains_mutation(document: str) -> bool:
     """Return True when the document defines at least one mutation operation.
 
-    Syntax errors are not treated as mutations, so CLI ``--yes`` is not required
-    for a document that will fail to parse.
+    Syntax errors and documents too nested to parse are not treated as
+    mutations, so CLI ``--yes`` is not required for a document that will fail
+    to parse.
     """
-    try:
-        doc = parse(document)
-    except GraphQLSyntaxError:
-        return False
+    return inspect_graphql_document(document).contains_mutation
+
+
+def _document_defines_mutation(doc: DocumentNode) -> bool:
     for defn in doc.definitions:
         if (
             isinstance(defn, OperationDefinitionNode)
@@ -23,3 +61,22 @@ def document_contains_mutation(document: str) -> bool:
         ):
             return True
     return False
+
+
+def _mutation_descriptor(doc: DocumentNode) -> str:
+    for defn in doc.definitions:
+        if not isinstance(defn, OperationDefinitionNode):
+            continue
+        if defn.operation != OperationType.MUTATION:
+            continue
+        return f"{_FALLBACK_MUTATION_DESCRIPTOR} {_mutation_operation_name(defn)}"
+    return _FALLBACK_MUTATION_DESCRIPTOR
+
+
+def _mutation_operation_name(defn: OperationDefinitionNode) -> str:
+    if defn.name is not None:
+        return defn.name.value
+    for selection in defn.selection_set.selections:
+        if isinstance(selection, FieldNode):
+            return selection.name.value
+    return "operation"

--- a/packages/sdk/src/pipefy_sdk/graphql_document.py
+++ b/packages/sdk/src/pipefy_sdk/graphql_document.py
@@ -1,0 +1,28 @@
+"""Detect mutation operations in a GraphQL document string."""
+
+from __future__ import annotations
+
+from graphql import GraphQLSyntaxError, parse
+from graphql.language.ast import OperationDefinitionNode, OperationType
+
+
+def document_contains_mutation(document: str) -> bool:
+    """Return True when the document defines at least one mutation operation.
+
+    Syntax errors are not treated as mutations, so CLI ``--yes`` is not required
+    for a document that will fail to parse.
+
+    Args:
+        document: GraphQL document string (query, mutation, subscription, or mixed).
+    """
+    try:
+        doc = parse(document)
+    except GraphQLSyntaxError:
+        return False
+    for defn in doc.definitions:
+        if (
+            isinstance(defn, OperationDefinitionNode)
+            and defn.operation == OperationType.MUTATION
+        ):
+            return True
+    return False

--- a/packages/sdk/src/pipefy_sdk/graphql_document.py
+++ b/packages/sdk/src/pipefy_sdk/graphql_document.py
@@ -11,9 +11,6 @@ def document_contains_mutation(document: str) -> bool:
 
     Syntax errors are not treated as mutations, so CLI ``--yes`` is not required
     for a document that will fail to parse.
-
-    Args:
-        document: GraphQL document string (query, mutation, subscription, or mixed).
     """
     try:
         doc = parse(document)

--- a/packages/sdk/tests/test_graphql_document.py
+++ b/packages/sdk/tests/test_graphql_document.py
@@ -1,6 +1,9 @@
 """Tests for GraphQL document mutation detection."""
 
-from pipefy_sdk.graphql_document import document_contains_mutation
+from pipefy_sdk.graphql_document import (
+    document_contains_mutation,
+    inspect_graphql_document,
+)
 
 
 def test_document_contains_mutation_detects_mutation():
@@ -22,3 +25,40 @@ def test_document_contains_mutation_mixed_query_and_mutation():
 
 def test_document_contains_mutation_rejects_subscription_only():
     assert document_contains_mutation("subscription { __typename }") is False
+
+
+def test_inspect_syntax_error_is_not_too_nested():
+    inspection = inspect_graphql_document("not graphql {{{")
+    assert inspection.contains_mutation is False
+    assert inspection.too_nested is False
+
+
+def test_inspect_too_nested_document_is_not_a_mutation():
+    nested = "{a" * 400 + "}" * 400
+    inspection = inspect_graphql_document(nested)
+    assert inspection.contains_mutation is False
+    assert inspection.too_nested is True
+    assert document_contains_mutation(nested) is False
+
+
+def test_inspect_too_nested_mutation_is_not_a_mutation():
+    nested = "mutation { " + "a { " * 400 + "x " + "} " * 401
+    inspection = inspect_graphql_document(nested)
+    assert inspection.contains_mutation is False
+    assert inspection.too_nested is True
+
+
+def test_mutation_descriptor_uses_operation_name():
+    inspection = inspect_graphql_document(
+        "mutation DeletePipe { deletePipe(id: 1) { id } }"
+    )
+    assert inspection.contains_mutation is True
+    assert "DeletePipe" in inspection.mutation_descriptor
+
+
+def test_mutation_descriptor_uses_root_field_when_unnamed():
+    inspection = inspect_graphql_document("mutation { deletePipe(id: 1) { id } }")
+    assert inspection.contains_mutation is True
+    assert "deletePipe" in inspection.mutation_descriptor
+    unnamed = inspect_graphql_document("mutation { deleteCard(id: 1) { id } }")
+    assert inspection.mutation_descriptor != unnamed.mutation_descriptor

--- a/packages/sdk/tests/test_graphql_document.py
+++ b/packages/sdk/tests/test_graphql_document.py
@@ -1,0 +1,24 @@
+"""Tests for GraphQL document mutation detection."""
+
+from pipefy_sdk.graphql_document import document_contains_mutation
+
+
+def test_document_contains_mutation_detects_mutation():
+    assert document_contains_mutation("mutation { __typename }") is True
+
+
+def test_document_contains_mutation_rejects_query():
+    assert document_contains_mutation("query { __typename }") is False
+
+
+def test_document_contains_mutation_syntax_error_is_not_mutation():
+    assert document_contains_mutation("not graphql {{{") is False
+
+
+def test_document_contains_mutation_mixed_query_and_mutation():
+    document = "query Q { __typename }\nmutation M { __typename }"
+    assert document_contains_mutation(document) is True
+
+
+def test_document_contains_mutation_rejects_subscription_only():
+    assert document_contains_mutation("subscription { __typename }") is False


### PR DESCRIPTION
## Summary

Closes the two one-call destruction paths left open by #629.

- **GraphQL:** mutations take the same two-step ticket, queries stay one-shot. Identity is `sha256(document)` + canonical `variables` hash, so changing either invalidates the token. No `destructiveHint` on `execute_graphql`.
- **iPaaS:** judged destructive in fixed order: annotation `true` → `arguments.operation` needle-equality → annotation `false` stops → catalog-name substring. Mixed `operation=DELETE` two-step; `ADD` / `UPDATE` one-shot. Token binds the whole `arguments` map, so a leftover `DELETE` token cannot run an `ADD`. One OAuth handshake per invocation.
- **Too-nested documents refused on both surfaces.** Unclassifiable means it could be an unconfirmed mutation, so nothing is sent. `pipefy graphql exec` exits 2 even with `--yes` (previously an uncaught `RecursionError`). Ceiling is stack headroom, not a depth; recorded in the SDK docstring.
- Preview text names the operation it would run, so two pending mutations stop rendering identical approval text.

Spans `packages/sdk` (document inspection), `packages/mcp` (gates) and `packages/cli` (matching refusal), hence no scope in the title.

**Part 2 of 3.** Stacked on #629; retarget to `dev` when #629 merges.

## Verification

Base is a feature branch, so GitHub runs DCO only. Full `ci.yml` set run locally on this head:

| Gate | Result |
| --- | --- |
| `pytest -m "not integration"` | 4684 passed |
| `ruff check` / `ruff format --check` | clean |
| banned imports (sdk/auth/infra), `lint-imports` (mcp) | pass |
| version lockstep, wheel build, clean-venv install | pass |

## Test plan

- [x] `uv run pytest packages/sdk/tests/test_graphql_document.py packages/mcp/tests/tools/test_introspection_tools.py packages/mcp/tests/tools/test_ipaas_tools.py packages/mcp/tests/core/test_ipaas_gateway.py`
- [x] `uv run pytest packages/cli/tests -k graphql`
- [x] `uv run pytest -m "not integration"` (4684 passed)
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] Live smoke: query one-shot; `mutation { __typename }` previews then executes with the returned token; iPaaS destructive call previewed, not confirmed

## Docs / skills

- [x] No docs/skills in this PR. Parity rows, skills and CHANGELOG for both gates land in #631.

## Legal / contributions

- [x] Commits include DCO sign-off (`git commit -s`)
