### PR TITLE
fix: Set readOnlyHint=False on create_ipaas_connection write tool

### DIFF
--- a/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
+++ b/packages/mcp/src/pipefy_mcp/tools/ipaas_tools.py
@@ -399,7 +399,10 @@ class IpaasTools:
 
             return await _run_ipaas_tool(ctx, pipe_id, work)
 
-        @mcp.tool(annotations=ToolAnnotations(openWorldHint=True), meta=REMOTE)
+        @mcp.tool(
+            annotations=ToolAnnotations(readOnlyHint=False, openWorldHint=True),
+            meta=REMOTE,
+        )
         async def create_ipaas_connection(
             pipe_id: PipefyId,
             piece_name: str,

--- a/packages/mcp/tests/tools/test_ipaas_tools.py
+++ b/packages/mcp/tests/tools/test_ipaas_tools.py
@@ -1441,6 +1441,9 @@ async def test_connection_auth_url_is_not_read_only(mock_client, mock_gateway):
     auth_url = by_name["get_ipaas_connection_auth_url"]
     assert auth_url.annotations is not None
     assert auth_url.annotations.read_only_hint is False
+    create_conn = by_name["create_ipaas_connection"]
+    assert create_conn.annotations is not None
+    assert create_conn.annotations.read_only_hint is False
     # The discovery meta-tool stays a genuine read.
     assert by_name["get_ipaas_tools"].annotations.read_only_hint is True
 


### PR DESCRIPTION
## Summary

Set readOnlyHint=False on create_ipaas_connection write tool

## Changes

- Match other write tools: ToolAnnotations(readOnlyHint=False, openWorldHint=True)
- create_ipaas_connection upserts credentials and must not look read-only

Fixes #644
