### PR TITLE
feat(skills): add process-impact playbook for change justification

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -26,6 +26,7 @@
     "./skills/pipes-and-cards/pipefy-pipes-and-cards",
     "./skills/portal-setup/pipefy-portal-setup",
     "./skills/process-design/pipefy-process-design",
+    "./skills/process-impact/pipefy-process-impact",
     "./skills/process-intelligence/pipefy-process-intelligence",
     "./skills/relations/pipefy-relations",
     "./skills/reports/pipefy-reports"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Skills (`pipefy-process-impact`)**: consulting playbook for whether a process change is worth it. Uses Pipefy context already in the conversation; a pipe diagnosis runs only when asked (or when `pipefy-process-intelligence` is already in flight). Process-design and process-intelligence emit a 1–2 line impact blurb on material changes.
+
 ### Fixed
 
 - **Cursor Marketplace plugin**: hosted MCP config is `.mcp.json` only. `.cursor-plugin/plugin.json` points `mcpServers` at `./.mcp.json`, the same file Claude Code auto-discovers.

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -25,7 +25,7 @@ skills/
 The copyable starter lives at [`.github/skill-template/pipefy-skill-template/`](../.github/skill-template/pipefy-skill-template/), outside this catalog.
 
 **Domain folders** match the MCP tool surface:
-`pipes-and-cards`, `database-tables`, `relations`, `reports`, `automations`, `ipaas`, `ai-agents`, `observability`, `members-email-webhooks`, `portal-setup`, `attachments`, `introspection`, `building`, `process-design`, `process-intelligence`, `api-troubleshoot`, `onboarding`
+`pipes-and-cards`, `database-tables`, `relations`, `reports`, `automations`, `ipaas`, `ai-agents`, `observability`, `members-email-webhooks`, `portal-setup`, `attachments`, `introspection`, `building`, `process-design`, `process-impact`, `process-intelligence`, `api-troubleshoot`, `onboarding`
 
 Regulated domains (`legal`, `human-resources`, `finance`, `compliance`, or any skill involving decisions about natural persons) require substantive Legal review and a filled `COMPLIANCE.md` (start from [`docs/compliance/COMPLIANCE.template.md`](../docs/compliance/COMPLIANCE.template.md)). See [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -42,6 +42,7 @@ git clone https://github.com/pipefy/ai-toolkit.git
 | **Attachments** | [pipefy-attachments](attachments/pipefy-attachments/SKILL.md) | Upload files to card or table-record attachment fields. 2 MCP tools. |
 | **Building** | [pipefy-building](building/pipefy-building/SKILL.md) | Thin router: map build/configure intent → domain skill. Not a delivery playbook. |
 | **Process Design** | [pipefy-process-design](process-design/pipefy-process-design/SKILL.md) | Process architecture (consulting; not execution). |
+| **Process Impact** | [pipefy-process-impact](process-impact/pipefy-process-impact/SKILL.md) | Quantify impact / ROI of a process change (consulting; not execution). |
 | **Process Intelligence** | [pipefy-process-intelligence](process-intelligence/pipefy-process-intelligence/SKILL.md) | Analyze pipes for improvement opportunities. |
 | **API Fallback** | [pipefy-api-fallback](api-troubleshoot/pipefy-api-fallback/SKILL.md) | Raw GraphQL fallback when higher-level tools are insufficient. |
 | **Onboarding** | [pipefy-toolkit-setup](onboarding/pipefy-toolkit-setup/SKILL.md) | First-time install: Cursor Marketplace plugin, hosted MCP, `install.sh`, or Claude Code plugin. |

--- a/skills/building/pipefy-building/SKILL.md
+++ b/skills/building/pipefy-building/SKILL.md
@@ -24,6 +24,7 @@ If the user already has a building skill or a detailed build prompt/spec, use th
 | User intent (examples) | Read |
 |------------------------|------|
 | Design / architecture / "help me structure this process" | [pipefy-process-design](../../process-design/pipefy-process-design/SKILL.md) (consulting only) |
+| Impact / ROI / "is this change worth it?" / justify internally | [pipefy-process-impact](../../process-impact/pipefy-process-impact/SKILL.md) (consulting; do not implement from there) |
 | Pipes, phases, fields, labels, cards, field conditions | [pipefy-pipes-and-cards](../../pipes-and-cards/pipefy-pipes-and-cards/SKILL.md) |
 | Traditional or AI automations (if/then, prompt-driven rules) | [pipefy-automations](../../automations/pipefy-automations/SKILL.md) |
 | Conversational AI agents and behaviors | [pipefy-ai-agents](../../ai-agents/pipefy-ai-agents/SKILL.md) |
@@ -47,4 +48,5 @@ Hard stops and quirks (phase connections UI-only, email template create/edit UI-
 ## See also
 
 - [pipefy-process-design](../../process-design/pipefy-process-design/SKILL.md) — consulting when the ask is design, not build.
+- [pipefy-process-impact](../../process-impact/pipefy-process-impact/SKILL.md) — consulting when the ask is impact / ROI / justification, not build.
 - [skills/README.md](../../README.md) — full catalog.

--- a/skills/process-design/pipefy-process-design/SKILL.md
+++ b/skills/process-design/pipefy-process-design/SKILL.md
@@ -102,8 +102,14 @@ Phases: [list]
 Start form fields: [list with types]
 Key automations: [list]
 Related processes: [list or "none"]
+Impact: [1–2 lines — time this design returns to the team vs a fully manual
+run of the same flow. If a phase exists only as human triage, say what an
+automation vs an AI agent would change. Do not start a pipe diagnosis.]
 Next step: [execute with pipes-and-cards skill? or more questions?]
 ```
+
+Do not invent volume, hourly cost, or lead time. If the user wants a fuller
+justification, read [pipefy-process-impact](../../process-impact/pipefy-process-impact/SKILL.md).
 
 ---
 
@@ -116,6 +122,7 @@ Next step: [execute with pipes-and-cards skill? or more questions?]
 ## See also
 
 - [pipefy-building](../../building/pipefy-building/SKILL.md) — for execution / build asks, read the router then the domain skill (do not expand this consulting skill into a build playbook).
+- [pipefy-process-impact](../../process-impact/pipefy-process-impact/SKILL.md) — justify a material change; this skill only emits the 1–2 line impact blurb.
 - `skills/pipes-and-cards/` — execute the design once finalized.
 - `skills/automations/` — add automation rules to the new pipe.
 - `skills/process-intelligence/` — analyze an existing process for improvement (distinct from designing new).

--- a/skills/process-impact/pipefy-process-impact/SKILL.md
+++ b/skills/process-impact/pipefy-process-impact/SKILL.md
@@ -2,18 +2,22 @@
 name: pipefy-process-impact
 description: >
   Use this skill when the user asks whether a process change is worth it,
-  wants impact / ROI / a short internal justification, or when
-  process-design / process-intelligence just proposed a material change.
-  Quantify time returned to the team from Pipefy data already in context;
-  do not start a pipe diagnosis unless the user asks. Do not use this skill
-  to implement changes (that is process-intelligence plus domain skills).
+  wants impact / ROI / a short internal justification, or wants more than
+  the 1-2 line impact blurb already emitted by process-design or
+  process-intelligence. Quantify time returned to the team from Pipefy
+  data already in context. Start a pipe diagnosis only if the user asked
+  to measure this pipe, or process-intelligence is already running (reuse
+  round 1 only). Do not implement from this skill; if intelligence is
+  already implementing, continue there.
 tags: [pipefy, process-impact, impact, automation]
 ---
 
 # Process impact
 
 Quantify the impact of a process change already under discussion. **Use
-context you already have. Do not open a diagnosis unless the user asks.**
+context you already have. Open a diagnosis only if the user asked to
+measure this pipe, or process-intelligence is already running (reuse
+round 1 only).**
 
 This skill does not create pipes, automations, or AI agents. Point to the
 domain skill when the user wants the change built.
@@ -42,7 +46,7 @@ Pick the cheapest mode that answers the question:
 
 | Mode | When | Extra MCP calls |
 |------|------|-----------------|
-| **Impact line** | Default. Design and intelligence already emit this. | None |
+| **Impact line** | Default. Design and intelligence already emit a 1–2 line blurb. | None |
 | **Impact case** | User asked to justify or go deeper on numbers. | None — use conversation context plus stated assumptions |
 | **Diagnosis** | User asked to measure *this pipe*, or intelligence is already running | Reuse [pipefy-process-intelligence](../../process-intelligence/pipefy-process-intelligence/SKILL.md) round 1. Do not duplicate that investigation here. |
 
@@ -55,7 +59,8 @@ Pick the cheapest mode that answers the question:
 
 - A proposed or existing change in view (phase, automation, AI agent, iPaaS,
   or a new process design).
-- Optional: `pipe_id` if the user asked for a diagnosis.
+- Optional: `pipe_id` if the user asked for a diagnosis; `pipe.uuid` when
+  listing agents.
 
 ---
 
@@ -72,6 +77,10 @@ call them for an impact line or impact case):
 | `get_ai_agents` | `pipefy agent list` | Yes |
 | `search_pipes` | `pipefy pipe list` | Yes |
 
+`get_ai_agents` / `pipefy agent list --repo` take the pipe **UUID**. If
+diagnosis runs, follow process-intelligence: `get_pipe` then
+`get_ai_agents repo_uuid=<pipe.uuid>`.
+
 Usage and credit totals, if the user already wants them in the case, live in
 [pipefy-observability](../../observability/pipefy-observability/SKILL.md).
 Treat credit spend as the cost of capacity the process already produces — not
@@ -83,8 +92,8 @@ as a line to cut.
 
 | Axis | Without a diagnosis | With intelligence round 1 | Ask the user |
 |------|---------------------|---------------------------|--------------|
-| Time people spend operating the pipe | Count visible manual hops (phase with no automation, human triage) | Volume from a card sample; which phases have automations or AI agents | Minutes per hop; weekly volume if no sample |
-| Lead time (card created → done) | Do not invent a number | Proxy: cards waiting in a phase (`phases[].cards_count` on `get_pipe`). True cycle needs dates the default card tools do not return | "How long does a case take today, end to end?" |
+| Time people spend operating the pipe | Count visible manual hops (phase with no automation, human triage) | Composition: which hops look manual. A card sample is not weekly volume. `phases[].cards_count` is live WIP / bottleneck inventory, not duration | Minutes per hop; weekly volume (`cases_per_week`) unless a dated throughput source is already in context |
+| Lead time (card created → done) | Do not invent a number | Not measured unless dates are already in this round's context | "How long does a case take today, end to end?" |
 | Cost / capacity | Hours returned to the team | Same, with measured volume | Hourly cost **optional**. Money only when they give it |
 | Revenue | Omit | Omit unless the user confirms this process sits on the path to revenue (quotes, onboarding, billing) | Ticket, conversion, or that confirmation |
 
@@ -133,8 +142,9 @@ Do not recommend a capability the evidence does not support.
 ## Steps
 
 1. **Choose the mode** — impact line, impact case, or diagnosis (table
-   above). If diagnosis, read process-intelligence and stop duplicating
-   tool calls.
+   above). If diagnosis, reuse intelligence round 1 only; do not start
+   round 2+ from this skill. If the user asked to analyze **and** improve,
+   intelligence owns implementation after they approve a round.
 
 2. **Name the current hop** — what people do in the pipe today for this
    change (manual move, triage, copy-paste, waiting).
@@ -153,7 +163,9 @@ Do not recommend a capability the evidence does not support.
 
 ## Output format
 
-**Impact line** (also used by process-design and process-intelligence):
+**Impact line:** design and intelligence emit their own 1–2 line blurbs
+(see those skills). The paragraph below is this skill's **impact-case**
+default, not the hook blurb.
 
 ```
 Impact: [this hop is manual today]. A [automation] avoids ~N actions/week
@@ -170,7 +182,7 @@ if volume is confirmed.
 Current: [what people do in the pipe today]
 Minimum step: [automation] — time returned: [formula]
 Next step (optional): [AI agent / iPaaS] — extra lift: [why, or "does not close"]
-Lead time: [number + source] or [not measured; give today's cycle or diagnose]
+Lead time: [number + source] or [not measured; give today's end-to-end cycle]
 Assumptions: [minutes/hop, volume, hourly cost if any]
 If you want this built: [domain skill]
 ```
@@ -194,14 +206,14 @@ path to revenue.
 | Symptom | Likely cause | Recovery |
 |---------|--------------|----------|
 | User wants a dollar ROI | No hourly cost in context | Ask for it; otherwise stop at hours returned |
-| User wants lead time | Default card tools have no timestamps | Ask for today's cycle, or diagnose and use phase WIP as a proxy |
+| User wants lead time | Default card tools have no timestamps | Ask for today's cycle; omit the number if they do not give one |
 | Quiet / unused pipe | Process never launched | Reactivate or connect; cover hops with automations or AI agents if they fit. Do not delete unless asked |
 | User asks to cut credits or leave Pipefy | Out of scope | Stay on process impact; do not recommend moving work off the pipe |
 
 ## See also
 
 - [pipefy-process-design](../../process-design/pipefy-process-design/SKILL.md) — new process architecture (emits an impact line).
-- [pipefy-process-intelligence](../../process-intelligence/pipefy-process-intelligence/SKILL.md) — diagnose and implement; reuse for Diagnosis mode.
+- [pipefy-process-intelligence](../../process-intelligence/pipefy-process-intelligence/SKILL.md) — diagnose (round 1); reuse for Diagnosis mode. Round 2+ implementation stays on process-intelligence when the user asked to improve — not from this skill.
 - [pipefy-building](../../building/pipefy-building/SKILL.md) — route implementation to a domain skill.
 - [pipefy-automations](../../automations/pipefy-automations/SKILL.md) — minimum-step automations.
 - [pipefy-ai-agents](../../ai-agents/pipefy-ai-agents/SKILL.md) — next-step AI agents.

--- a/skills/process-impact/pipefy-process-impact/SKILL.md
+++ b/skills/process-impact/pipefy-process-impact/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: pipefy-process-impact
+description: >
+  Use this skill when the user asks whether a process change is worth it,
+  wants impact / ROI / a short internal justification, or when
+  process-design / process-intelligence just proposed a material change.
+  Quantify time returned to the team from Pipefy data already in context;
+  do not start a pipe diagnosis unless the user asks. Do not use this skill
+  to implement changes (that is process-intelligence plus domain skills).
+tags: [pipefy, process-impact, impact, automation]
+---
+
+# Process impact
+
+Quantify the impact of a process change already under discussion. **Use
+context you already have. Do not open a diagnosis unless the user asks.**
+
+This skill does not create pipes, automations, or AI agents. Point to the
+domain skill when the user wants the change built.
+
+---
+
+## When to use
+
+- "Is this change worth it?" / "Does this pay off?"
+- "What is the impact / ROI?" / "Help me justify this internally."
+- Design or intelligence just proposed a material change (phase, automation,
+  AI agent, iPaaS) and the user wants more than the 1–2 line impact blurb.
+
+Do not use this skill for:
+
+- Designing a new process from scratch → `skills/process-design/`
+- Investigating or implementing pipe improvements → `skills/process-intelligence/`
+- Building the recommended automation or agent → `pipefy-building`, then the
+  domain skill
+
+---
+
+## Cost of investigation
+
+Pick the cheapest mode that answers the question:
+
+| Mode | When | Extra MCP calls |
+|------|------|-----------------|
+| **Impact line** | Default. Design and intelligence already emit this. | None |
+| **Impact case** | User asked to justify or go deeper on numbers. | None — use conversation context plus stated assumptions |
+| **Diagnosis** | User asked to measure *this pipe*, or intelligence is already running | Reuse [pipefy-process-intelligence](../../process-intelligence/pipefy-process-intelligence/SKILL.md) round 1. Do not duplicate that investigation here. |
+
+`get_card` / `get_cards` / `find_cards` do **not** return `created_at` or
+`updated_at`. Do not invent lead time from those tools.
+
+---
+
+## Prerequisites
+
+- A proposed or existing change in view (phase, automation, AI agent, iPaaS,
+  or a new process design).
+- Optional: `pipe_id` if the user asked for a diagnosis.
+
+---
+
+## Tools needed
+
+Only in **Diagnosis** mode, and only by following process-intelligence (do not
+call them for an impact line or impact case):
+
+| Tool (MCP) | CLI equivalent | Read-only |
+|------------|----------------|-----------|
+| `get_pipe` | `pipefy pipe get` | Yes |
+| `get_cards` | `pipefy card list` | Yes |
+| `get_automations` | `pipefy automation list` | Yes |
+| `get_ai_agents` | `pipefy agent list` | Yes |
+| `search_pipes` | `pipefy pipe list` | Yes |
+
+Usage and credit totals, if the user already wants them in the case, live in
+[pipefy-observability](../../observability/pipefy-observability/SKILL.md).
+Treat credit spend as the cost of capacity the process already produces — not
+as a line to cut.
+
+---
+
+## What you can measure
+
+| Axis | Without a diagnosis | With intelligence round 1 | Ask the user |
+|------|---------------------|---------------------------|--------------|
+| Time people spend operating the pipe | Count visible manual hops (phase with no automation, human triage) | Volume from a card sample; which phases have automations or AI agents | Minutes per hop; weekly volume if no sample |
+| Lead time (card created → done) | Do not invent a number | Proxy: cards waiting in a phase (`phases[].cards_count` on `get_pipe`). True cycle needs dates the default card tools do not return | "How long does a case take today, end to end?" |
+| Cost / capacity | Hours returned to the team | Same, with measured volume | Hourly cost **optional**. Money only when they give it |
+| Revenue | Omit | Omit unless the user confirms this process sits on the path to revenue (quotes, onboarding, billing) | Ticket, conversion, or that confirmation |
+
+Always show the arithmetic:
+
+```
+hours_returned / week
+  ≈ manual_hops_per_case × minutes_per_hop × cases_per_week / 60
+
+cost_avoided / week   (only if hourly cost was given)
+  ≈ hours_returned × hourly_cost
+```
+
+If a number is missing, keep the formula and label the gap as an assumption
+— do not fill it in.
+
+---
+
+## Value ladder
+
+Every material recommendation has **two rungs**. The user chooses. Do not
+stack both as "do these now."
+
+1. **Minimum step** — a traditional automation when the rule is clear
+   ("if field = X, move"). Impact: hops and time returned.
+2. **Next step (optional)** — an AI agent / AI automation when the hop is
+   judgment, free text, or conversation; iPaaS when the work lives in another
+   app. Show the extra lift (for example: the triage phase can go away and
+   the card arrives ready in the next phase). If the extra rung does not
+   close with evidence, say so and stop.
+
+Do not recommend a capability the evidence does not support.
+
+---
+
+## Structural change vs leaving the process
+
+| User ask | Read it as | Response |
+|----------|------------|----------|
+| Fewer **phases** | A cleaner flow | Yes, when the work stays in the pipe. Prefer replacing the hop with an automation or AI agent. |
+| Fewer **pipes** / a quiet pipe | Architecture, or a process that never launched | Do not delete. Ask: missing trigger (form, portal, create-card automation)? Duplicate of a live pipe? Should it be a relation or a database table? Reactivate or connect it, and cover remaining manual hops with automations or AI agents when that fits. Delete a pipe **only** when the user asks in so many words — and then absorb the work into the pipe that remains, not a spreadsheet. |
+| Less **platform** (cut credits, seats, "go back to Excel") | Out of scope | This skill measures process impact. Do not recommend moving work off Pipefy. |
+
+---
+
+## Steps
+
+1. **Choose the mode** — impact line, impact case, or diagnosis (table
+   above). If diagnosis, read process-intelligence and stop duplicating
+   tool calls.
+
+2. **Name the current hop** — what people do in the pipe today for this
+   change (manual move, triage, copy-paste, waiting).
+
+3. **Write the ladder** — minimum step + optional next step, each with
+   time returned (formula). Lead time only with a user-stated cycle or
+   dates already in context.
+
+4. **Ask only for missing assumptions** — minutes/hop, weekly volume,
+   hourly cost. One question, not a survey.
+
+5. **Point to implementation** — which domain skill builds the chosen rung.
+   Do not implement from this skill.
+
+---
+
+## Output format
+
+**Impact line** (also used by process-design and process-intelligence):
+
+```
+Impact: [this hop is manual today]. A [automation] avoids ~N actions/week
+(assumption: …). If the hop is free-text triage, an AI agent at this point
+lets you drop phase [X] and the card arrives ready in [Y] — extra lift only
+if volume is confirmed.
+```
+
+**Impact case:**
+
+```
+## Process impact — [pipe or proposed change]
+
+Current: [what people do in the pipe today]
+Minimum step: [automation] — time returned: [formula]
+Next step (optional): [AI agent / iPaaS] — extra lift: [why, or "does not close"]
+Lead time: [number + source] or [not measured; give today's cycle or diagnose]
+Assumptions: [minutes/hop, volume, hourly cost if any]
+If you want this built: [domain skill]
+```
+
+Add a revenue line only when the user confirmed the process sits on the
+path to revenue.
+
+---
+
+## Success criteria
+
+- Assumptions are explicit. No currency figure without an hourly cost.
+- No invented lead time.
+- No pipe deletion unless the user asked to delete that pipe.
+- Report **time returned to the team** on repetitive hops. Do not frame
+  impact as fewer people on the process.
+- Rung 2 is omitted or marked "does not close" when the evidence is weak.
+
+## Failure modes
+
+| Symptom | Likely cause | Recovery |
+|---------|--------------|----------|
+| User wants a dollar ROI | No hourly cost in context | Ask for it; otherwise stop at hours returned |
+| User wants lead time | Default card tools have no timestamps | Ask for today's cycle, or diagnose and use phase WIP as a proxy |
+| Quiet / unused pipe | Process never launched | Reactivate or connect; cover hops with automations or AI agents if they fit. Do not delete unless asked |
+| User asks to cut credits or leave Pipefy | Out of scope | Stay on process impact; do not recommend moving work off the pipe |
+
+## See also
+
+- [pipefy-process-design](../../process-design/pipefy-process-design/SKILL.md) — new process architecture (emits an impact line).
+- [pipefy-process-intelligence](../../process-intelligence/pipefy-process-intelligence/SKILL.md) — diagnose and implement; reuse for Diagnosis mode.
+- [pipefy-building](../../building/pipefy-building/SKILL.md) — route implementation to a domain skill.
+- [pipefy-automations](../../automations/pipefy-automations/SKILL.md) — minimum-step automations.
+- [pipefy-ai-agents](../../ai-agents/pipefy-ai-agents/SKILL.md) — next-step AI agents.
+- [pipefy-ipaas](../../ipaas/pipefy-ipaas/SKILL.md) — next step when work lives in another app.
+- [pipefy-observability](../../observability/pipefy-observability/SKILL.md) — usage and credits already in the process.
+- [pipefy-reports](../../reports/pipefy-reports/SKILL.md) — exports when the user asked for a deeper volume picture.

--- a/skills/process-intelligence/pipefy-process-intelligence/SKILL.md
+++ b/skills/process-intelligence/pipefy-process-intelligence/SKILL.md
@@ -24,6 +24,7 @@ The user asks to analyze or improve an existing process:
 - "Where are the bottlenecks?"
 
 **Not for:** designing a new process from scratch → use `skills/process-design/`.
+Justifying a change with numbers only (no implementation) → use `skills/process-impact/`.
 
 ---
 
@@ -72,7 +73,7 @@ The user asks to analyze or improve an existing process:
 | Same comment posted repeatedly | AI agent to auto-post based on trigger |
 | No automation between intake and first action | Add "notify assignee" automation on card creation |
 | Large field count on start form | Move optional fields to later phases |
-| Phases with 0 cards over 90 days | Consider removing or merging phases |
+| Phases with 0 cards over 90 days | Merge into a neighboring phase, or replace the hop with an automation or AI agent. Do not treat an empty phase as a reason to delete the pipe. |
 
 ---
 
@@ -111,9 +112,19 @@ Each round focuses on 1–2 improvements; report results before proceeding.
 ### Implemented this round
 - [Change 1]: [tool called + result]
 
+### Impact
+- Minimum step: [automation already done or proposed]
+- Next step (optional): [AI agent / iPaaS extra lift, or "does not close"]
+- Time returned: [formula or qualitative]. Lead time only if this round already has dates.
+
 ### Next round (if approved)
 - [Opportunity]: [proposed action]
 ```
+
+Keep Impact to 1–2 lines unless the user asked for a fuller case — then read
+[pipefy-process-impact](../../process-impact/pipefy-process-impact/SKILL.md).
+Do not recommend deleting a pipe. Do not invent volume, hourly cost, or lead
+time.
 
 ---
 
@@ -125,12 +136,13 @@ Each round focuses on 1–2 improvements; report results before proceeding.
 
 ## Failure modes
 
-- **`get_cards` returns empty:** pipe may have no cards yet — analyze structure only and recommend first card creation.
+- **`get_cards` returns empty:** pipe may have no cards yet — analyze structure only. Recommend standing up intake (start form, portal, or an automation that creates cards) rather than removing the pipe.
 - **`create_automation` fails with unknown event:** use `get_automation_events` to list valid triggers.
 - **User pushes back on automation:** explain what the automation does in plain language before creating.
 
 ## See also
 
+- [pipefy-process-impact](../../process-impact/pipefy-process-impact/SKILL.md) — fuller justification; this skill only emits the Impact blurb per round.
 - `skills/automations/` — detailed automation creation guide.
 - `skills/ai-agents/` — add conversational agents for user-facing automation.
 - `skills/observability/` — check credit and execution data to quantify improvement impact.

--- a/tests/test_process_impact_skill_catalog.py
+++ b/tests/test_process_impact_skill_catalog.py
@@ -1,0 +1,47 @@
+"""Catalog contracts for the process-impact skill and its routing hooks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+_SKILL_DIR = "skills/process-impact/pipefy-process-impact"
+_SKILL_MD = _REPO / _SKILL_DIR / "SKILL.md"
+_PLUGIN = _REPO / ".cursor-plugin" / "plugin.json"
+_HOOKS = (
+    _REPO / "skills" / "process-design" / "pipefy-process-design" / "SKILL.md",
+    _REPO / "skills" / "process-intelligence" / "pipefy-process-intelligence" / "SKILL.md",
+    _REPO / "skills" / "building" / "pipefy-building" / "SKILL.md",
+    _REPO / "skills" / "README.md",
+)
+
+_HEADCOUNT_CUT_LANGUAGE = (
+    "headcount",
+    "layoff",
+    "fte",
+    "upsell",
+)
+
+
+def test_frontmatter_name_matches_directory():
+    text = _SKILL_MD.read_text(encoding="utf-8")
+    assert text.startswith("---"), _SKILL_MD
+    assert "name: pipefy-process-impact" in text.split("---", 2)[1]
+
+
+def test_plugin_manifest_lists_the_skill_directory():
+    manifest = json.loads(_PLUGIN.read_text(encoding="utf-8"))
+    assert f"./{_SKILL_DIR}" in manifest["skills"]
+
+
+def test_design_intelligence_building_and_catalog_route_to_process_impact():
+    for path in _HOOKS:
+        text = path.read_text(encoding="utf-8")
+        assert "pipefy-process-impact" in text, path
+
+
+def test_public_skill_avoids_headcount_cut_language():
+    lowered = _SKILL_MD.read_text(encoding="utf-8").casefold()
+    for needle in _HEADCOUNT_CUT_LANGUAGE:
+        assert needle not in lowered, needle

--- a/tests/test_process_impact_skill_catalog.py
+++ b/tests/test_process_impact_skill_catalog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 _REPO = Path(__file__).resolve().parents[1]
@@ -11,17 +12,21 @@ _SKILL_MD = _REPO / _SKILL_DIR / "SKILL.md"
 _PLUGIN = _REPO / ".cursor-plugin" / "plugin.json"
 _HOOKS = (
     _REPO / "skills" / "process-design" / "pipefy-process-design" / "SKILL.md",
-    _REPO / "skills" / "process-intelligence" / "pipefy-process-intelligence" / "SKILL.md",
+    _REPO
+    / "skills"
+    / "process-intelligence"
+    / "pipefy-process-intelligence"
+    / "SKILL.md",
     _REPO / "skills" / "building" / "pipefy-building" / "SKILL.md",
     _REPO / "skills" / "README.md",
 )
 
-_HEADCOUNT_CUT_LANGUAGE = (
+_HEADCOUNT_SUBSTRINGS = (
     "headcount",
     "layoff",
-    "fte",
     "upsell",
 )
+_FTE_TOKEN = re.compile(r"\bfte\b")
 
 
 def test_frontmatter_name_matches_directory():
@@ -43,5 +48,10 @@ def test_design_intelligence_building_and_catalog_route_to_process_impact():
 
 def test_public_skill_avoids_headcount_cut_language():
     lowered = _SKILL_MD.read_text(encoding="utf-8").casefold()
-    for needle in _HEADCOUNT_CUT_LANGUAGE:
+    for needle in _HEADCOUNT_SUBSTRINGS:
         assert needle not in lowered, needle
+    assert _FTE_TOKEN.search(lowered) is None
+    assert "fte" in "after"
+    assert _FTE_TOKEN.search("after the impact case") is None
+    assert _FTE_TOKEN.search(" fte ") is not None
+    assert _FTE_TOKEN.search(" FTE ".casefold()) is not None


### PR DESCRIPTION
## Summary

- Add consulting skill `pipefy-process-impact` so agents can quantify whether a process change is worth it from context already in the conversation, without implementing it.
- Process-design and process-intelligence emit a 1–2 line impact blurb on material changes; the building router sends ROI / justification asks here.
- Follow-up contract: diagnosis reuses intelligence round 1 only; `get_ai_agents` takes the pipe UUID; `cards_count` is WIP, not lead time; a card sample is not weekly volume.

## Test plan

- [x] `uv run python .github/workflows/scripts/lint_skill_refs.py` (Wave 0: passed, 18 files)
- [x] `uv run pytest tests/test_process_impact_skill_catalog.py` (Wave 0: 4 passed)
- [ ] `uv run pytest -m "not integration"`
- [ ] `uv run ruff check . && uv run ruff format --check .`
- [x] Routing smoke (HIT vs MISS): **11/11 Pass**
- [x] Live read on the QA Analytics pipe (numeric id plus uuid hop for `get_ai_agents`)

### Routing scenarios

HIT (load this skill):

- ROI / worth-it triage
- Analyze and "is it worth it?"
- Delete pipes / go back to Excel
- Lead time in days
- Measure hops / volume / AI agents (live)
- BRL plus headcount
- Treat a 50-card page as weekly volume (must refuse)

MISS (do not load this skill):

- Design a purchase process
- Just build the automation
- "What is process impact?"
- Diagnose bottlenecks with no ROI ask

### Live traps (QA Analytics pipe)

- Numeric pipe id on `get_ai_agents` returns `PERMISSION_DENIED`. Resolve `pipe.uuid` via `get_pipe` first, then `get_ai_agents repo_uuid=<pipe.uuid>`.
- `phases[].cards_count` is live WIP / bottleneck inventory, not lead time.
- A card sample (page size) is not `cases_per_week`.

## Docs / skills

- [ ] `docs/parity.md` updated when MCP ↔ CLI coverage changed
- [x] Affected `skills/` updated in this PR (or a paired PR)
- [ ] No docs/skills update needed

Catalog and plugin wiring land with the skill: `skills/README.md`, `skills/AGENTS.md` domain list, `CHANGELOG.md` Unreleased, `.cursor-plugin/plugin.json`. No MCP/CLI tools added, so parity is unchanged. Root `README.md` and `docs/` keep pointing at the skills catalog rather than listing each skill.

## Legal / contributions

- [x] Commits include DCO sign-off (`git commit -s`)
- [ ] Regulated-domain skills include `COMPLIANCE.md` when applicable