### PR TITLE
refactor(sdk): ship the destructive-confirmation helpers in pipefy_sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **SDK destructive-confirmation helpers**: `mint_confirmation_token`, `verify_confirmation_token`, `classify_confirmation_token_failure`, `confirmation_signing_key`, `DESTRUCTIVE_CONFIRMATION_TTL_SECONDS` and `ConfirmationTokenFailure` are exported from `pipefy_sdk` (module `pipefy_sdk.destructive_confirmation`). Signatures and token wire format are unchanged, so a token minted by one build verifies on the other. An in-process SDK consumer can now honour the "caller must enforce preview/confirm UX" contract without depending on `pipefy-mcp-server`. `confirmation_signing_key` is new: it derives one caller's HMAC key from that caller's credential, which is what stops one caller's token from confirming another's deletion. `signing_key_for` in the MCP guard now calls it, so both sides share one derivation. The internal `pipefy_mcp.tools.destructive_confirmation_token` module is removed; it was never an exported path (`pipefy_mcp.tools.__init__` exports only `PIPEFY_TOOL_NAMES` and `ToolRegistry`) and no MCP tool contract changes.
 - **Claude Code plugin MCP**: `.mcp.json` is the hosted `mcp.pipefy.com` server with in-client OAuth, the same file the Cursor plugin points at. Local stdio (`uvx`) remains the Quick-install / `claude mcp add` path.
 
 ## [0.5.0-beta.1] - 2026-08-21

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -48,6 +48,52 @@ Other exported error types sit outside this root. Catch these by name:
 Transport-level failures (connection refused, timeouts) surface as `gql`'s
 `TransportError`, which the SDK does not wrap.
 
+## Destructive operations
+
+The SDK does not gate deletion. Every `delete_*` and `remove_*` method runs the mutation as soon as you call it. Enforcing a preview/confirm step is the caller's job, for all of them — `delete_pipe` and `delete_table` say so in their docstrings, and the same obligation applies to the rest.
+
+`pipefy_sdk.destructive_confirmation` ships the helpers that step needs, so an in-process consumer runs the same protocol the MCP server runs:
+
+```python
+import time
+
+from pipefy_sdk import (
+    confirmation_signing_key,
+    mint_confirmation_token,
+    verify_confirmation_token,
+)
+
+# Derive the key from THIS caller's own credential, never a shared constant.
+key = confirmation_signing_key(caller_bearer)
+identity = {"pipe_id": pipe_id}
+
+# First call: describe what would be deleted, and hand the token back.
+token = mint_confirmation_token(
+    tool_name="delete_pipe",
+    resource_identity=identity,
+    key=key,
+    now=int(time.time()),
+)
+
+# Second call: the caller returns the token. Delete only when it verifies.
+if verify_confirmation_token(
+    token,
+    tool_name="delete_pipe",
+    resource_identity=identity,
+    key=key,
+    now=int(time.time()),
+):
+    await client.delete_pipe(pipe_id)
+```
+
+The token binds one operation name, one canonicalized resource identity, and one `key`. It expires after `DESTRUCTIVE_CONFIRMATION_TTL_SECONDS`. Verification is stateless HMAC, so no server-side store is needed. `tool_name` is any stable label for the operation: the MCP server passes its tool name, and a library consumer passes its own.
+
+`confirmation_signing_key` derives the `key` from one caller's credential. Use it per caller. A single module-level key defeats the binding, because every token then verifies for every caller, and nothing in the SDK can catch that for you.
+
+`classify_confirmation_token_failure` says **why** verification would fail (`missing`, `invalid_or_expired`, `identity_mismatch`) so you can word the rejection. It is diagnostic only. Never let it authorize the deletion — that stays behind `verify_confirmation_token`.
+
+The token orders the two steps. It is not an authorization control: the API permission on the credential remains the boundary that allows or denies the deletion.
+
 ## Configuration
 
 OAuth and endpoint variables are documented in **[`../config.md`](../config.md)** and **[`../../.env.example`](../../.env.example)**. Integration tests use `@pytest.mark.integration` and the same `PIPEFY_*` keys from local **`.env`** (e.g. `PIPEFY_PORTAL_ORG_UUID` for portal live tests). Unit tests use fictional ids in **[`../../packages/sdk/tests/_shared/fixture_ids.py`](../../packages/sdk/tests/_shared/fixture_ids.py)** — not production org UUIDs.

--- a/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
+++ b/packages/mcp/src/pipefy_mcp/tools/destructive_tool_guard.py
@@ -13,22 +13,22 @@ control. API permission remains the boundary that allows or denies the deletion.
 
 from __future__ import annotations
 
-import hashlib
 import secrets
 import time
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, Literal
 
 from mcp.server.mcpserver import Context
-from typing_extensions import NotRequired, TypedDict
-
-from pipefy_mcp.auth.request_identity import require_request_bearer
-from pipefy_mcp.tools.destructive_confirmation_token import (
+from pipefy_sdk import (
     ConfirmationTokenFailure,
     classify_confirmation_token_failure,
+    confirmation_signing_key,
     mint_confirmation_token,
     verify_confirmation_token,
 )
+from typing_extensions import NotRequired, TypedDict
+
+from pipefy_mcp.auth.request_identity import require_request_bearer
 
 _PROCESS_SIGNING_KEY = secrets.token_bytes(32)
 
@@ -53,7 +53,7 @@ def signing_key_for(ctx: Context) -> bytes:
         bearer = require_request_bearer(ctx.request_context.request)
     except Exception:  # noqa: BLE001
         return _PROCESS_SIGNING_KEY
-    return hashlib.sha256(bearer.encode("utf-8")).digest()
+    return confirmation_signing_key(bearer)
 
 
 async def check_destructive_confirmation(

--- a/packages/mcp/tests/tools/test_destructive_tool_guard.py
+++ b/packages/mcp/tests/tools/test_destructive_tool_guard.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from _rs_fixtures import authenticated_user, request_with_user
+from pipefy_sdk import confirmation_signing_key
 
 from pipefy_mcp.tools import destructive_tool_guard as guard_mod
 from pipefy_mcp.tools.destructive_tool_guard import check_destructive_confirmation
@@ -379,3 +380,23 @@ async def test_signing_key_is_absent_from_preview_and_token_error_envelopes(
         resource_identity={"phase_id": "other"},
     )
     assert_key_absent(mismatch)
+
+
+def test_signing_key_for_derives_the_bearer_key_through_the_sdk_helper():
+    """The guard owns the ctx and the fallback; the SDK owns the derivation.
+
+    Both sides must agree, or a token minted here stops verifying for an
+    in-process SDK consumer running the same protocol.
+    """
+    bearer = "rs-validated-bearer"
+    ctx = _make_ctx(request=request_with_user(authenticated_user(bearer)))
+
+    assert guard_mod.signing_key_for(ctx) == confirmation_signing_key(bearer)
+
+
+def test_signing_key_for_falls_back_to_the_process_key_without_a_bearer():
+    ctx = _make_ctx(request=request_with_user(None))
+
+    key = guard_mod.signing_key_for(ctx)
+    assert key == guard_mod._PROCESS_SIGNING_KEY
+    assert key != confirmation_signing_key("")

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,6 +1,6 @@
 # pipefy
 
-**Vendor API SDK** for Pipefy's GraphQL API: the shared library consumed by `pipefy-mcp-server` and `pipefy-cli` (not a generic “shared utils” layer). It owns HTTP/GraphQL transport, service classes, query constants, Pydantic models, shared settings, exceptions, and utilities.
+**Vendor API SDK** for Pipefy's GraphQL API: the shared library consumed by `pipefy-mcp-server` and `pipefy-cli` (not a generic “shared utils” layer). It owns HTTP/GraphQL transport, service classes, query constants, Pydantic models, shared settings, exceptions, the destructive-confirmation token helpers, and utilities.
 
 ## Status
 

--- a/packages/sdk/src/pipefy_sdk/__init__.py
+++ b/packages/sdk/src/pipefy_sdk/__init__.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 __version__ = "0.5.0-beta.1"
 
 from pipefy_sdk.client import PipefyClient, PipefyEngine
+from pipefy_sdk.destructive_confirmation import (
+    DESTRUCTIVE_CONFIRMATION_TTL_SECONDS,
+    ConfirmationTokenFailure,
+    classify_confirmation_token_failure,
+    confirmation_signing_key,
+    mint_confirmation_token,
+    verify_confirmation_token,
+)
 from pipefy_sdk.exceptions import PipefyAPIError, PipefyError
 from pipefy_sdk.field_filters import (
     filter_editable_field_definitions,
@@ -123,10 +131,12 @@ __all__ = [
     "CommentInput",
     "CONDITION_OPERATIONS",
     "ConditionExpressionInput",
+    "ConfirmationTokenFailure",
     "CreateAiAgentInput",
     "CreateAiAutomationInput",
     "CreatePortalElementInput",
     "CreateSendTaskAutomationInput",
+    "DESTRUCTIVE_CONFIRMATION_TTL_SECONDS",
     "DataLookupCondition",
     "DeleteCommentInput",
     "GraphQLProblem",
@@ -145,8 +155,10 @@ __all__ = [
     "LlmProviderWritePayload",
     "ProviderAccessProbeResult",
     "ProviderDependenciesResult",
+    "classify_confirmation_token_failure",
     "classify_exception",
     "classify_graphql_error_dicts",
+    "confirmation_signing_key",
     "download_bytes",
     "filter_editable_field_definitions",
     "filter_fields_by_definitions",
@@ -170,6 +182,8 @@ __all__ = [
     "copy_card_search",
     "create_form_model",
     "infer_content_type",
+    "mint_confirmation_token",
     "skipped_field_ids",
     "stream_bytes",
+    "verify_confirmation_token",
 ]

--- a/packages/sdk/src/pipefy_sdk/destructive_confirmation.py
+++ b/packages/sdk/src/pipefy_sdk/destructive_confirmation.py
@@ -1,4 +1,7 @@
-"""Pure planner that mints and verifies HMAC confirmation tokens."""
+"""Pure planner for the HMAC confirmation tokens that order a destructive call.
+
+Derives the per-caller signing key, mints a token, and verifies one.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +17,23 @@ _TOKEN_VERSION = "v1"
 _B64URL_SEGMENT_RE = re.compile(r"[A-Za-z0-9_-]*")
 
 ConfirmationTokenFailure = Literal["missing", "invalid_or_expired", "identity_mismatch"]
+
+
+def confirmation_signing_key(caller_secret: str | bytes) -> bytes:
+    """Derive one caller's HMAC key from that caller's own credential.
+
+    Deriving per caller is what stops one caller's token from confirming
+    another's deletion. A single module-level key defeats that binding, because
+    every token then verifies for everyone.
+
+    Args:
+        caller_secret: The caller's credential (a bearer token, a session
+            secret). Encoded as UTF-8 when given as ``str``. Never stored, and
+            never recoverable from the returned key or from a minted token.
+    """
+    if isinstance(caller_secret, str):
+        caller_secret = caller_secret.encode("utf-8")
+    return hashlib.sha256(caller_secret).digest()
 
 
 def mint_confirmation_token(

--- a/packages/sdk/src/pipefy_sdk/services/pipe_config_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/pipe_config_service.py
@@ -75,7 +75,11 @@ class PipeConfigService:
         return await self._executor.execute_query(UPDATE_PIPE_MUTATION, variables)
 
     async def delete_pipe(self, pipe_id: str | int) -> dict:
-        """Delete a pipe by ID (permanent). Caller must enforce preview/confirm UX."""
+        """Delete a pipe by ID (permanent).
+
+        Caller must enforce preview/confirm UX; :mod:`pipefy_sdk.destructive_confirmation`
+        ships the token helpers for it.
+        """
         variables: dict[str, Any] = {"input": {"id": str(pipe_id)}}
         return await self._executor.execute_query(DELETE_PIPE_MUTATION, variables)
 

--- a/packages/sdk/src/pipefy_sdk/services/table_service.py
+++ b/packages/sdk/src/pipefy_sdk/services/table_service.py
@@ -140,7 +140,11 @@ class TableService:
         )
 
     async def delete_table(self, table_id: str | int) -> dict[str, Any]:
-        """Delete a database table by ID (permanent). Caller must enforce preview/confirm UX."""
+        """Delete a database table by ID (permanent).
+
+        Caller must enforce preview/confirm UX; :mod:`pipefy_sdk.destructive_confirmation`
+        ships the token helpers for it.
+        """
         return await self._executor.execute_query(
             DELETE_TABLE_MUTATION,
             {"input": {"id": str(table_id)}},

--- a/packages/sdk/tests/test_destructive_confirmation.py
+++ b/packages/sdk/tests/test_destructive_confirmation.py
@@ -8,9 +8,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from pipefy_mcp.tools.destructive_confirmation_token import (
+from pipefy_sdk.destructive_confirmation import (
     DESTRUCTIVE_CONFIRMATION_TTL_SECONDS,
     classify_confirmation_token_failure,
+    confirmation_signing_key,
     mint_confirmation_token,
     verify_confirmation_token,
 )
@@ -520,7 +521,7 @@ def test_tampered_version_prefix_is_rejected():
 def test_verify_uses_hmac_compare_digest(monkeypatch):
     import hmac as hmac_mod
 
-    from pipefy_mcp.tools import destructive_confirmation_token as planner
+    from pipefy_sdk import destructive_confirmation as planner
 
     spy = MagicMock(wraps=hmac_mod.compare_digest)
     monkeypatch.setattr(planner.hmac, "compare_digest", spy)
@@ -547,7 +548,7 @@ def test_verify_uses_hmac_compare_digest(monkeypatch):
 def test_planner_has_no_io():
     import inspect
 
-    from pipefy_mcp.tools import destructive_confirmation_token as planner
+    from pipefy_sdk import destructive_confirmation as planner
 
     source = inspect.getsource(planner)
     assert "Context" not in source
@@ -572,3 +573,73 @@ def test_token_payload_does_not_contain_key_and_has_canonical_fields():
     assert KEY.decode("latin-1") not in token
     assert payload["tool"] == TOOL
     assert payload["exp"] == NOW + DESTRUCTIVE_CONFIRMATION_TTL_SECONDS
+
+
+def test_helpers_are_exported_from_the_package_root():
+    import pipefy_sdk
+    from pipefy_sdk import destructive_confirmation as planner
+
+    for name in (
+        "DESTRUCTIVE_CONFIRMATION_TTL_SECONDS",
+        "ConfirmationTokenFailure",
+        "classify_confirmation_token_failure",
+        "confirmation_signing_key",
+        "mint_confirmation_token",
+        "verify_confirmation_token",
+    ):
+        assert name in pipefy_sdk.__all__
+        assert getattr(pipefy_sdk, name) is getattr(planner, name)
+
+
+def test_wire_format_matches_the_pinned_vector():
+    """Pin the token bytes so a mint and a verify on different builds agree.
+
+    Verification derives its key from the caller, not from server state, so a
+    rolling deploy has one build mint and another verify. Changing the payload
+    layout, the MAC message, or the base64 spelling breaks that pair mid-deploy.
+    """
+    assert (
+        mint_confirmation_token(
+            tool_name=TOOL,
+            resource_identity=IDENTITY,
+            key=KEY,
+            now=NOW,
+        )
+        == "v1.eyJleHAiOjE3MDAwMDAzMDAsImlkZW50aXR5Ijp7ImZpZWxkX2lkIjoiMSIsInBpcGVfdXVpZCI6ImFiYyJ9LCJ0b29sIjoiZGVsZXRlX3BoYXNlX2ZpZWxkIn0"
+        ".SO7bsGv4zk4uNJLxdn6dYJihtYV2ybCysDaLq8U8PoE"
+    )
+
+
+def test_signing_key_is_sha256_of_the_utf8_credential():
+    bearer = "caller-a-bearer"
+
+    assert (
+        confirmation_signing_key(bearer)
+        == hashlib.sha256(bearer.encode("utf-8")).digest()
+    )
+    assert confirmation_signing_key(bearer) == confirmation_signing_key(
+        bearer.encode("utf-8")
+    )
+
+
+def test_each_caller_gets_a_distinct_key():
+    """One caller's token must not confirm another caller's deletion.
+
+    ``test_wrong_key_fails`` pins the half that rejects a foreign key. This pins
+    the half that hands two callers two different keys in the first place.
+    """
+    assert confirmation_signing_key("caller-a") != confirmation_signing_key("caller-b")
+
+
+def test_signing_key_does_not_leak_the_credential():
+    bearer = "caller-a-bearer"
+    key = confirmation_signing_key(bearer)
+
+    assert bearer.encode("utf-8") not in key
+    token = mint_confirmation_token(
+        tool_name=TOOL,
+        resource_identity=IDENTITY,
+        key=key,
+        now=NOW,
+    )
+    assert bearer not in token


### PR DESCRIPTION
Closes #649.

## Motivation

The SDK ships ungated `delete_*` / `remove_*` methods — 56 across the package — plus a docstring obligation to gate them, but not the code that does the gating. `delete_pipe` and `delete_table` both say "Caller must enforce preview/confirm UX".

The canonical implementation of that protocol lived in `pipefy-mcp-server`. An application that embeds the SDK in process cannot import it without taking two things it does not want. First, the `mcp[cli]==2.0.*` pin, which conflicts with any environment holding `mcp` 1.x. Second, a package whose identity resolution raises outside the server request scope by design. So every in-process consumer that wants to honour the contract reimplements the token logic, and drifts from the behaviour the MCP server enforces.

## Outcome

`mint_confirmation_token`, `verify_confirmation_token`, `classify_confirmation_token_failure` and `confirmation_signing_key` are importable from `pipefy_sdk`. An in-process consumer runs the same protocol the MCP server runs, from the same code.

- The module is `pipefy_sdk.destructive_confirmation`, stdlib-only. The SDK dependency list is unchanged: 8 `Requires-Dist` entries, read off the built wheel.
- The token wire format is unchanged and pinned by a golden vector, so a token minted by one build verifies on another during a rolling deploy.
- `confirmation_signing_key` is new. It derives one caller's HMAC key from that caller's credential, which is what stops one caller's token from confirming another's deletion. `signing_key_for` in the MCP guard calls it, so both sides share one derivation.
- `pipefy_mcp.tools.destructive_confirmation_token` is deleted. The guard imports from `pipefy_sdk`.
- The MCP protocol is unchanged. No tool name, schema, annotation, envelope, or preview text moves, so hosted and remote callers cannot observe this.

Read `packages/sdk/src/pipefy_sdk/destructive_confirmation.py` first. Its only change against the old module is the added `confirmation_signing_key`. The three original functions and every private helper are byte-identical.

## Testing

Offline: full suite 4762 passed / 39 skipped, `ruff check`, `ruff format --check`, `lint-imports` (2 contracts kept), `bump_version.py verify`, the skill-reference and Cursor-plugin linters, `uv build --all-packages`.

The live runs below drove the `pipefy-mcp-server` binary built from this branch, over the real MCP protocol, against a prod organization. They used throwaway pipes only. All seven were created and deleted by the runs, and each deletion was confirmed afterwards.

### Local profile, stdio

| # | Scenario | Expected | Observed | Verdict |
| --- | --- | --- | --- | --- |
| 0 | Server built from this branch serves the tool surface | `delete_pipe` registered | 187 tools, present | PASS |
| 1 | `delete_pipe confirm=false` | Preview, token minted, no deletion | `requires_confirmation=true`, token minted | PASS |
| 2 | `get_pipe` after the preview | Pipe still exists | Returned the pipe | PASS |
| 3 | `confirm=true`, token omitted | Previews again, no deletion | `requires_confirmation=true` | PASS |
| 4 | Tampered token, MAC no longer matches | Rejected, no deletion | `requires_confirmation=true` | PASS |
| 5 | Pipe B's token replayed against pipe A | Identity mismatch, no deletion | `requires_confirmation=true` | PASS |
| 6 | `get_pipe` after three rejected confirmations | Pipe still exists | Returned the pipe | PASS |
| 7 | `confirm=true` with the matching token | Pipe is deleted | `Pipe ... was permanently deleted.` | PASS |
| 8 | `get_pipe` immediately after the deletion | Not found | Still resolved | see below |
| 9 | Spent token for A replayed against B | Identity mismatch, B survives | `requires_confirmation=true` | PASS |

Row 8 is a property of the Pipefy API, not of this change. Pipe deletion is eventually consistent: polling shows the pipe stops resolving 6.6 s after the mutation returns success. The deletion mutation itself is untouched SDK code.

A separate stdio run replayed one token across two server processes. Process B rejected process A's token. That confirms the local profile falls back to the per-process random key and never reaches `confirmation_signing_key`.

### Remote profile, Streamable HTTP with a validated bearer

| # | Scenario | Expected | Observed | Verdict |
| --- | --- | --- | --- | --- |
| 0 | RFC 9728 protected-resource metadata | 200 naming this resource | 200, resource matches | PASS |
| 1 | `tools/list` with no bearer | 401 | 401 | PASS |
| 2 | Validated bearer reaches the remote-safe surface | `delete_pipe` present, surface smaller than local's 187 | 184 tools, present | PASS |
| 3 | `delete_pipe confirm=false` | Preview, token minted, no deletion | `requires_confirmation=true`, token minted | PASS |
| 4 | Token minted by process A, confirmed against a fresh process B, same bearer | Verifies and deletes | `Pipe ... was permanently deleted.` | PASS |
| 5 | Pipe A's token replayed against pipe B, same caller | Identity mismatch, B survives | `requires_confirmation=true` | PASS |

Row 4 covers the changed line. The same cross-process replay is rejected on stdio. A token survives a server restart only when its key comes from the caller rather than from the process, so row 4 is what proves `confirmation_signing_key(bearer)` runs.

Not verified: `mcp.pipefy.com`. The hosted deployment pins an exact published release of `pipefy-mcp-server` (`0.5.0b1` today), so it cannot exercise this branch. Hosted coverage follows the release and the pin bump. The remote profile above therefore ran locally against the real issuer.

## Notes

Issue #649 asked for a deprecated re-export shim at the old path. This drops it. `pipefy_mcp.tools.__init__` exports only `PIPEFY_TOOL_NAMES` and `ToolRegistry`, and `docs/DEPRECATION.md` scopes the MCP surface to tool names and argument shapes, so the deleted path was never public.
